### PR TITLE
feat(deploy): add --yes flag for non-interactive mode

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -euo pipefail
 
 # NixOS configuration deployment script


### PR DESCRIPTION
## Summary
- Add `--yes`/`-y` flag to skip the confirmation prompt for automated deployments
- Add `--help`/`-h` flag for usage information
- Clean up emoji usage in output messages for better CI log compatibility

## Usage
```bash
# Interactive (existing behavior)
nix run .#deploy -- sancta-choir

# Non-interactive (new)
nix run .#deploy -- --yes sancta-choir
nix run .#deploy -- -y sancta-choir
```

## Test plan
- [ ] Verify `--help` displays usage information
- [ ] Verify `--yes` skips confirmation prompt
- [ ] Verify interactive mode still prompts for confirmation
- [ ] Test with both local and remote flake paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)