### PR TITLE
fix(common): add jq to system packages for Ralph Wiggum plugin

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -33,6 +33,7 @@
     git
     curl
     wget
+    jq # Required for Ralph Wiggum plugin hooks (JSON parsing)
   ];
 
   # Default state version (override per host if needed)


### PR DESCRIPTION
## Summary
- Adds `jq` to system packages in `hosts/common.nix`
- Fixes Ralph Wiggum plugin stop hook failure: `jq: command not found`

## Context
The Ralph Wiggum plugin hooks use `jq` for JSON parsing to track iteration state. Without `jq` installed system-wide, the stop hook fails.

## Test plan
- [x] Verified `jq` is available after rebuild: `jq-1.8.1`
- [x] Ralph Wiggum plugin hooks now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)