### PR TITLE
fix(qdrant): add qdrant-client dependency and fix file upload

### DIFF
--- a/tests/e2e/owui_client.py
+++ b/tests/e2e/owui_client.py
@@ -424,12 +424,15 @@ class OpenWebUIClient:
         actual_filename = filename or os.path.basename(file_path)
 
         # Use multipart form data for file upload
+        # Must use requests directly (not session) to avoid Content-Type: application/json
+        # being added from session headers, which breaks multipart uploads
+        import requests as req
+
         with open(file_path, "rb") as f:
             files = {"file": (actual_filename, f)}
-            # Remove Content-Type header for multipart
             headers = {"Authorization": f"Bearer {self.api_key}"}
 
-            response = self.session.post(
+            response = req.post(
                 f"{self.base_url}/api/v1/files/",
                 files=files,
                 headers=headers,


### PR DESCRIPTION
## Summary

Fixes discovered during E2E testing of Qdrant RAG integration on rpi5:

- **qdrant-client missing**: Open-WebUI crashed with `ModuleNotFoundError: No module named 'qdrant_client'`
  - Added package override to include `qdrant-client` when `vectorDb.type = "qdrant"`
  - See: https://github.com/nixos/nixpkgs/issues/422030

- **File upload 422 error**: E2E tests failed with HTTP 422 on `/api/v1/files/`
  - Root cause: Session's default `Content-Type: application/json` header breaking multipart uploads
  - Fixed by using `requests.post()` directly instead of session for file uploads

## Test Results

All 5 Qdrant RAG E2E tests pass on rpi5:

```
tests/e2e/test_qdrant_rag.py::TestQdrantRAGIntegration::test_rag_config_shows_qdrant PASSED
tests/e2e/test_qdrant_rag.py::TestQdrantRAGIntegration::test_file_upload_creates_embeddings PASSED
tests/e2e/test_qdrant_rag.py::TestQdrantRAGIntegration::test_rag_query_returns_document_context PASSED
tests/e2e/test_qdrant_rag.py::TestQdrantRAGIntegration::test_multiple_files_rag PASSED
tests/e2e/test_qdrant_rag.py::TestQdrantRAGIntegration::test_file_deletion_removes_from_qdrant PASSED
```

## Test plan

- [x] `nix flake check` passes
- [x] E2E tests pass on rpi5
- [x] Qdrant service running (138 MB memory)
- [x] Open-WebUI connects to Qdrant for RAG

🤖 Generated with [Claude Code](https://claude.com/claude-code)