### PR TITLE
docs: add profiling & debugging section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,11 +316,11 @@ systemctl status earlyoom        # OOM killer status
 journalctl -u earlyoom -f        # Watch earlyoom decisions
 ```
 
-**Important:** `cgroup_enable=memory` and `psi=1` boot params were added in PR #202 but require a **reboot** to take effect. Until then, `systemd-cgtop` won't show memory columns and `/proc/pressure/` won't exist.
+**Important:** `cgroup_enable=memory` and `psi=1` boot params were added in PR #202 but require a **reboot** to take effect. Verify: `grep -q "cgroup_enable=memory" /proc/cmdline && echo "Applied" || echo "Reboot required"`. Until then, `systemd-cgtop` won't show memory columns and `/proc/pressure/` won't exist.
 
 ### perf (NOT available)
 
-`linuxPackages.perf` has a kernel version mismatch (perf 6.18 vs running kernel 6.12). Do not add until the nixos-raspberrypi module updates.
+`linuxPackages.perf` has a kernel version mismatch (perf 6.18.2 vs running kernel 6.12.34). Do not add until the nixos-raspberrypi module updates.
 
 ## Service Configuration Notes
 


### PR DESCRIPTION
## Summary
- Add **Profiling & Debugging** section to CLAUDE.md documenting:
  - Installed tools: `strace`, `nix-tree` (from PR #202)
  - Nix eval profiling with `--eval-profiler flamegraph` (built-in, no install needed)
  - On-demand tools via `nix shell` (flamegraph, nom, nvd, nixprof, statix, deadnix)
  - RPi5 memory/resource monitoring commands (`systemd-cgtop`, PSI, earlyoom)
  - `perf` kernel version mismatch caveat (6.18 vs 6.12)

## Test plan
- [ ] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)