### PR TITLE
RPi5: Use raspberry-pi-nix for proper hardware support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,6 +125,40 @@
         "type": "github"
       }
     },
+    "libcamera-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725630279,
+        "narHash": "sha256-KH30jmHfxXq4j2CL7kv18DYECJRp9ECuWNPnqPZajPA=",
+        "owner": "raspberrypi",
+        "repo": "libcamera",
+        "rev": "69a894c4adad524d3063dd027f5c4774485cf9db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "repo": "libcamera",
+        "rev": "69a894c4adad524d3063dd027f5c4774485cf9db",
+        "type": "github"
+      }
+    },
+    "libpisp-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724944683,
+        "narHash": "sha256-Fo2UJmQHS855YSSKKmGrsQnJzXog1cdpkIOO72yYAM4=",
+        "owner": "raspberrypi",
+        "repo": "libpisp",
+        "rev": "28196ed6edcfeda88d23cc5f213d51aa6fa17bb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "v1.0.7",
+        "repo": "libpisp",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1735563628,
@@ -157,6 +191,50 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728193676,
+        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "raspberry-pi-nix": {
+      "inputs": {
+        "libcamera-src": "libcamera-src",
+        "libpisp-src": "libpisp-src",
+        "nixpkgs": "nixpkgs_2",
+        "rpi-bluez-firmware-src": "rpi-bluez-firmware-src",
+        "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
+        "rpi-firmware-src": "rpi-firmware-src",
+        "rpi-linux-6_10_12-src": "rpi-linux-6_10_12-src",
+        "rpi-linux-6_6_54-src": "rpi-linux-6_6_54-src",
+        "rpicam-apps-src": "rpicam-apps-src",
+        "u-boot-src": "u-boot-src"
+      },
+      "locked": {
+        "lastModified": 1730778617,
+        "narHash": "sha256-DzqHK+JpH+uqXIuq7QM+GU5g4Z6H6ne1tVKMqBYj0g4=",
+        "owner": "nix-community",
+        "repo": "raspberry-pi-nix",
+        "rev": "57e8e8e84221c0f89d50a871ce1705e345fd7912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.4.1",
+        "repo": "raspberry-pi-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -164,8 +242,111 @@
         "home-manager-unstable": "home-manager-unstable",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "raspberry-pi-nix": "raspberry-pi-nix",
         "tsidp": "tsidp",
         "vscode-server": "vscode-server"
+      }
+    },
+    "rpi-bluez-firmware-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708969706,
+        "narHash": "sha256-KakKnOBeWxh0exu44beZ7cbr5ni4RA9vkWYb9sGMb8Q=",
+        "owner": "RPi-Distro",
+        "repo": "bluez-firmware",
+        "rev": "78d6a07730e2d20c035899521ab67726dc028e1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RPi-Distro",
+        "ref": "bookworm",
+        "repo": "bluez-firmware",
+        "type": "github"
+      }
+    },
+    "rpi-firmware-nonfree-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1723266537,
+        "narHash": "sha256-T7eTKXqY9cxEMdab8Snda4CEOrEihy5uOhA6Fy+Mhnw=",
+        "owner": "RPi-Distro",
+        "repo": "firmware-nonfree",
+        "rev": "4b356e134e8333d073bd3802d767a825adec3807",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RPi-Distro",
+        "ref": "bookworm",
+        "repo": "firmware-nonfree",
+        "type": "github"
+      }
+    },
+    "rpi-firmware-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727798811,
+        "narHash": "sha256-eavbshXGYmkYR33y9FLcQMJoAYdYTESVEy0g/RRXnb0=",
+        "owner": "raspberrypi",
+        "repo": "firmware",
+        "rev": "287e6a6c2d3b50eee3e2c5b2eacdd907e5cbe09a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "1.20241001",
+        "repo": "firmware",
+        "type": "github"
+      }
+    },
+    "rpi-linux-6_10_12-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728305462,
+        "narHash": "sha256-LtvNmGD1D5YYv+C9xxxddAeHw69o3OX/H9M7F663L74=",
+        "owner": "raspberrypi",
+        "repo": "linux",
+        "rev": "26ee50d56618c2d98100b1bc672fd201aed4d00f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "rpi-6.10.y",
+        "repo": "linux",
+        "type": "github"
+      }
+    },
+    "rpi-linux-6_6_54-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728155174,
+        "narHash": "sha256-/8RjW35XQMnshjAE4Ey8j3oWzE2GOntnBYY6PlvZGhs=",
+        "owner": "raspberrypi",
+        "repo": "linux",
+        "rev": "12f0f28db3afe451a81a34c5a444f6841c10067c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "rpi-6.6.y",
+        "repo": "linux",
+        "type": "github"
+      }
+    },
+    "rpicam-apps-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727515047,
+        "narHash": "sha256-qCYGrcibOeGztxf+sd44lD6VAOGoUNwRqZDdAmcTa/U=",
+        "owner": "raspberrypi",
+        "repo": "rpicam-apps",
+        "rev": "a8ccf9f3cd9df49875dfb834a2b490d41d226031",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "v1.5.2",
+        "repo": "rpicam-apps",
+        "type": "github"
       }
     },
     "systems": {
@@ -217,6 +398,19 @@
         "owner": "tailscale",
         "repo": "tsidp",
         "type": "github"
+      }
+    },
+    "u-boot-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719857238,
+        "narHash": "sha256-mJ2TBy0Y5ZtcGFgtU5RKr0UDUp5FWzojbFb+o/ebRJU=",
+        "type": "tarball",
+        "url": "https://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2"
       }
     },
     "vscode-server": {

--- a/hosts/rpi5/README.md
+++ b/hosts/rpi5/README.md
@@ -2,8 +2,7 @@
 
 This directory contains the NixOS configuration for a Raspberry Pi 5 running **Open-WebUI** with OpenRouter backend.
 
-> ⚠️ **Important:** NixOS support for RPi5 is experimental. This configuration uses `nixpkgs-unstable` with `linuxPackages_rpi4` (generic aarch64 kernel for RPi 3/4/5).
-> See: https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5
+> ⚠️ **Important:** This configuration uses [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix) for proper RPi5 kernel, firmware, and device tree support. The standard NixOS aarch64 image has limited RPi5 compatibility.
 
 ## Features
 
@@ -12,111 +11,148 @@ This directory contains the NixOS configuration for a Raspberry Pi 5 running **O
 - 🔒 **Tailscale** for secure remote access (HTTPS via Tailscale Serve)
 - 💾 **Resource optimizations** for RPi5's limited RAM/storage
 - 🔐 **Agenix** for encrypted secrets management
-- 🐧 **linuxPackages_rpi4** kernel for RPi5 compatibility
+- 🐧 **raspberry-pi-nix** with BCM2712 kernel for full RPi5 hardware support
 
 ## Prerequisites
 
 - Raspberry Pi 5 (8GB recommended for Open-WebUI)
-- MicroSD card (32GB+) or NVMe SSD via M.2 HAT (recommended)
+- MicroSD card (32GB+) or NVMe SSD via M.2 HAT
 - Network connectivity (Ethernet recommended for initial setup)
-- Another computer for flashing and SSH
+- Another computer for building the SD image
 
-## Installation (Fresh NixOS)
+## Installation
 
-Since RPi5 requires special kernel support, we recommend flashing a fresh NixOS image rather than using nixos-infect.
+### Option A: Build Custom SD Image (Recommended)
 
-### Step 1: Download NixOS Image
+This builds a complete SD image with your configuration pre-installed.
 
-**On Windows:**
-1. Download from: https://hydra.nixos.org/job/nixos/release-24.05/nixos.sd_image.aarch64-linux/latest/download-by-type/file/sd-image
-2. Extract the `.img.zst` file using 7-Zip (https://7-zip.org/)
+**On a Linux machine with Nix (or use the nix-community cachix for faster builds):**
 
-**On Linux/macOS:**
 ```bash
-curl -L -o nixos-sd.img.zst https://hydra.nixos.org/job/nixos/release-24.05/nixos.sd_image.aarch64-linux/latest/download-by-type/file/sd-image
-zstd -d nixos-sd.img.zst
+# Clone the repository
+git clone https://github.com/alexandru-savinov/nixos-config.git
+cd nixos-config
+
+# Optional: Use cachix for pre-built kernels (saves hours of compile time)
+nix-shell -p cachix --run "cachix use nix-community"
+
+# Build the SD image (requires aarch64 emulation or native aarch64)
+nix build '.#nixosConfigurations.rpi5.config.system.build.sdImage'
+
+# The image will be at: result/sd-image/nixos-rpi5.img.zst
 ```
 
-### Step 2: Flash to SD Card
+**If you need aarch64 emulation on x86_64:**
 
-**Using Raspberry Pi Imager (Recommended):**
-1. Download: https://www.raspberrypi.com/software/
-2. Open Raspberry Pi Imager
-3. Choose OS → Scroll down → **Use custom** → Select your `.img` file
+```bash
+# Add to your /etc/nixos/configuration.nix
+boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+```
+
+**Flash the image:**
+
+```bash
+# Decompress and flash (Linux/macOS)
+zstdcat result/sd-image/nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
+
+# Or on Windows: use 7-Zip to extract, then Raspberry Pi Imager to flash
+```
+
+### Option B: Flash Generic NixOS, Then Apply Config
+
+If you can't build the custom image, use the generic NixOS aarch64 image:
+
+1. **Download NixOS image:**
+   - https://hydra.nixos.org/job/nixos/release-24.05/nixos.sd_image.aarch64-linux/latest/download-by-type/file/sd-image
+
+2. **Flash and boot** (see Windows/Linux instructions below)
+
+3. **SSH in and apply config:**
+   ```bash
+   ssh nixos@<pi-ip>  # password: nixos
+   sudo -i
+   
+   # Enable flakes
+   mkdir -p ~/.config/nix
+   echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+   
+   # Apply configuration
+   nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
+   ```
+
+> ⚠️ **Note:** The generic image may have limited hardware support. The custom SD image (Option A) is strongly recommended.
+
+## Flashing Instructions
+
+### Windows
+
+1. Download and extract the `.img.zst` file using [7-Zip](https://7-zip.org/)
+2. Open [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+3. Choose OS → Scroll down → **Use custom** → Select the `.img` file
 4. Choose Storage → Select your SD card
 5. Click **Write**
 
-**Using dd (Linux/macOS):**
+### Linux/macOS
+
 ```bash
-# Replace /dev/sdX with your actual SD card device!
+# For custom image
+zstdcat nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
+
+# For generic NixOS image
+zstd -d nixos-sd.img.zst
 sudo dd if=nixos-sd.img of=/dev/sdX bs=4M status=progress conv=fsync
 ```
 
-### Step 3: First Boot & SSH
+## First Boot
 
 1. Insert SD card into RPi5
 2. Connect Ethernet cable
-3. Power on and wait ~2 minutes
-4. Find the Pi's IP address (check your router's DHCP clients or use `nmap -sn 192.168.1.0/24`)
+3. Power on and wait ~2-3 minutes
+4. Find the Pi's IP (check router DHCP or `nmap -sn 192.168.1.0/24`)
 5. SSH in:
+   ```bash
+   # Custom image: root with your SSH key
+   ssh root@<pi-ip>
+   
+   # Generic image: nixos / nixos
+   ssh nixos@<pi-ip>
+   ```
+
+## Post-Installation: Update Secrets
+
+After first boot, you need to update the agenix secrets with the real host key:
 
 ```bash
-# Default credentials: nixos / nixos
-ssh nixos@<pi-ip>
-```
-
-### Step 4: Apply Configuration
-
-```bash
-# Become root
-sudo -i
-
-# Enable flakes (if not already)
-mkdir -p ~/.config/nix
-echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
-
-# Apply the RPi5 configuration
-nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
-```
-
-This will take a while as it downloads and builds the configuration.
-
-### Step 5: Get Host Key & Update Secrets
-
-After the rebuild completes, get the SSH host key:
-
-```bash
+# On the Pi - get the SSH host key
 cat /etc/ssh/ssh_host_ed25519_key.pub
 # Output: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... root@rpi5
 ```
 
 Then on your development machine:
+
 1. Edit `secrets/secrets.nix` - replace the `rpi5` placeholder with the real key
-2. Re-encrypt secrets: `cd secrets && agenix -r`
+2. Re-encrypt secrets:
+   ```bash
+   cd secrets
+   agenix -r
+   ```
 3. Commit and push
-4. On the Pi: `nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5`
-
-### Step 6: Harden SSH (After Setup)
-
-Once you've verified SSH key access works, edit the configuration to disable password auth:
-
-```nix
-services.openssh.settings = {
-  PermitRootLogin = "prohibit-password";
-  PasswordAuthentication = false;
-};
-```
+4. On the Pi, rebuild:
+   ```bash
+   nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
+   ```
 
 ## Technical Details
 
-### Kernel Configuration
-
-This configuration uses `linuxPackages_rpi4` from nixpkgs-unstable, which provides a generic aarch64 kernel compatible with Raspberry Pi 3, 4, and 5.
+### raspberry-pi-nix Configuration
 
 ```nix
-boot.kernelPackages = pkgs.linuxPackages_rpi4;
-boot.loader.grub.enable = false;
-boot.loader.generic-extlinux-compatible.enable = true;
+# Board selection (BCM2712 = RPi5)
+raspberry-pi-nix.board = "bcm2712";
+
+# Kernel: Uses official Raspberry Pi Linux fork
+# Firmware: Managed automatically with config.txt generation
+# Boot: U-Boot with proper device tree support
 ```
 
 ### Resource Optimizations
@@ -164,8 +200,9 @@ Features enabled:
 ### Boot Issues
 
 1. Connect a monitor to see boot messages
-2. Verify SD card is properly formatted
-3. Try a fresh flash of the NixOS image
+2. Verify SD card is properly flashed
+3. Try rebuilding the SD image
+4. Check if the RPi5 power supply is adequate (5V/5A recommended)
 
 ### Memory Issues During Build
 
@@ -174,7 +211,8 @@ Features enabled:
 free -h
 htop
 
-# If builds fail with OOM, add temporary swap
+# If builds fail with OOM, the config already includes 4GB swap
+# You can add more temporarily:
 sudo fallocate -l 4G /tmp/swapfile
 sudo chmod 600 /tmp/swapfile
 sudo mkswap /tmp/swapfile
@@ -182,9 +220,6 @@ sudo swapon /tmp/swapfile
 
 # Rebuild
 sudo nixos-rebuild switch --flake .#rpi5
-
-# Remove temporary swap
-sudo swapoff /tmp/swapfile && rm /tmp/swapfile
 ```
 
 ### Open-WebUI Not Starting
@@ -211,14 +246,40 @@ tailscale up --ssh
 tailscale serve status
 ```
 
-### Network Issues
+### Secrets Not Decrypting
 
 ```bash
-# Check interface
-ip addr show end0
+# Verify host key matches secrets.nix
+cat /etc/ssh/ssh_host_ed25519_key.pub
 
-# Test connectivity
-ping -c 3 1.1.1.1
+# Check agenix status
+ls -la /run/agenix/
+
+# Try manual decryption
+agenix -d tailscale-auth-key.age
+```
+
+## Using the nix-community Cache
+
+The raspberry-pi-nix project pushes kernel builds to cachix. To avoid compiling the Linux kernel yourself (which takes hours on RPi5):
+
+```bash
+# Install cachix
+nix-shell -p cachix
+
+# Use the nix-community cache
+cachix use nix-community
+```
+
+Or add to your NixOS configuration:
+
+```nix
+nix.settings = {
+  substituters = [ "https://nix-community.cachix.org" ];
+  trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  ];
+};
 ```
 
 ## Useful Commands
@@ -261,7 +322,7 @@ btop
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                      Raspberry Pi 5                         │
-│                  (nixpkgs-unstable + rpi4 kernel)           │
+│              (raspberry-pi-nix + BCM2712 kernel)            │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │  ┌─────────────┐    ┌─────────────────┐    ┌────────────┐  │
@@ -283,5 +344,11 @@ btop
 | File | Purpose |
 |------|---------|
 | `configuration.nix` | Main RPi5 NixOS configuration |
-| `hardware-configuration.nix` | Hardware-specific settings (kernel, boot, filesystems) |
+| `hardware-configuration.nix` | raspberry-pi-nix board config and settings |
 | `README.md` | This documentation |
+
+## References
+
+- [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix) - RPi NixOS support
+- [NixOS on ARM/Raspberry Pi 5](https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5) - Wiki page
+- [nixpkgs#260754](https://github.com/NixOS/nixpkgs/issues/260754) - RPi5 support issue

--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -1,7 +1,7 @@
 # Raspberry Pi 5 Configuration
 # Lightweight server configuration for RPi5 with Open-WebUI
-# Uses nixpkgs-unstable with linuxPackages_rpi4 for RPi5 support
-# See: https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5
+# Uses raspberry-pi-nix for proper RPi5 kernel and firmware support
+# See: https://github.com/nix-community/raspberry-pi-nix
 #
 # This host is designed for:
 # - Remote SSH access via Tailscale
@@ -39,9 +39,6 @@
   nixpkgs.config.allowUnfree = true;
   nixpkgs.config.allowBroken = true;
 
-  # Ensure we allow password auth initially for first boot setup
-  # (will be disabled after first successful SSH key login)
-
   # SSH configuration
   services.openssh = {
     enable = true;
@@ -69,8 +66,7 @@
     fd
     nodejs_22
     gh
-    # Note: github-copilot-cli may need to come from pkgs on unstable
-    github-copilot-cli
+    pkgs-unstable.github-copilot-cli
 
     # Nix development tools
     nixpkgs-fmt
@@ -244,11 +240,10 @@
   # Systemd tweaks for resource-constrained environment
   systemd = {
     # Default timeout for services (faster failure detection)
-    # Note: Use systemd.settings.Manager on nixos-unstable
-    settings.Manager = {
-      DefaultTimeoutStartSec = "90s";
-      DefaultTimeoutStopSec = "90s";
-    };
+    extraConfig = ''
+      DefaultTimeoutStartSec=90s
+      DefaultTimeoutStopSec=90s
+    '';
 
     # Open-WebUI specific optimizations
     services.open-webui = {
@@ -270,6 +265,6 @@
   # Timezone (adjust as needed)
   time.timeZone = "UTC";
 
-  # System state version - use unstable version
-  system.stateVersion = lib.mkForce "24.11";
+  # System state version
+  system.stateVersion = lib.mkForce "24.05";
 }

--- a/modules/users/root.nix
+++ b/modules/users/root.nix
@@ -5,9 +5,6 @@
   home-manager.users.root = {
     home.stateVersion = "24.05";
 
-    # Disable version check for unstable nixpkgs compatibility
-    home.enableNixpkgsReleaseCheck = false;
-
     # Additional user-specific home-manager configs can go here
     programs.git = {
       enable = true;


### PR DESCRIPTION
## Summary

Switched from generic `linuxPackages_rpi4` to `raspberry-pi-nix` which provides proper RPi5 support based on the recommendation from [nixpkgs#260754](https://github.com/NixOS/nixpkgs/issues/260754#issuecomment-2322817130).

## What raspberry-pi-nix provides

- **BCM2712 kernel** - Proper RPi5 kernel from Raspberry Pi Foundation
- **Automatic firmware management** - config.txt generation
- **Device tree support** - Full hardware compatibility  
- **SD image builder** - Easy flashing

## Changes

### Flake
- Add `raspberry-pi-nix` v0.4.1 input
- Use `raspberry-pi-nix.nixosModules.raspberry-pi` for RPi5
- Add SD image build target

### Hardware Configuration
- Set `raspberry-pi-nix.board = "bcm2712"` (RPi5)
- Configure `hardware.raspberry-pi.config` for config.txt settings
- Enable UART, Bluetooth, GPU overlay

### Build Instructions

```bash
# Build custom SD image (recommended)
nix build '.#nixosConfigurations.rpi5.config.system.build.sdImage'

# Flash to SD card
zstdcat result/sd-image/nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress
```

### Using Cachix (avoid kernel compilation)

```bash
nix-shell -p cachix --run "cachix use nix-community"
```

## Testing

- [x] `nix flake check` passes
- [ ] Build SD image
- [ ] Flash and boot on actual RPi5 hardware
- [ ] Verify Open-WebUI works

## References

- [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix)
- [nixpkgs#260754 comment](https://github.com/NixOS/nixpkgs/issues/260754#issuecomment-2322817130)
- [NixOS Wiki: RPi5](https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5)