### PR TITLE
feat(tailscale): add GitOps ACL management with CI/CD workflow

### DIFF
--- a/.github/workflows/tailscale-acl.yml
+++ b/.github/workflows/tailscale-acl.yml
@@ -1,0 +1,38 @@
+name: Tailscale ACL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tailscale/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tailscale/**"
+
+jobs:
+  acl:
+    name: Tailscale ACL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test ACL
+        if: github.event_name == 'pull_request'
+        uses: tailscale/gitops-acl-action@v1
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tailnet: ${{ secrets.TS_TAILNET }}
+          policy-file: tailscale/policy.hujson
+          action: test
+
+      - name: Deploy ACL
+        if: github.event_name == 'push'
+        uses: tailscale/gitops-acl-action@v1
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tailnet: ${{ secrets.TS_TAILNET }}
+          policy-file: tailscale/policy.hujson
+          action: apply

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -1,0 +1,87 @@
+{
+  // Tailscale ACL policy for sancta-choir infrastructure
+  // Docs: https://tailscale.com/kb/1337/policy-syntax
+  //
+  // To get started:
+  // 1. Export your current ACL from https://login.tailscale.com/admin/acls/file
+  // 2. Replace this file's content with your exported policy
+  // 3. Add tests to validate your rules
+
+  "groups": {
+    "group:admins": [
+      // Add admin email addresses here
+      // "admin@example.com",
+    ],
+  },
+
+  "tagOwners": {
+    "tag:server": ["group:admins"],
+    "tag:nixos": ["group:admins"],
+  },
+
+  "acls": [
+    // Admins have full access
+    {
+      "action": "accept",
+      "src": ["group:admins"],
+      "dst": ["*:*"],
+    },
+
+    // Servers can communicate with each other
+    {
+      "action": "accept",
+      "src": ["tag:server"],
+      "dst": ["tag:server:*"],
+    },
+
+    // Allow HTTPS access to tagged servers from all tailnet members
+    {
+      "action": "accept",
+      "src": ["autogroup:member"],
+      "dst": [
+        "tag:server:443",   // Open-WebUI
+        "tag:server:3001",  // Uptime Kuma
+        "tag:server:5678",  // n8n
+      ],
+    },
+  ],
+
+  "ssh": [
+    // Admins can SSH as any user to servers
+    {
+      "action": "accept",
+      "src": ["group:admins"],
+      "dst": ["tag:server"],
+      "users": ["root", "nixos", "autogroup:nonroot"],
+    },
+  ],
+
+  // Tests validate your ACL rules
+  // These run automatically when you push changes via GitOps
+  "tests": [
+    // Test: Admins can access everything
+    {
+      "src": "group:admins",
+      "accept": ["tag:server:22", "tag:server:443", "tag:server:5678"],
+    },
+
+    // Test: Members can access web services but not SSH
+    {
+      "src": "autogroup:member",
+      "accept": ["tag:server:443", "tag:server:3001", "tag:server:5678"],
+      "deny": ["tag:server:22"],
+    },
+
+    // Test: Servers can reach each other
+    {
+      "src": "tag:server",
+      "accept": ["tag:server:443", "tag:server:8080"],
+    },
+
+    // Test: Non-admins cannot SSH
+    {
+      "src": "autogroup:member",
+      "deny": ["tag:server:22"],
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for Tailscale ACL GitOps management
- Add policy.hujson with groups, tags, and access control rules
- Tests ACLs on PR, deploys to tailnet on merge to main

## Configuration Required
Add these secrets to the repository:
- `TS_OAUTH_CLIENT_ID` - Tailscale OAuth client ID
- `TS_OAUTH_SECRET` - Tailscale OAuth secret
- `TS_TAILNET` - Your tailnet name

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Add required secrets to GitHub repository
- [ ] Test ACL validation on PR
- [ ] Verify ACL deployment on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)