### PR TITLE
fix(nixframe): prevent imv CPU spin loop after nixos-rebuild

### DIFF
--- a/modules/services/nixframe.nix
+++ b/modules/services/nixframe.nix
@@ -104,6 +104,13 @@ let
     FAIL_COUNT=0
     MAX_FAILS=5
     while true; do
+      # Exit if Sway is gone (e.g. after nixos-rebuild restarts getty@tty7).
+      # Without this check, orphaned imv spins at 100% CPU on a dead POLLHUP socket.
+      if [ -n "$SWAYSOCK" ] && [ ! -e "$SWAYSOCK" ]; then
+        echo "Sway socket gone ($SWAYSOCK), exiting." >&2
+        exit 0
+      fi
+
       START_TIME=$(date +%s)
       ${pkgs.imv}/bin/imv -t ${toString cfg.slideshowInterval} "$PHOTO_DIR"
       EXIT_CODE=$?
@@ -140,6 +147,12 @@ let
     FAIL_COUNT=0
     MAX_FAILS=5
     while true; do
+      # Exit if Sway is gone (e.g. after nixos-rebuild restarts getty@tty7)
+      if [ -n "$SWAYSOCK" ] && [ ! -e "$SWAYSOCK" ]; then
+        echo "Sway socket gone ($SWAYSOCK), exiting." >&2
+        exit 0
+      fi
+
       START_TIME=$(date +%s)
       ${pkgs.eww}/bin/eww daemon &
       EWW_PID=$!


### PR DESCRIPTION
## Summary
- Fixes imv-wayland consuming 100% CPU after `nixos-rebuild switch`
- Root cause: when getty@tty7 restarts, old Sway dies but its child scripts (imvStart, ewwStart) get reparented to PID 1 as orphans. They keep restarting imv against a dead Wayland socket, causing a tight `ppoll`/`read` busy-loop (~62K iterations/sec on a `POLLHUP` socket)
- Fix: check `$SWAYSOCK` existence at the top of each restart loop iteration. If the socket file is gone, exit cleanly

## Profiling evidence
```
% time     seconds  usecs/call     calls    errors syscall
 55.14    0.547952           1    311713           ppoll
 44.86    0.445797           1    311714    311714 read
```
All 311K `read` calls fail with `EAGAIN` on a dead socket — pure CPU waste.

## Test plan
- [x] `nix fmt` passes
- [x] `nix flake check` passes
- [ ] Deploy to RPi5, verify imv runs normally
- [ ] Run `nixos-rebuild switch` again, verify orphaned scripts exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)