### PR TITLE
audit: Configuration review - fix duplicate config blocks in issue-28 branch

### DIFF
--- a/CONFIG-REVIEW.md
+++ b/CONFIG-REVIEW.md
@@ -1,0 +1,39 @@
+# Configuration Review - 2025-12-19
+
+**Branch:** `claude/check-config-adjustments-spPjz`
+**Status:** ✅ Complete
+
+## Summary
+
+Configuration audit performed. Main branch is clean and production-ready.
+
+## Critical Issue Found
+
+**Location:** `feature/issue-28-openrouter-zdr-pipe` branch
+**File:** `modules/services/open-webui.nix`
+**Issue:** Duplicate config blocks (102 lines)
+**Impact:** Would prevent NixOS from building
+**Status:** Fixed on feature branch (commits 2b5350e, 99cc6f2)
+
+### What Was Fixed
+- Removed duplicate systemd service definitions
+- Properly structured NixOS module with `config = mkIf cfg.enable` wrapper
+- All functionality preserved
+
+## Configuration Health
+
+✅ **Main Branch:** No issues - production ready
+✅ **Security:** All checks passed (agenix, SSH keys, hardening)
+✅ **Architecture:** Clean modular design
+✅ **CI/CD:** Properly configured
+
+## Recommendations (Optional)
+
+1. **NixOS 24.11 upgrade** - Current: 24.05, Latest: 24.11
+2. **Automated flake updates** - Weekly dependency updates
+3. **Pre-commit hooks** - Validation before commits
+
+## Next Steps
+
+1. Merge issue-28 fix before deploying that feature
+2. Current main branch ready for deployment


### PR DESCRIPTION
Found and fixed critical issue in feature/issue-28-openrouter-zdr-pipe:
- modules/services/open-webui.nix had duplicate config blocks (102 lines)
- Would prevent NixOS from building
- Fixed on feature branch

Main branch: clean, production ready
Security: all checks passed