### PR TITLE
feat: Add n8n workflow automation with Tailscale access

### DIFF
--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -44,12 +44,6 @@ in
       '';
     };
 
-    stateDir = mkOption {
-      type = types.path;
-      default = "/var/lib/n8n";
-      description = "Directory for n8n data (SQLite database, files, etc).";
-    };
-
     extraSettings = mkOption {
       type = types.attrs;
       default = { };
@@ -175,8 +169,8 @@ in
             # Concurrency limit
             echo "N8N_CONCURRENCY_PRODUCTION_LIMIT=${toString cfg.concurrencyLimit}" >> "$ENV_FILE"
 
-            # Make readable by DynamicUser (directory already restricts access)
-            chmod 644 "$ENV_FILE"
+            # Make readable only by DynamicUser (600 + dir 0700 = secure)
+            chmod 600 "$ENV_FILE"
           '')
         ];
       };


### PR DESCRIPTION
## Summary

- Add `modules/services/n8n.nix` - wrapper module for n8n with Tailscale-only access
- Create encrypted `n8n-encryption-key.age` secret for credential encryption
- Enable n8n on both `sancta-choir` and `rpi5` hosts
- Uses native NixOS `services.n8n` module with SQLite storage (no PostgreSQL needed)

Partially addresses #29 (implements core NixOS module with agenix secrets, but uses SQLite and Tailscale-only access instead of PostgreSQL and public Funnel webhooks).

## Key Features

- **Agenix secret management** for `N8N_ENCRYPTION_KEY`
- **Tailscale-only access** via firewall rules on `tailscale0` interface
- **Privacy-focused defaults**: telemetry disabled, public API disabled
- **Security hardening**: DynamicUser, ProtectSystem=strict, etc.

## Files Changed

| File | Description |
|------|-------------|
| `modules/services/n8n.nix` | New service module |
| `secrets/secrets.nix` | Add n8n-encryption-key definition |
| `secrets/n8n-encryption-key.age` | Encrypted secret |
| `hosts/sancta-choir/configuration.nix` | Enable n8n |
| `hosts/rpi5/configuration.nix` | Enable n8n |

## Access

- sancta-choir: http://sancta-choir.tail4249a9.ts.net:5678
- rpi5: http://rpi5.tail4249a9.ts.net:5678

## Test plan

- [x] Build configuration (`nix flake check`)
- [x] Verify systemd service generated correctly
- [x] Verify firewall rules (port 5678 on tailscale0)
- [x] Deploy to sancta-choir
- [x] Health check: `curl http://localhost:5678/healthz` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)