### PR TITLE
feat(rpi5): auto-start btop on tty1 for system monitoring

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -235,6 +235,27 @@
     DefaultTimeoutStopSec = "90s";
   };
 
+  # ============================================================
+  # BTOP ON TTY1 - Auto-start system monitor on physical console
+  # ============================================================
+  # Auto-login root on tty1 only (other TTYs require normal login)
+  systemd.services."getty@tty1" = {
+    overrideStrategy = "asDropin";
+    serviceConfig.ExecStart = [
+      "" # Clear the default ExecStart
+      "@${pkgs.util-linux}/sbin/agetty agetty --autologin root --noclear %I $TERM"
+    ];
+  };
+
+  # Start btop automatically when logged into tty1
+  # Quitting btop (q) returns to a bash shell; type 'exit' to trigger re-login and restart btop
+  programs.bash.interactiveShellInit = ''
+    if [[ $(tty) == "/dev/tty1" ]] && [[ -z "$BTOP_RUNNING" ]]; then
+      export BTOP_RUNNING=1
+      ${pkgs.btop}/bin/btop
+    fi
+  '';
+
   # Timezone (adjust as needed)
   time.timeZone = "UTC";
 


### PR DESCRIPTION
## Summary
- Auto-login root on tty1 (physical HDMI console) via systemd getty override
- Launch btop automatically on login for immediate system visibility
- Quitting btop (q) returns to bash shell; `exit` restarts the btop loop

## Test plan
- [ ] Build rpi5 config: `nix build .#nixosConfigurations.rpi5.config.system.build.toplevel`
- [ ] Deploy to RPi5 and verify btop starts on tty1 after boot
- [ ] Press `q` to quit btop and verify bash shell is available
- [ ] Type `exit` to verify btop restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)