### PR TITLE
fix(open-webui): fix Python syntax error in f-string

### DIFF
--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -989,7 +989,8 @@ in
         row = cursor.fetchone()
         conn.close()
         if not row:
-            print(f"ERROR: No API key found for {os.environ[\"USER_EMAIL\"]}", file=sys.stderr)
+            user_email = os.environ["USER_EMAIL"]
+            print(f"ERROR: No API key found for {user_email}", file=sys.stderr)
             print("Check open-webui-e2e-test-user service logs for setup failures", file=sys.stderr)
             sys.exit(1)
         print(row[0], end="")


### PR DESCRIPTION
## Summary
- Fixes Python syntax error: backslash escapes inside f-string braces are invalid
- Use variable to store value before using in f-string

## Context
The previous PR #118 introduced a syntax error that caused `open-webui-e2e-test-user` service to fail with:
```
SyntaxError: unexpected character after line continuation character
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)