### PR TITLE
feat(.claude): add nix-commit plugin with nix fmt pre-commit

### DIFF
--- a/.claude/plugins/nix-commit/.claude-plugin/plugin.json
+++ b/.claude/plugins/nix-commit/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "nix-commit",
+  "description": "Git commit commands with automatic nix fmt formatting for NixOS projects",
+  "version": "1.0.0",
+  "author": {
+    "name": "nixos-config"
+  },
+  "license": "MIT",
+  "keywords": ["nix", "nixos", "git", "commit", "formatting"],
+  "commands": "./commands/"
+}

--- a/.claude/plugins/nix-commit/commands/commit-push-pr.md
+++ b/.claude/plugins/nix-commit/commands/commit-push-pr.md
@@ -1,0 +1,23 @@
+---
+allowed-tools: Bash(nix fmt:*), Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+description: Format Nix files, commit, push, and create a PR
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Based on the above changes:
+
+1. Run `nix fmt` to format all Nix files before committing
+2. Create a new branch if on main
+3. Stage all changes (including any formatting fixes from step 1)
+4. Create a single commit with an appropriate message
+5. Push the branch to origin
+6. Create a pull request using `gh pr create`
+
+You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/.claude/plugins/nix-commit/commands/commit.md
+++ b/.claude/plugins/nix-commit/commands/commit.md
@@ -1,0 +1,21 @@
+---
+allowed-tools: Bash(nix fmt:*), Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Format Nix files and create a commit
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+
+## Your task
+
+Based on the above changes:
+
+1. Run `nix fmt` to format all Nix files before committing
+2. Stage all changes (including any formatting fixes from step 1)
+3. Create a single git commit with an appropriate message
+
+You have the capability to call multiple tools in a single response. Do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "ralph-wiggum@claude-plugins-official": true,
     "explanatory-output-style@claude-plugins-official": true,
-    ".claude/plugins/local-review": true
+    ".claude/plugins/local-review": true,
+    ".claude/plugins/nix-commit": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,11 +130,22 @@ Use these plugin commands when working on this project:
 
 | Command | When to Use |
 |---------|-------------|
-| `/commit` | When asked to commit changes |
-| `/commit-push-pr` | When asked to commit, push, and create a PR in one step |
+| `/nix-commit:commit` | Commit changes (runs `nix fmt` first) |
+| `/nix-commit:commit-push-pr` | Commit, push, and create PR (runs `nix fmt` first) |
 | `/clean_gone` | After merging PRs to clean up stale local branches |
 | `/review-pr` | Before creating pull requests to catch issues early |
 | `/feature-dev` | For complex feature implementations requiring architecture planning |
+
+### Project-Local Plugins
+
+This repo has custom Claude Code plugins in `.claude/plugins/` that override marketplace commands:
+
+| Plugin | Location | Purpose |
+|--------|----------|---------|
+| `nix-commit` | `.claude/plugins/nix-commit/` | Runs `nix fmt` before commits to pass CI formatting checks |
+| `local-review` | `.claude/plugins/local-review/` | Pre-commit code review |
+
+**Important:** Use `/nix-commit:commit` instead of `/commit` to ensure Nix files are formatted before committing. This prevents CI failures from formatting mismatches.
 
 ## Nix Code Style
 


### PR DESCRIPTION
## Summary
- Add `nix-commit` plugin with `commit` and `commit-push-pr` commands
- Runs `nix fmt` before committing to ensure CI formatting checks pass
- Update CLAUDE.md to document project-local plugins

## Changes
- `.claude/plugins/nix-commit/` - New plugin with two commands
- `CLAUDE.md` - Document project-local plugins and usage
- `.claude/settings.json` - Enable nix-commit plugin

## Test plan
- [x] Plugin files created with correct structure
- [x] Commands use `nix fmt` instead of `nixpkgs-fmt`
- [x] CLAUDE.md updated with documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)