### PR TITLE
fix(open-webui): run service as dedicated user instead of root

### DIFF
--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -708,7 +708,15 @@ in
                 # Read API key from secrets.env (created by main service's ExecStartPre)
                 # This avoids needing root access to read agenix secrets directly
                 if [ -f /run/open-webui/secrets.env ]; then
-                  source /run/open-webui/secrets.env
+                  source /run/open-webui/secrets.env || {
+                    echo "ERROR: Failed to parse /run/open-webui/secrets.env" >&2
+                    exit 1
+                  }
+                  if [ -z "''${OPENAI_API_KEY:-}" ]; then
+                    echo "ERROR: OPENAI_API_KEY not found in secrets.env" >&2
+                    echo "HINT: Ensure services.open-webui-tailscale.openai.apiKeyFile is configured" >&2
+                    exit 1
+                  fi
                   API_KEY="$OPENAI_API_KEY"
                 else
                   echo "ERROR: /run/open-webui/secrets.env not found" >&2
@@ -905,7 +913,15 @@ in
                 # Read the WEBUI_SECRET_KEY from secrets.env (created by main service's ExecStartPre)
                 # This avoids needing root access to read agenix secrets directly
                 if [ -f /run/open-webui/secrets.env ]; then
-                  source /run/open-webui/secrets.env
+                  source /run/open-webui/secrets.env || {
+                    echo "ERROR: Failed to parse /run/open-webui/secrets.env" >&2
+                    exit 1
+                  }
+                  if [ -z "''${WEBUI_SECRET_KEY:-}" ]; then
+                    echo "ERROR: WEBUI_SECRET_KEY not found in secrets.env" >&2
+                    echo "HINT: Ensure services.open-webui-tailscale.secretKeyFile is configured" >&2
+                    exit 1
+                  fi
                   export SECRET_KEY="$WEBUI_SECRET_KEY"
                 else
                   echo "ERROR: /run/open-webui/secrets.env not found" >&2
@@ -1262,7 +1278,15 @@ in
                 # Read API key from secrets.env (created by main service's ExecStartPre)
                 # This avoids needing root access to read agenix secrets directly
                 if [ -f /run/open-webui/secrets.env ]; then
-                  source /run/open-webui/secrets.env
+                  source /run/open-webui/secrets.env || {
+                    echo "ERROR: Failed to parse /run/open-webui/secrets.env" >&2
+                    exit 1
+                  }
+                  if [ -z "''${OPENAI_API_KEY:-}" ]; then
+                    echo "ERROR: OPENAI_API_KEY not found in secrets.env" >&2
+                    echo "HINT: Ensure services.open-webui-tailscale.openai.apiKeyFile is configured" >&2
+                    exit 1
+                  fi
                   API_KEY="$OPENAI_API_KEY"
                 else
                   echo "ERROR: /run/open-webui/secrets.env not found" >&2


### PR DESCRIPTION
## Summary

- Creates a dedicated `open-webui` system user and group
- Configures the main service and all helper services to run as this user instead of root
- Fixes security anti-pattern where web-facing application ran with full root privileges

## Changes

| Service | Before | After |
|---------|--------|-------|
| `open-webui` | root | `open-webui` |
| `open-webui-memory-migration` | root | `open-webui` |
| `open-webui-zdr-function` | root | `open-webui` |
| `open-webui-auto-memory-function` | root | `open-webui` |
| `open-webui-e2e-test-user` | root | `open-webui` |
| `tailscale-serve-open-webui` | root | root (requires privileges) |

## Test plan

- [x] `nix flake check` passes
- [x] Configuration evaluates successfully
- [x] Verified `User` and `Group` are set correctly in systemd service configs
- [ ] Deploy and verify service starts successfully
- [ ] Verify database access works with new user
- [ ] Verify state directory permissions are correct

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)