### PR TITLE
fix(ci): use Opus model for issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -29,6 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
+            --model claude-opus-4-5-20251101
             --allowedTools "Bash(gh issue:*)"
           prompt: |
             You MUST triage GitHub issue #${{ github.event.issue.number }} by applying labels and adding a comment.


### PR DESCRIPTION
## Summary
- Switch issue-triage workflow from default Sonnet to Opus 4.5 model
- Uses dated model ID (`claude-opus-4-5-20251101`) for consistent CI behavior
- Should improve triage quality with Opus's stronger reasoning

## Test plan
- [ ] CI passes (workflow YAML syntax validation)
- [ ] Open a test issue to verify Opus model is used (check workflow logs)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)