### PR TITLE
fix(systemd): enable cgroup accounting for resource limit enforcement

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -21,6 +21,10 @@
   # Nix settings
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
+  # Enable systemd cgroup accounting so MemoryMax/MemoryHigh/CPUQuota are enforced
+  # Without this, all systemd resource limits are ignored (Issue #179)
+  systemd.enableCgroupAccounting = true;
+
   # FHS compatibility: create /bin/bash symlink for scripts with hardcoded shebangs
   # Required for tools like Claude Code plugins that use #!/bin/bash
   system.activationScripts.binbash = lib.stringAfter [ "stdio" ] ''


### PR DESCRIPTION
## Problem

All `MemoryMax`/`MemoryHigh` resource limits configured in `hosts/rpi5-full/configuration.nix` were not being enforced because systemd cgroup accounting was disabled.

## Solution

Added `systemd.enableCgroupAccounting = true;` to `hosts/common.nix` to enable cgroup v2 memory accounting and enforcement on both rpi5 and sancta-choir.

## Verification

After deployment, verify limits are enforced:
```bash
systemctl show open-webui.service --property=MemoryCurrent
# Should return actual bytes instead of [not set]
```

Fixes #179

---
Generated with [Claude Code](https://claude.ai/code)