### PR TITLE
fix(testing): update Open-WebUI API for 0.6+ compatibility

### DIFF
--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -364,10 +364,11 @@ in
             else cfg.openai.apiBaseUrl;
         }
         (mkIf cfg.tavilySearch.enable {
-          ENABLE_RAG_WEB_SEARCH = "True";
-          RAG_WEB_SEARCH_ENGINE = "tavily";
-          RAG_WEB_SEARCH_RESULT_COUNT = "3";
-          RAG_WEB_SEARCH_CONCURRENT_REQUESTS = "10";
+          # Open-WebUI 0.6+ uses ENABLE_WEB_SEARCH (not ENABLE_RAG_WEB_SEARCH)
+          ENABLE_WEB_SEARCH = "True";
+          WEB_SEARCH_ENGINE = "tavily";
+          WEB_SEARCH_RESULT_COUNT = "3";
+          WEB_SEARCH_CONCURRENT_REQUESTS = "10";
         })
         (mkIf cfg.oidc.enable {
           OAUTH_PROVIDER_NAME = "Tailscale";


### PR DESCRIPTION
## Summary
- Update web search environment variables for Open-WebUI 0.6+ API compatibility
- Fix web search endpoint path and request format in test client
- Add network timeout handling to E2E tests for reliability on resource-constrained devices

## Changes

| File | Description |
|------|-------------|
| `modules/services/open-webui.nix` | Fix env var names: `ENABLE_WEB_SEARCH`, `WEB_SEARCH_ENGINE` |
| `tests/e2e/owui_client.py` | Update endpoint to `/api/v1/retrieval/process/web/search` |
| `tests/e2e/test_web_search.py` | Add timeout handling with graceful skip |

## Test plan
- [x] All 30 E2E tests pass locally on rpi5
- [x] `nix flake check` passes
- [x] Web search functionality verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)