### PR TITLE
fix(n8n): set N8N_USER_FOLDER for workflow-sync service

### DIFF
--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -310,6 +310,14 @@ in
         ProtectSystem = "strict";
         ProtectHome = true;
         PrivateTmp = true;
+        # Use same environment file as main n8n service for encryption key
+        EnvironmentFile = "-/run/n8n/env";
+      };
+
+      # n8n needs N8N_USER_FOLDER to know where config/database is stored
+      # Without this, it defaults to $HOME/.n8n which fails with DynamicUser
+      environment = {
+        N8N_USER_FOLDER = "/var/lib/n8n/.n8n";
       };
 
       path = [ pkgs.curl pkgs.jq pkgs.sqlite pkgs.n8n ];


### PR DESCRIPTION
## Summary
- Fixes n8n-workflow-sync service failing with `ENOENT: no such file or directory, mkdir '/.n8n'`
- n8n import:workflow was trying to create config at filesystem root because DynamicUser sets HOME incorrectly

## Changes
- Add `N8N_USER_FOLDER=/var/lib/n8n/.n8n` environment variable
- Add `EnvironmentFile` to inherit encryption key from main n8n service

## Test plan
- [ ] Deploy to rpi5-full
- [ ] Verify n8n-workflow-sync service starts successfully
- [ ] Verify workflows are imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)