### PR TITLE
RPi5: Use raspberry-pi-nix for proper hardware support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,26 @@
         "type": "github"
       }
     },
+    "home-manager-unstable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764361670,
+        "narHash": "sha256-jgWzgpIaHbL3USIq0gihZeuy1lLf2YSfwvWEwnfAJUw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "780be8ef503a28939cf9dc7996b48ffb1a3e04c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
@@ -102,6 +122,40 @@
         "owner": "nix-community",
         "ref": "release-24.05",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "libcamera-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725630279,
+        "narHash": "sha256-KH30jmHfxXq4j2CL7kv18DYECJRp9ECuWNPnqPZajPA=",
+        "owner": "raspberrypi",
+        "repo": "libcamera",
+        "rev": "69a894c4adad524d3063dd027f5c4774485cf9db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "repo": "libcamera",
+        "rev": "69a894c4adad524d3063dd027f5c4774485cf9db",
+        "type": "github"
+      }
+    },
+    "libpisp-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724944683,
+        "narHash": "sha256-Fo2UJmQHS855YSSKKmGrsQnJzXog1cdpkIOO72yYAM4=",
+        "owner": "raspberrypi",
+        "repo": "libpisp",
+        "rev": "28196ed6edcfeda88d23cc5f213d51aa6fa17bb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "v1.0.7",
+        "repo": "libpisp",
         "type": "github"
       }
     },
@@ -137,14 +191,162 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728193676,
+        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "raspberry-pi-nix": {
+      "inputs": {
+        "libcamera-src": "libcamera-src",
+        "libpisp-src": "libpisp-src",
+        "nixpkgs": "nixpkgs_2",
+        "rpi-bluez-firmware-src": "rpi-bluez-firmware-src",
+        "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
+        "rpi-firmware-src": "rpi-firmware-src",
+        "rpi-linux-6_10_12-src": "rpi-linux-6_10_12-src",
+        "rpi-linux-6_6_54-src": "rpi-linux-6_6_54-src",
+        "rpicam-apps-src": "rpicam-apps-src",
+        "u-boot-src": "u-boot-src"
+      },
+      "locked": {
+        "lastModified": 1730778617,
+        "narHash": "sha256-DzqHK+JpH+uqXIuq7QM+GU5g4Z6H6ne1tVKMqBYj0g4=",
+        "owner": "nix-community",
+        "repo": "raspberry-pi-nix",
+        "rev": "57e8e8e84221c0f89d50a871ce1705e345fd7912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.4.1",
+        "repo": "raspberry-pi-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
         "home-manager": "home-manager_2",
+        "home-manager-unstable": "home-manager-unstable",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "raspberry-pi-nix": "raspberry-pi-nix",
         "tsidp": "tsidp",
         "vscode-server": "vscode-server"
+      }
+    },
+    "rpi-bluez-firmware-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708969706,
+        "narHash": "sha256-KakKnOBeWxh0exu44beZ7cbr5ni4RA9vkWYb9sGMb8Q=",
+        "owner": "RPi-Distro",
+        "repo": "bluez-firmware",
+        "rev": "78d6a07730e2d20c035899521ab67726dc028e1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RPi-Distro",
+        "ref": "bookworm",
+        "repo": "bluez-firmware",
+        "type": "github"
+      }
+    },
+    "rpi-firmware-nonfree-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1723266537,
+        "narHash": "sha256-T7eTKXqY9cxEMdab8Snda4CEOrEihy5uOhA6Fy+Mhnw=",
+        "owner": "RPi-Distro",
+        "repo": "firmware-nonfree",
+        "rev": "4b356e134e8333d073bd3802d767a825adec3807",
+        "type": "github"
+      },
+      "original": {
+        "owner": "RPi-Distro",
+        "ref": "bookworm",
+        "repo": "firmware-nonfree",
+        "type": "github"
+      }
+    },
+    "rpi-firmware-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727798811,
+        "narHash": "sha256-eavbshXGYmkYR33y9FLcQMJoAYdYTESVEy0g/RRXnb0=",
+        "owner": "raspberrypi",
+        "repo": "firmware",
+        "rev": "287e6a6c2d3b50eee3e2c5b2eacdd907e5cbe09a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "1.20241001",
+        "repo": "firmware",
+        "type": "github"
+      }
+    },
+    "rpi-linux-6_10_12-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728305462,
+        "narHash": "sha256-LtvNmGD1D5YYv+C9xxxddAeHw69o3OX/H9M7F663L74=",
+        "owner": "raspberrypi",
+        "repo": "linux",
+        "rev": "26ee50d56618c2d98100b1bc672fd201aed4d00f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "rpi-6.10.y",
+        "repo": "linux",
+        "type": "github"
+      }
+    },
+    "rpi-linux-6_6_54-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728155174,
+        "narHash": "sha256-/8RjW35XQMnshjAE4Ey8j3oWzE2GOntnBYY6PlvZGhs=",
+        "owner": "raspberrypi",
+        "repo": "linux",
+        "rev": "12f0f28db3afe451a81a34c5a444f6841c10067c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "rpi-6.6.y",
+        "repo": "linux",
+        "type": "github"
+      }
+    },
+    "rpicam-apps-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727515047,
+        "narHash": "sha256-qCYGrcibOeGztxf+sd44lD6VAOGoUNwRqZDdAmcTa/U=",
+        "owner": "raspberrypi",
+        "repo": "rpicam-apps",
+        "rev": "a8ccf9f3cd9df49875dfb834a2b490d41d226031",
+        "type": "github"
+      },
+      "original": {
+        "owner": "raspberrypi",
+        "ref": "v1.5.2",
+        "repo": "rpicam-apps",
+        "type": "github"
       }
     },
     "systems": {
@@ -196,6 +398,19 @@
         "owner": "tailscale",
         "repo": "tsidp",
         "type": "github"
+      }
+    },
+    "u-boot-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719857238,
+        "narHash": "sha256-mJ2TBy0Y5ZtcGFgtU5RKr0UDUp5FWzojbFb+o/ebRJU=",
+        "type": "tarball",
+        "url": "https://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2"
       }
     },
     "vscode-server": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
       url = "github:nix-community/home-manager/release-24.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    home-manager-unstable = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     vscode-server = {
       url = "github:nix-community/nixos-vscode-server";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -20,9 +24,15 @@
       url = "github:ryantm/agenix/0.15.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # Raspberry Pi 5 support - provides proper kernel, firmware, and config.txt management
