### PR TITLE
fix(n8n): correct database path in diagnostic script

### DIFF
--- a/scripts/diagnose-n8n-workflow.sh
+++ b/scripts/diagnose-n8n-workflow.sh
@@ -25,7 +25,8 @@ fi
 
 # Paths
 N8N_DIR="/var/lib/n8n"
-DB_PATH="$N8N_DIR/database.sqlite"
+# n8n stores its database in ~/.n8n/ which is /var/lib/n8n/.n8n/ when run as n8n user
+DB_PATH="$N8N_DIR/.n8n/database.sqlite"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 SOURCE_DIR="$REPO_ROOT/n8n-workflows"


### PR DESCRIPTION
## Summary

- Fixes the database path in the diagnostic script from PR #163
- n8n stores its database at `~/.n8n/database.sqlite` which resolves to `/var/lib/n8n/.n8n/database.sqlite` when running as the n8n user

## Related

- Fixes issue discovered while working on #157
- Follow-up to #163

🤖 Generated with [Claude Code](https://claude.ai/code)