### PR TITLE
feat(system): add sqlite to dev-tools for workflow diagnostics

### DIFF
--- a/modules/system/dev-tools.nix
+++ b/modules/system/dev-tools.nix
@@ -28,6 +28,9 @@
       ripgrep
       fd
 
+      # Database tools
+      sqlite
+
       # Development tools
       nodejs_22
       gh


### PR DESCRIPTION
## Summary
- Adds `pkgs.sqlite` to dev-tools package set (~1.5 MB disk, ~2-4 MB RAM)
- Required by `scripts/diagnose-n8n-workflow.sh` to compare deployed workflows against source files

## Test plan
- [x] Rebuilt with `nixos-rebuild switch --flake .#rpi5-full`
- [x] Verified `sqlite3 --version` returns 3.50.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)