### PR TITLE
feat: Upgrade GitHub Copilot CLI to latest version (0.0.362)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
         "type": "github"
       },
       "original": {

--- a/modules/system/host.nix
+++ b/modules/system/host.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs-unstable, lib, ... }:
 
 {
   # Allow unfree packages
@@ -57,7 +57,7 @@
     btop
     nodejs_22
     gh
-    github-copilot-cli
+    pkgs-unstable.github-copilot-cli # Use unstable for latest @github/copilot package
     # Nix development tools
     nixpkgs-fmt
     nil # Nix language server

--- a/modules/users/root.nix
+++ b/modules/users/root.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, pkgs-unstable, lib, ... }:
 
 {
   # Home Manager configuration for root user
@@ -14,9 +14,8 @@
     # Bash configuration
     programs.bash = {
       enable = true;
-      shellAliases = {
-        copilot = "${pkgs.nodejs_22}/bin/node ~/.npm-global/lib/node_modules/@github/copilot/index.js";
-      };
+      # Note: 'copilot' command is available directly from pkgs-unstable.github-copilot-cli
+      # No alias needed as it's in PATH via environment.systemPackages
     };
   };
 }


### PR DESCRIPTION
## Summary

This PR upgrades the GitHub Copilot CLI from the deprecated `@githubnext/github-copilot-cli` package (v0.1.36) to the current official `@github/copilot` package (v0.0.362).

## Background

The version numbers appear different (`0.1.x` vs `0.0.x`) because they are **two completely different npm packages**:

| Package | Version | Status |
|---------|---------|--------|
| `@githubnext/github-copilot-cli` | 0.1.36 | **Deprecated** (GitHub Next experimental project) |
| `@github/copilot` | 0.0.362 | **Current** (Official GitHub Copilot CLI) |

The new package includes the 'Copilot coding agent' feature directly in the terminal.

## Changes

- `modules/system/host.nix`: Use `pkgs-unstable.github-copilot-cli` instead of `pkgs.github-copilot-cli`
- `modules/users/root.nix`: Remove obsolete npm-based shell alias (no longer needed as `copilot` is in PATH)
- `flake.lock`: Updated `nixpkgs-unstable` to 2025-11-24

## Testing

- [x] `nix flake check` passes
- [x] Full system build succeeds
- [x] `copilot --version` returns `0.0.362`
- [x] Binary correctly linked in system path

## Verification

```
$ /nix/store/.../github-copilot-cli-0.0.362/bin/copilot --version
0.0.362
Commit: 0c95944
```