### PR TITLE
Fix deploy script flake check status handling

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,9 +40,11 @@ fi
 
 # Check flake
 echo "🔍 Checking flake..."
-if nix flake check "$FLAKE_PATH" 2>&1 | head -20; then
+if FLAKE_CHECK_OUTPUT=$(nix flake check "$FLAKE_PATH" 2>&1); then
+    echo "$FLAKE_CHECK_OUTPUT" | head -20
     echo "✅ Flake check passed"
 else
+    echo "$FLAKE_CHECK_OUTPUT" | head -20
     echo "⚠️  Flake check had warnings (may be normal)"
 fi
 echo ""


### PR DESCRIPTION
## Summary
- store the output of `nix flake check` before trimming it for display
- ensure a successful flake check is not misreported as a warning due to head truncation

## Testing
- No automated tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915cd431030832b880756e7d5d027e2)