### PR TITLE
fix: change system timezone from UTC to Europe/Chisinau

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -310,7 +310,7 @@
   '';
 
   # Timezone (adjust as needed)
-  time.timeZone = "UTC";
+  time.timeZone = "Europe/Chisinau";
 
   # System state version - do NOT change on existing systems
   system.stateVersion = lib.mkForce "24.05";

--- a/modules/system/host.nix
+++ b/modules/system/host.nix
@@ -50,7 +50,7 @@
   # Networking-specific packages can be added here if needed
 
   # Time zone
-  time.timeZone = "UTC";
+  time.timeZone = "Europe/Chisinau";
 
   # Locale
   i18n.defaultLocale = "en_US.UTF-8";


### PR DESCRIPTION
## Summary
- Changes system timezone from UTC to Europe/Chisinau (UTC+2, UTC+3 in summer)
- Updates both `hosts/rpi5/configuration.nix` (rpi5-specific) and `modules/system/host.nix` (sancta-choir shared module)

## Test plan
- [ ] `nix flake check` passes
- [ ] `nixos-rebuild switch --flake .#rpi5-full` applies correctly
- [ ] `date` shows correct Chisinau time after rebuild
- [ ] Deploy to sancta-choir after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)