### PR TITLE
fix: use NixOS-managed copilot-cli instead of VS Code bundled version

### DIFF
--- a/modules/users/root.nix
+++ b/modules/users/root.nix
@@ -14,8 +14,11 @@
     # Bash configuration
     programs.bash = {
       enable = true;
-      # Note: 'copilot' command is available directly from pkgs-unstable.github-copilot-cli
-      # No alias needed as it's in PATH via environment.systemPackages
+      # Use NixOS-managed copilot instead of VS Code's older bundled version
+      # VS Code adds its shim to PATH first, so we override with an alias
+      shellAliases = {
+        copilot = "${pkgs-unstable.github-copilot-cli}/bin/copilot";
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add bash alias to override VS Code's PATH shim
- Ensures system uses pkgs-unstable.github-copilot-cli (0.0.362)
- VS Code bundles older 0.0.355, alias bypasses this

## Changes
- Updated `modules/users/root.nix` with shell alias for `copilot`