### PR TITLE
feat: add zellij terminal multiplexer to common packages

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -34,6 +34,9 @@
     curl
     wget
     jq # Required for Ralph Wiggum plugin hooks (JSON parsing)
+
+    # Terminal multiplexer
+    zellij
   ];
 
   # Default state version (override per host if needed)


### PR DESCRIPTION
## Summary
- Add zellij terminal multiplexer to system-wide packages in `hosts/common.nix`
- Provides modern, beginner-friendly terminal multiplexing with built-in keybinding hints
- Available on all hosts (sancta-choir and rpi5)

## Test plan
- [x] Verified `nix flake check` passes
- [x] Deployed and tested on rpi5 - `zellij --version` returns 0.43.1
- [x] Ran `nix fmt` to ensure formatting compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)