### PR TITLE
docs(CLAUDE.md): add pre-switch validation checklist for worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,26 @@ GitHub Actions on push/PR: `nix flake check`, build all hosts, format check. Mai
 
 **IMPORTANT:** Always use git worktrees when making code changes. Never commit directly to main.
 
+### Pre-Switch Validation
+
+**Before creating or switching to a worktree**, validate the current work:
+
+```bash
+# 1. Format check
+nix fmt
+
+# 2. Flake validation + tests
+nix flake check
+
+# 3. Build current host (architecture-specific)
+nixos-rebuild build --flake .#sancta-choir  # x86_64 only
+nixos-rebuild build --flake .#rpi5          # aarch64 only
+```
+
+This ensures broken code isn't left behind when context-switching.
+
+### Worktree Commands
+
 ```bash
 # Create worktree for new feature/fix
 git worktree add ../nixos-config-<branch-name> -b <branch-name>
@@ -98,7 +118,7 @@ cd ../nixos-config-<branch-name>
 git worktree remove ../nixos-config-<branch-name>
 ```
 
-Branch naming:
+### Branch Naming
 - `feat/<name>` - New features
 - `fix/<name>` - Bug fixes
 - `docs/<name>` - Documentation changes


### PR DESCRIPTION
## Summary
- Add pre-switch validation section to Git Workflow documentation
- Require `nix fmt`, `nix flake check` (runs tests), and architecture-specific builds before switching worktrees
- Reorganize workflow section with subsections for better readability

## Test plan
- [ ] Review documentation changes for accuracy
- [ ] Verify commands match project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)