### PR TITLE
Fix issue-triage workflow: remove invalid allowed_tools param

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -61,5 +61,3 @@ jobs:
             - For spam/invalid: just label `invalid` and add a brief note
             - For valid issues: add category + priority labels
             - This is a NixOS configuration repo - issues should relate to NixOS, flakes, services, or deployment
-          allowed_tools: |
-            Bash(gh issue:*)


### PR DESCRIPTION
## Summary

Fixes the issue-triage workflow that wasn't applying labels.

The `allowed_tools` parameter is not valid for `claude-code-action@v1` - it was being ignored with a warning. Tool restrictions should be done via `claude_args: --allowedTools` if needed.

For now, removing the restriction and relying on prompt guidance to keep Claude focused on `gh issue` commands.

## Test plan

- [ ] Re-run triage on issue #71 after merge

🤖 Generated with [Claude Code](https://claude.ai/code)