### PR TITLE
fix(rpi5): make unifi-password readable for Claude Code MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ result-*
 secrets.yaml
 *.key
 *.pem
-*.age
 .sops.yaml
+
+# MCP config (contains plaintext credentials)
+.mcp.json
 
 # Editor
 .vscode/

--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -102,7 +102,10 @@
   # Additional secrets for Open-WebUI, n8n, etc. are in rpi5-full
   age.secrets = {
     tailscale-auth-key.file = "${self}/secrets/tailscale-auth-key.age";
-    unifi-password.file = "${self}/secrets/unifi-password.age";
+    unifi-password = {
+      file = "${self}/secrets/unifi-password.age";
+      mode = "0444"; # Readable by all (needed for Claude Code MCP)
+    };
   };
 
   # ==========================================================================


### PR DESCRIPTION
## Summary
- Set mode 0444 on unifi-password agenix secret so non-root users (Claude Code) can read it for MCP authentication
- Add .mcp.json to .gitignore (contains runtime credentials)
- Remove *.age from .gitignore (encrypted secrets should be committed)

## Test plan
- [x] Verified secret is readable after `sudo chmod 444 /run/agenix/unifi-password`
- [ ] Rebuild NixOS to apply persistent permission change

🤖 Generated with [Claude Code](https://claude.com/claude-code)