### PR TITLE
feat(n8n): add webhook health check to workflow-sync service

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -192,6 +192,10 @@
     # Workflows must have stable "id" field for idempotency
     workflowsDir = "${self}/n8n-workflows";
 
+    # Wait for this webhook to be registered before completing workflow sync
+    # Prevents 404 errors when accessing webhooks immediately after n8n start
+    webhookHealthCheck = "image-to-anki-ui";
+
     # Admin password for REST API authentication (required for community packages)
     adminPasswordFile = config.age.secrets.n8n-admin-password.path;
 

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -195,6 +195,24 @@ in
       '';
     };
 
+    webhookHealthCheck = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "image-to-anki-ui";
+      description = ''
+        Webhook path to verify after workflow sync completes.
+
+        n8n reports workflows as "activated" before webhooks are actually
+        registered internally. This causes 404 errors if webhooks are hit
+        immediately after n8n starts.
+
+        Set this to a known webhook path (without /webhook/ prefix) to wait
+        until that webhook responds before considering workflow sync complete.
+        The health check polls the webhook with GET requests until it returns
+        a non-404 response or times out after 60 seconds.
+      '';
+    };
+
     extraEnvironment = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -618,6 +636,33 @@ in
         ''}
 
         echo "Workflow active state sync complete"
+
+        ${optionalString (cfg.webhookHealthCheck != null) ''
+          # Verify webhooks are actually registered (not just "activated")
+          # n8n logs "Activated workflow" before webhooks are ready to receive requests
+          echo "Verifying webhook registration for: ${cfg.webhookHealthCheck}"
+          webhook_timeout=60
+          webhook_ready=0
+          while [ $webhook_timeout -gt 0 ]; do
+            http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+              "http://127.0.0.1:${toString cfg.port}/webhook/${cfg.webhookHealthCheck}" 2>/dev/null || echo "000")
+            # Any response except 404 means webhook is registered
+            # (200=success, 405=wrong method, 500=error, but NOT 404=not found)
+            if [ "$http_code" != "404" ] && [ "$http_code" != "000" ]; then
+              echo "Webhook health check passed (HTTP $http_code) after $((60 - webhook_timeout))s"
+              webhook_ready=1
+              break
+            fi
+            webhook_timeout=$((webhook_timeout - 1))
+            sleep 1
+          done
+
+          if [ $webhook_ready -eq 0 ]; then
+            echo "WARNING: Webhook ${cfg.webhookHealthCheck} not ready after 60s (still returning 404)"
+            echo "  Webhooks may not be registered yet. Check: journalctl -u n8n"
+            # Don't fail - webhook might be legitimately disabled or have different path
+          fi
+        ''}
       '';
     };
 


### PR DESCRIPTION
## Summary
- Add `webhookHealthCheck` option to n8n module that verifies webhooks are actually registered after workflow sync
- n8n logs "Activated workflow" before webhooks are ready to receive requests, causing 404 errors
- Health check polls specified webhook path up to 60 seconds until it returns non-404

## Problem
After `nixos-rebuild switch`, n8n reports workflows as "Activated" but hitting webhooks immediately returns 404. This is because webhook registration is async internally.

```
18:53:36  n8n: "Activated workflow Image to Anki UI"  ← LOG says ready
18:53:36  User hits webhook                           ← IMMEDIATELY after
18:53:36  n8n: "webhook not registered"               ← BUT IT'S NOT READY
```

## Solution
Add webhook health check at end of `n8n-workflow-sync` service:
- Configurable via `webhookHealthCheck = "webhook-path";`
- Polls webhook until non-404 response or 60s timeout
- Ensures webhooks are truly ready before service completes

## Test plan
- [ ] Deploy with `nixos-rebuild switch --flake .#rpi5-full`
- [ ] Check workflow-sync logs: `journalctl -u n8n-workflow-sync`
- [ ] Verify health check message: "Webhook health check passed (HTTP XXX) after Ns"
- [ ] Test webhook immediately after rebuild - should work without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)