### PR TITLE
fix(n8n): correct N8N_USER_FOLDER path

### DIFF
--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -316,8 +316,9 @@ in
 
       # n8n needs N8N_USER_FOLDER to know where config/database is stored
       # Without this, it defaults to $HOME/.n8n which fails with DynamicUser
+      # Note: n8n creates .n8n subdirectory inside N8N_USER_FOLDER
       environment = {
-        N8N_USER_FOLDER = "/var/lib/n8n/.n8n";
+        N8N_USER_FOLDER = "/var/lib/n8n";
       };
 
       path = [ pkgs.curl pkgs.jq pkgs.sqlite pkgs.n8n ];


### PR DESCRIPTION
## Summary
n8n creates `.n8n` subdirectory inside `N8N_USER_FOLDER`, so the path should be `/var/lib/n8n` not `/var/lib/n8n/.n8n`.

**Before:** `/var/lib/n8n/.n8n/.n8n/config` (wrong - doubled path)
**After:** `/var/lib/n8n/.n8n/config` (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)