### PR TITLE
feat(n8n): sync workflow active state from JSON to database

### DIFF
--- a/n8n-workflows/rpi5-system-health-check.json
+++ b/n8n-workflows/rpi5-system-health-check.json
@@ -129,7 +129,7 @@
       ]
     }
   },
-  "active": false,
+  "active": true,
   "settings": {
     "executionOrder": "v1"
   }

--- a/tests/n8n-declarative.nix
+++ b/tests/n8n-declarative.nix
@@ -17,7 +17,7 @@ pkgs.testers.nixosTest {
 
     # Test workflow (minimal valid workflow - MUST have stable id!)
     environment.etc."n8n-test-workflow.json".text = builtins.toJSON {
-      id = "test-declarative-import";  # REQUIRED for idempotency
+      id = "test-declarative-import"; # REQUIRED for idempotency
       name = "Test Declarative Import";
       nodes = [
         {
@@ -26,12 +26,12 @@ pkgs.testers.nixosTest {
           type = "n8n-nodes-base.manualTrigger";
           typeVersion = 1;
           position = [ 250 300 ];
-          parameters = {};
+          parameters = { };
         }
       ];
-      connections = {};
+      connections = { };
       active = false;
-      settings = {};
+      settings = { };
     };
 
     services.n8n-tailscale = {
@@ -39,7 +39,7 @@ pkgs.testers.nixosTest {
       encryptionKeyFile = "/etc/n8n-encryption-key";
       credentialsFile = "/etc/n8n-credentials.json";
       workflows = [ "/etc/n8n-test-workflow.json" ];
-      tailscaleServe.enable = false;  # No tailscale in test VM
+      tailscaleServe.enable = false; # No tailscale in test VM
       # Enable public API for testing workflow verification
       extraEnvironment.N8N_PUBLIC_API_DISABLED = "false";
     };


### PR DESCRIPTION
## Summary
- Add post-import step to sync `active` state from workflow JSON to n8n database
- n8n's `import:workflow` doesn't update active state of existing workflows
- Uses `jq` to extract `id` and `active` from JSON, `sqlite3` to update database
- Activate rpi5-system-health-check workflow by default

## Test plan
- [x] Deploy to rpi5-full
- [x] Verify workflow shows `active=1` in database after restart
- [x] Check logs show "Syncing workflow active states..." and "Set ... active=true"

🤖 Generated with [Claude Code](https://claude.com/claude-code)