### PR TITLE
fix(secrets): restrict UniFi password permissions to wheel group

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -98,7 +98,8 @@
     tailscale-auth-key.file = "${self}/secrets/tailscale-auth-key.age";
     unifi-password = {
       file = "${self}/secrets/unifi-password.age";
-      mode = "0444"; # Readable by all (needed for Claude Code MCP)
+      mode = "0440";
+      group = "wheel"; # Only root and wheel group members can read
     };
   };
 


### PR DESCRIPTION
Change UniFi password secret from world-readable (0444) to group-readable (0440) with wheel group ownership. This maintains functionality for Claude Code MCP (which runs as nixos, a wheel member) while preventing unauthorized access from other system services and users.

Fixes #186

---

Generated with [Claude Code](https://claude.ai/code)