### PR TITLE
fix(services): add partOf directive to tailscale-serve services

### DIFF
--- a/modules/services/gatus.nix
+++ b/modules/services/gatus.nix
@@ -591,6 +591,9 @@ in
         "gatus.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when gatus restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "gatus.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -635,6 +635,9 @@ in
         "n8n.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when n8n restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "n8n.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -1091,6 +1091,9 @@ in
         "open-webui.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when open-webui restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "open-webui.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/services/qdrant.nix
+++ b/modules/services/qdrant.nix
@@ -153,6 +153,9 @@ in
         "qdrant.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when qdrant restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "qdrant.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/services/unifi-mcp.nix
+++ b/modules/services/unifi-mcp.nix
@@ -364,6 +364,9 @@ in
         "unifi-mcp.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when unifi-mcp restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "unifi-mcp.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/services/uptime-kuma.nix
+++ b/modules/services/uptime-kuma.nix
@@ -112,6 +112,9 @@ in
         "uptime-kuma.service"
       ];
       wantedBy = [ "multi-user.target" ];
+      # PartOf ensures this service restarts when uptime-kuma restarts
+      # Without this, Requires= only stops this service but doesn't restart it
+      partOf = [ "uptime-kuma.service" ];
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
## Summary
- Adds `partOf=` directive to all 6 tailscale-serve services so they restart when their parent service restarts
- Fixes bug where tailscale-serve-* services would stop but not restart when the main service restarted, leaving the HTTPS proxy unavailable

## Root Cause
`Requires=` in systemd only creates a "stop when dependency stops" relationship, not a "restart when dependency restarts" one. Adding `partOf=` creates the proper lifecycle binding.

## Affected Services
- tailscale-serve-n8n
- tailscale-serve-gatus  
- tailscale-serve-open-webui
- tailscale-serve-qdrant
- tailscale-serve-unifi-mcp
- tailscale-serve-uptime-kuma

## Test plan
- [x] Verified with `nix flake check`
- [x] Rebuilt system with `nixos-rebuild switch`
- [x] Tested n8n restart - tailscale-serve-n8n now restarts automatically
- [x] Confirmed HTTPS proxy is available after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)