### PR TITLE
feat(gatus): add image-to-anki workflow monitoring

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -318,6 +318,14 @@
         conditions = [ "[STATUS] == 200" ];
       };
 
+      rpi5-anki-workflow = {
+        name = "Anki Workflow";
+        group = "rpi5";
+        url = "http://127.0.0.1:5678/webhook/image-to-anki-ui";
+        interval = "1m";
+        conditions = [ "[STATUS] == 200" ];
+      };
+
       rpi5-qdrant = {
         name = "Qdrant";
         group = "rpi5";


### PR DESCRIPTION
## Summary
- Add health check endpoint for the `image-to-anki-ui` webhook to Gatus
- Monitors that the n8n workflow is loaded and responding (1 minute interval)

## Test plan
- [ ] Verify Gatus shows the new endpoint after deploy
- [ ] Confirm endpoint shows healthy when workflow is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)