### PR TITLE
fix(n8n): restart n8n after workflow import to register webhooks

### DIFF
--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -582,6 +582,9 @@ in
         # Security hardening compatible with root + systemctl restart
         ProtectHome = true;
         PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
       };
 
       # n8n needs N8N_USER_FOLDER to know where config/database is stored
@@ -617,7 +620,8 @@ in
             fi
             sleep 1
           done
-          sleep 2
+          # Extra delay for full initialization (webhook registration is async)
+          sleep 5
         }
 
         wait_for_n8n "initial startup"


### PR DESCRIPTION
## Summary
- Fixes webhooks returning 404 after `nixos-rebuild switch` by restarting n8n after workflow import
- The `n8n import:workflow` CLI writes to the DB but does NOT register webhooks in n8n's in-memory router ([n8n#2155](https://github.com/n8n-io/n8n/issues/2155))
- Changed `Requires=` to `Wants=` so the n8n restart doesn't kill the sync script (systemd stops dependent units on restart)
- Runs sync service as root with `runuser -u n8n` for DB operations to enable `systemctl restart`

## Test plan
- [ ] Deploy to rpi5: `sudo nixos-rebuild switch --flake .#rpi5-full`
- [ ] Check sync logs: `journalctl -u n8n-workflow-sync` shows restart + health check pass
- [ ] Verify webhooks work immediately after deploy
- [ ] **Wait 1+ hours** — webhooks should STILL work (the key regression test)
- [ ] Check n8n logs: `journalctl -u n8n --since "1 hour ago"` — no deregistration events

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)