### PR TITLE
feat(open-webui): update to 0.7.1 via pkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,11 +260,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1763966396,
-        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Switches Open-WebUI module to use `pkgs-unstable` instead of stable nixpkgs
- Updates `nixpkgs-unstable` flake input to latest (Jan 2026)
- Upgrades Open-WebUI from **0.6.38** → **0.7.1**

## Changes
- Added `pkgs-unstable` to module function arguments
- Always set `services.open-webui.package` to use pkgs-unstable
- Ensures both base package and qdrant variant use consistent Python versions

## Test plan
- [x] `nix flake check` passes
- [x] `nix eval` confirms package version is 0.7.1
- [ ] Deploy to sancta-choir and verify service starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)