### PR TITLE
feat: Add Claude Code CLI as a persistent system package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,12 +27,18 @@
     # Raspberry Pi 5 support - provides proper kernel, firmware, and config.txt management
     # Archived but still functional and recommended for RPi5
     # See: https://github.com/nix-community/raspberry-pi-nix
+    # Claude Code - auto-updated hourly from npm
+    # See: https://github.com/sadjow/claude-code-nix
+    claude-code = {
+      url = "github:sadjow/claude-code-nix";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     raspberry-pi-nix = {
       url = "github:nix-community/raspberry-pi-nix/v0.4.1";
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, raspberry-pi-nix, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, raspberry-pi-nix, claude-code, ... }@inputs:
     let
       # Systems that can run our scripts and packages
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
@@ -58,6 +64,7 @@
               config.allowUnfree = true;
             };
             inherit self; # Pass self for accessing flake root
+            inherit claude-code; # Pass claude-code flake
           };
           modules = [
             ./hosts/sancta-choir/configuration.nix
@@ -84,6 +91,7 @@
               config.allowUnfree = true;
             };
             inherit self; # Pass self for accessing flake root
+            inherit claude-code; # Pass claude-code flake
           };
           modules = [
             # raspberry-pi-nix provides proper Pi 5 kernel with RP1 drivers

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -2,6 +2,7 @@
 , pkgs
 , lib
 , self
+, claude-code
 , ...
 }:
 
@@ -10,14 +11,17 @@
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
   # Add nix-community cache for pre-built RPi5 kernels
+  # Also add claude-code cachix for pre-built Claude Code binaries
   nix.settings = {
     substituters = [
       "https://cache.nixos.org"
       "https://nix-community.cachix.org"
+      "https://claude-code.cachix.org"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "claude-code.cachix.org-1:p3pMxGi7K+xT7I3dLghdlrUijD8s+wfQlmWp8gQ/TJA="
     ];
   };
 
@@ -29,6 +33,7 @@
     ../../modules/system/nix-ld.nix
     ../../modules/users/root.nix
     ../../modules/services/copilot.nix
+    ../../modules/services/claude.nix
     ../../modules/services/tailscale.nix
     ../../modules/services/tsidp.nix
     ../../modules/services/open-webui.nix

--- a/modules/services/claude.nix
+++ b/modules/services/claude.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, lib, claude-code, ... }:
+
+{
+  # Claude Code - AI-powered coding assistant
+  # Auto-updated hourly via github:sadjow/claude-code-nix flake
+
+  # Add Claude Code to system packages
+  environment.systemPackages = [
+    claude-code.packages.${pkgs.system}.default
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `claude-code` flake input from `github:sadjow/claude-code-nix` for auto-updated Claude Code CLI
- Create `modules/services/claude.nix` module to install Claude Code as a system package
- Add `claude-code.cachix.org` binary cache for faster builds
- Pass `claude-code` to `specialArgs` for both `sancta-choir` and `rpi5` hosts

## Problem
Previously, Claude Code was installed via `npm install -g` which:
1. Installs to a temporary overlay on NixOS
2. Gets lost after reboot/reconnection
3. Requires manual reinstallation every session

## Solution
This PR makes Claude Code a declarative system package that:
- Persists across reboots and system rebuilds
- Auto-updates when running `nix flake update`
- Uses binary cache for fast installation

## Test plan
- [ ] Run `nixos-rebuild switch --flake .#sancta-choir`
- [ ] Verify `claude --version` works after rebuild
- [ ] Verify Claude persists after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)