### PR TITLE
Enable Bash tool for issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(gh issue:*)"
           prompt: |
             You MUST triage GitHub issue #${{ github.event.issue.number }} by applying labels and adding a comment.
 


### PR DESCRIPTION
Fixes triage by adding --allowedTools to allow gh issue commands.