### PR TITLE
fix(.claude): remove invalid plugin references

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,6 @@
     "commit-commands@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "ralph-wiggum@claude-plugins-official": true,
-    "explanatory-output-style@claude-plugins-official": true,
-    "error-diagnostics@claude-code-workflows": true,
-    "cicd-automation@claude-code-workflows": true
+    "explanatory-output-style@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Remove `error-diagnostics@claude-code-workflows` and `cicd-automation@claude-code-workflows` plugin entries
- These referenced a non-existent `claude-code-workflows` marketplace, causing plugin load errors on startup

## Test plan
- [x] Verify plugin errors no longer appear on Claude Code startup
- [x] Confirm remaining plugins load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)