### PR TITLE
fix(n8n): use valid OpenRouter image generation model

### DIFF
--- a/n8n-workflows/image-to-anki.json
+++ b/n8n-workflows/image-to-anki.json
@@ -191,7 +191,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ model: 'google/gemini-2.5-flash-preview-05-20', modalities: ['text', 'image'], messages: [{ role: 'user', content: 'Create a fun blocky illustration of ' + $json.word + ' (' + $json.description + ') for a kids flashcard. Style: cute pixel-art inspired, colorful blocks, Minecraft-like but friendly and simple. White background, no text.' }] }) }}",
+        "jsonBody": "={{ JSON.stringify({ model: 'google/gemini-2.5-flash-image', modalities: ['text', 'image'], messages: [{ role: 'user', content: 'Create a fun blocky illustration of ' + $json.word + ' (' + $json.description + ') for a kids flashcard. Style: cute pixel-art inspired, colorful blocks, Minecraft-like but friendly and simple. White background, no text.' }] }) }}",
         "options": { "timeout": 120000 }
       }
     },


### PR DESCRIPTION
## Summary
- Updated image generation model from invalid `google/gemini-2.5-flash-preview-05-20` to working `google/gemini-2.5-flash-image`
- Fixes Anki deck generation producing empty media files (0 images)
- Verified: new APKGs now contain generated flashcard images (~795KB vs 2 bytes before)

## Test plan
- [x] Tested API call with new model directly - returns valid image data
- [x] Deployed and triggered full workflow with image upload
- [x] Verified generated APKG has media: `{"0": "img_0.png"}` with 795KB image file

🤖 Generated with [Claude Code](https://claude.com/claude-code)