+    # Archived but still functional and recommended for RPi5
+    # See: https://github.com/nix-community/raspberry-pi-nix
+    raspberry-pi-nix = {
+      url = "github:nix-community/raspberry-pi-nix/v0.4.1";
+    };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, vscode-server, tsidp, agenix, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, raspberry-pi-nix, ... }@inputs:
     let
       # Systems that can run our scripts and packages
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
@@ -64,6 +74,8 @@
         };
 
         # Raspberry Pi 5 (aarch64)
+        # Uses raspberry-pi-nix for proper RPi5 kernel and firmware support
+        # See: https://github.com/nix-community/raspberry-pi-nix
         rpi5 = nixpkgs.lib.nixosSystem {
           system = "aarch64-linux";
           specialArgs = {
@@ -74,17 +86,29 @@
             inherit self; # Pass self for accessing flake root
           };
           modules = [
+            # raspberry-pi-nix provides kernel, firmware, and config.txt management
+            raspberry-pi-nix.nixosModules.raspberry-pi
             ./hosts/rpi5/configuration.nix
             home-manager.nixosModules.home-manager
             vscode-server.nixosModules.default
             agenix.nixosModules.default
-            ({ pkgs, ... }: {
+            ({ pkgs, lib, ... }: {
               environment.systemPackages = with pkgs; [
                 agenix
               ];
+              # Enable SD image build
+              # Build with: nix build .#nixosConfigurations.rpi5.config.system.build.sdImage
+              sdImage.compressImage = true;
+              sdImage.imageName = "nixos-rpi5.img";
             })
           ];
         };
+      };
+
+      # SD Image for Raspberry Pi 5
+      # Build with: nix build .#rpi5-sd-image
+      images = {
+        rpi5-sd-image = self.nixosConfigurations.rpi5.config.system.build.sdImage;
       };
 
       # Packages - scripts that can be built and run

--- a/hosts/rpi5/README.md
+++ b/hosts/rpi5/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the NixOS configuration for a Raspberry Pi 5 running **Open-WebUI** with OpenRouter backend.
 
+> ⚠️ **Important:** This configuration uses [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix) for proper RPi5 kernel, firmware, and device tree support. The standard NixOS aarch64 image has limited RPi5 compatibility.
+
 ## Features
 
 - 🌐 **Open-WebUI** with OpenRouter API integration
@@ -9,143 +11,151 @@ This directory contains the NixOS configuration for a Raspberry Pi 5 running **O
 - 🔒 **Tailscale** for secure remote access (HTTPS via Tailscale Serve)
 - 💾 **Resource optimizations** for RPi5's limited RAM/storage
 - 🔐 **Agenix** for encrypted secrets management
+- 🐧 **raspberry-pi-nix** with BCM2712 kernel for full RPi5 hardware support
 
 ## Prerequisites
 
 - Raspberry Pi 5 (8GB recommended for Open-WebUI)
-- MicroSD card (32GB+) or NVMe SSD via M.2 HAT (recommended)
+- MicroSD card (32GB+) or NVMe SSD via M.2 HAT
 - Network connectivity (Ethernet recommended for initial setup)
-- Another computer to SSH from
+- Another computer for building the SD image
 
-## Migration from Raspberry Pi OS
+## Installation
 
-The easiest way to migrate is using the **bootstrap script** which leverages `nixos-infect`:
+### Option A: Build Custom SD Image (Recommended)
 
-### Quick Start (From Raspberry Pi OS)
+This builds a complete SD image with your configuration pre-installed.
 
-```bash
-# 1. Flash Raspberry Pi OS Lite (64-bit) to your SD card
-#    - Use Raspberry Pi Imager
-#    - Enable SSH in the imager settings
-#    - Set hostname, username, and password
-
-# 2. Boot the Pi and SSH into it
-ssh pi@<pi-ip>
-
-# 3. Run the bootstrap script
-curl -L https://raw.githubusercontent.com/alexandru-savinov/nixos-config/main/scripts/bootstrap.sh | sudo bash -s -- rpi5
-```
-
-The script will:
-1. Install Nix package manager
-2. Enable flakes
-3. Optionally run `nixos-infect` to convert your system to NixOS
-4. Generate hardware configuration
-5. Apply the rpi5 configuration
-
-### What the Bootstrap Script Does
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  NixOS Bootstrap/Infect Script                              │
-│  For Raspberry Pi 5 and other aarch64/x86_64 systems        │
-└─────────────────────────────────────────────────────────────┘
-
-Step 1/5: Checking Nix installation...
-Step 2/5: Enabling flakes...
-Step 3/5: Checking if NixOS is installed...
-         → Offers nixos-infect option
-Step 4/5: Generating hardware configuration...
-Step 5/5: Applying configuration...
-```
-
-## Alternative: Fresh NixOS Installation
-
-### Method 1: Using Pre-built NixOS Image
+**On a Linux machine with Nix (or use the nix-community cachix for faster builds):**
 
 ```bash
-# Download the latest NixOS aarch64 SD image
-curl -L -o nixos-sd.img.zst https://hydra.nixos.org/job/nixos/release-24.05/nixos.sd_image.aarch64-linux/latest/download-by-type/file/sd-image
+# Clone the repository
+git clone https://github.com/alexandru-savinov/nixos-config.git
+cd nixos-config
+
+# Optional: Use cachix for pre-built kernels (saves hours of compile time)
+nix-shell -p cachix --run "cachix use nix-community"
+
+# Build the SD image (requires aarch64 emulation or native aarch64)
+nix build '.#nixosConfigurations.rpi5.config.system.build.sdImage'
+
+# The image will be at: result/sd-image/nixos-rpi5.img.zst
+```
+
+**If you need aarch64 emulation on x86_64:**
+
+```bash
+# Add to your /etc/nixos/configuration.nix
+boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+```
+
+**Flash the image:**
+
+```bash
+# Decompress and flash (Linux/macOS)
+zstdcat result/sd-image/nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
+
+# Or on Windows: use 7-Zip to extract, then Raspberry Pi Imager to flash
+```
+
+### Option B: Flash Generic NixOS, Then Apply Config
+
+If you can't build the custom image, use the generic NixOS aarch64 image:
+
+1. **Download NixOS image:**
+   - https://hydra.nixos.org/job/nixos/release-24.05/nixos.sd_image.aarch64-linux/latest/download-by-type/file/sd-image
+
+2. **Flash and boot** (see Windows/Linux instructions below)
+
+3. **SSH in and apply config:**
+   ```bash
+   ssh nixos@<pi-ip>  # password: nixos
+   sudo -i
+   
+   # Enable flakes
+   mkdir -p ~/.config/nix
+   echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+   
+   # Apply configuration
+   nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
+   ```
+
+> ⚠️ **Note:** The generic image may have limited hardware support. The custom SD image (Option A) is strongly recommended.
+
+## Flashing Instructions
+
+### Windows
+
+1. Download and extract the `.img.zst` file using [7-Zip](https://7-zip.org/)
+2. Open [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
+3. Choose OS → Scroll down → **Use custom** → Select the `.img` file
+4. Choose Storage → Select your SD card
+5. Click **Write**
+
+### Linux/macOS
+
+```bash
+# For custom image
+zstdcat nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
+
+# For generic NixOS image
 zstd -d nixos-sd.img.zst
-
-# Flash to SD card (replace /dev/sdX with your device!)
 sudo dd if=nixos-sd.img of=/dev/sdX bs=4M status=progress conv=fsync
-
-# Boot the Pi, SSH in (default: nixos/nixos)
-ssh nixos@<pi-ip>
-
-# Apply configuration
-sudo nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
 ```
 
-### Method 2: Manual Partitioning
+## First Boot
+
+1. Insert SD card into RPi5
+2. Connect Ethernet cable
+3. Power on and wait ~2-3 minutes
+4. Find the Pi's IP (check router DHCP or `nmap -sn 192.168.1.0/24`)
+5. SSH in:
+   ```bash
+   # Custom image: root with your SSH key
+   ssh root@<pi-ip>
+   
+   # Generic image: nixos / nixos
+   ssh nixos@<pi-ip>
+   ```
+
+## Post-Installation: Update Secrets
+
+After first boot, you need to update the agenix secrets with the real host key:
 
 ```bash
-# For SD card
-sudo parted /dev/mmcblk0 -- mklabel gpt
-sudo parted /dev/mmcblk0 -- mkpart ESP fat32 1MB 512MB
-sudo parted /dev/mmcblk0 -- set 1 esp on
-sudo parted /dev/mmcblk0 -- mkpart primary ext4 512MB 100%
-
-# Format
-sudo mkfs.fat -F 32 -n NIXOS_BOOT /dev/mmcblk0p1
-sudo mkfs.ext4 -L NIXOS_ROOT /dev/mmcblk0p2
-
-# Mount and install
-sudo mount /dev/disk/by-label/NIXOS_ROOT /mnt
-sudo mkdir -p /mnt/boot
-sudo mount /dev/disk/by-label/NIXOS_BOOT /mnt/boot
-
-sudo nixos-install --flake github:alexandru-savinov/nixos-config#rpi5
+# On the Pi - get the SSH host key
+cat /etc/ssh/ssh_host_ed25519_key.pub
+# Output: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... root@rpi5
 ```
 
-## Post-Installation Setup
+Then on your development machine:
 
-### 1. Update Hardware Configuration
+1. Edit `secrets/secrets.nix` - replace the `rpi5` placeholder with the real key
+2. Re-encrypt secrets:
+   ```bash
+   cd secrets
+   agenix -r
+   ```
+3. Commit and push
+4. On the Pi, rebuild:
+   ```bash
+   nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
+   ```
 
-After first boot, verify the hardware configuration matches your setup:
+## Technical Details
 
-```bash
-nixos-generate-config --show-hardware-config > /tmp/hw.nix
-diff /tmp/hw.nix /etc/nixos/hosts/rpi5/hardware-configuration.nix
+### raspberry-pi-nix Configuration
+
+```nix
+# Board selection (BCM2712 = RPi5)
+raspberry-pi-nix.board = "bcm2712";
+
+# Kernel: Uses official Raspberry Pi Linux fork
+# Firmware: Managed automatically with config.txt generation
+# Boot: U-Boot with proper device tree support
 ```
 
-Update `hardware-configuration.nix` with correct UUIDs if needed.
-
-### 2. Update Secrets for RPi5
-
-Get the Pi's SSH host key and update the secrets:
-
-```bash
-# On the Pi - get the host key
-cat /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $1 " " $2}'
-# Output: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
-```
-
-On your development machine:
-```bash
-# Edit secrets/secrets.nix - replace the rpi5 placeholder key
-vim secrets/secrets.nix
-
-# Re-encrypt all secrets with the new key
-cd secrets
-agenix -r
-
-# Commit and push
-git add -A && git commit -m "Add real rpi5 host key" && git push
-```
-
-### 3. Rebuild to Apply Secrets
-
-```bash
-sudo nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
-```
-
-## Resource Optimizations
-
-The RPi5 configuration includes several optimizations for running Open-WebUI on limited hardware:
-
-### Memory Management
+### Resource Optimizations
 
 | Setting | Value | Purpose |
 |---------|-------|---------|
@@ -172,13 +182,6 @@ The RPi5 configuration includes several optimizations for running Open-WebUI on 
 | GC trigger | 1GB free | Auto garbage collection |
 | GC retention | 3 days | Aggressive cleanup |
 
-### Storage Optimization
-
-- Documentation disabled (except man pages)
-- Journal limited to 100MB
-- Daily garbage collection
-- Auto-optimize nix store
-
 ## Accessing Open-WebUI
 
 Once deployed, Open-WebUI is accessible via Tailscale:
@@ -194,23 +197,29 @@ Features enabled:
 
 ## Troubleshooting
 
+### Boot Issues
+
+1. Connect a monitor to see boot messages
+2. Verify SD card is properly flashed
+3. Try rebuilding the SD image
+4. Check if the RPi5 power supply is adequate (5V/5A recommended)
+
 ### Memory Issues During Build
 
-If builds fail with OOM:
-
 ```bash
-# Temporarily add more swap
+# Check memory usage
+free -h
+htop
+
+# If builds fail with OOM, the config already includes 4GB swap
+# You can add more temporarily:
 sudo fallocate -l 4G /tmp/swapfile
 sudo chmod 600 /tmp/swapfile
 sudo mkswap /tmp/swapfile
 sudo swapon /tmp/swapfile
 
-# Then rebuild
+# Rebuild
 sudo nixos-rebuild switch --flake .#rpi5
-
-# Remove temporary swap
-sudo swapoff /tmp/swapfile
-rm /tmp/swapfile
 ```
 
 ### Open-WebUI Not Starting
@@ -218,32 +227,24 @@ rm /tmp/swapfile
 ```bash
 # Check service status
 systemctl status open-webui
-
-# View logs
 journalctl -u open-webui -f
 
-# Check memory usage
-free -h
-htop
+# Check if secrets are decrypted
+ls -la /run/agenix/
 ```
 
 ### Tailscale Issues
 
 ```bash
-# Check Tailscale status
+# Check status
 tailscale status
 
-# Re-authenticate if needed
+# Re-authenticate
 tailscale up --ssh
 
 # Check serve configuration
 tailscale serve status
 ```
-
-### chromadb Build Issues
-
-The configuration includes `allowBroken = true` because chromadb is marked as broken on aarch64.
-This is a known issue with NixOS 24.05. The package still works, just not officially supported.
 
 ### Secrets Not Decrypting
 
@@ -254,42 +255,37 @@ cat /etc/ssh/ssh_host_ed25519_key.pub
 # Check agenix status
 ls -la /run/agenix/
 
-# Manual decryption test
-agenix -d open-webui-secret-key.age
+# Try manual decryption
+agenix -d tailscale-auth-key.age
 ```
 
-## Performance Tips
+## Using the nix-community Cache
 
-### Use NVMe Instead of SD Card
+The raspberry-pi-nix project pushes kernel builds to cachix. To avoid compiling the Linux kernel yourself (which takes hours on RPi5):
 
-For significantly better performance:
-1. Get an M.2 HAT for RPi5
-2. Install NVMe SSD
-3. Flash NixOS to NVMe
-4. Update hardware-configuration.nix
+```bash
+# Install cachix
+nix-shell -p cachix
 
-### Active Cooling
+# Use the nix-community cache
+cachix use nix-community
+```
 
-For sustained workloads, use active cooling:
-- Official RPi5 Active Cooler
-- Or case with built-in fan
-
-### Reduce Build Load
-
-For faster rebuilds, use a remote builder:
+Or add to your NixOS configuration:
 
 ```nix
-nix.buildMachines = [{
-  hostName = "sancta-choir";
-  system = "x86_64-linux";
-  # ... remote build config
-}];
+nix.settings = {
+  substituters = [ "https://nix-community.cachix.org" ];
+  trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  ];
+};
 ```
 
 ## Useful Commands
 
 ```bash
-# Check system status
+# System status
 systemctl status
 
 # View logs
@@ -299,11 +295,11 @@ journalctl -f
 systemctl status open-webui
 curl -s http://127.0.0.1:8080/health
 
-# Tailscale status
+# Tailscale
 tailscale status
 tailscale serve status
 
-# Rebuild configuration
+# Rebuild
 sudo nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5
 
 # Update flake inputs
@@ -326,6 +322,7 @@ btop
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                      Raspberry Pi 5                         │
+│              (raspberry-pi-nix + BCM2712 kernel)            │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │  ┌─────────────┐    ┌─────────────────┐    ┌────────────┐  │
@@ -347,5 +344,11 @@ btop
 | File | Purpose |
 |------|---------|
 | `configuration.nix` | Main RPi5 NixOS configuration |
-| `hardware-configuration.nix` | Hardware-specific settings (UUIDs, boot) |
+| `hardware-configuration.nix` | raspberry-pi-nix board config and settings |
 | `README.md` | This documentation |
+
+## References
+
+- [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix) - RPi NixOS support
+- [NixOS on ARM/Raspberry Pi 5](https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5) - Wiki page
+- [nixpkgs#260754](https://github.com/NixOS/nixpkgs/issues/260754) - RPi5 support issue


### PR DESCRIPTION
## Summary

Switched from generic `linuxPackages_rpi4` to `raspberry-pi-nix` which provides proper RPi5 support based on the recommendation from [nixpkgs#260754](https://github.com/NixOS/nixpkgs/issues/260754#issuecomment-2322817130).

## What raspberry-pi-nix provides

- **BCM2712 kernel** - Proper RPi5 kernel from Raspberry Pi Foundation
- **Automatic firmware management** - config.txt generation
- **Device tree support** - Full hardware compatibility  
- **SD image builder** - Easy flashing

## Changes

### Flake
- Add `raspberry-pi-nix` v0.4.1 input
- Use `raspberry-pi-nix.nixosModules.raspberry-pi` for RPi5
- Add SD image build target

### Hardware Configuration
- Set `raspberry-pi-nix.board = "bcm2712"` (RPi5)
- Configure `hardware.raspberry-pi.config` for config.txt settings
- Enable UART, Bluetooth, GPU overlay

### Fixes from previous attempt
- **Format configuration.nix with nixpkgs-fmt** (CI was failing on formatting)

### Build Instructions

```bash
# Build custom SD image (recommended)
nix build '.#nixosConfigurations.rpi5.config.system.build.sdImage'

# Flash to SD card
zstdcat result/sd-image/nixos-rpi5.img.zst | sudo dd of=/dev/sdX bs=4M status=progress
```

### Using Cachix (avoid kernel compilation)

```bash
nix-shell -p cachix --run "cachix use nix-community"
```

## Testing

- [x] `nix flake check` passes
- [x] `nix fmt -- --check .` passes
- [ ] Build SD image
- [ ] Flash and boot on actual RPi5 hardware

## References

- [raspberry-pi-nix](https://github.com/nix-community/raspberry-pi-nix)
- [nixpkgs#260754 comment](https://github.com/NixOS/nixpkgs/issues/260754#issuecomment-2322817130)
- [NixOS Wiki: RPi5](https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_5)