### PR TITLE
fix(nixframe): set homeMode 0750 so n8n can write photos

### DIFF
--- a/modules/services/nixframe.nix
+++ b/modules/services/nixframe.nix
@@ -267,6 +267,7 @@ in
       group = "nixframe";
       extraGroups = [ "video" "input" ]; # DRM access for GPU rendering + libinput for Sway
       home = "/var/lib/nixframe";
+      homeMode = "0750"; # Group traverse so n8n (in nixframe group) can reach photos/
       createHome = true;
       description = "NixFrame photo frame display user";
     };


### PR DESCRIPTION
## Summary
- Add `homeMode = "0750"` to nixframe user config so n8n (in nixframe group) can traverse the home directory to reach `photos/`
- Fixes `EACCES: permission denied` on photo upload via n8n webhook

## Root Cause
`createHome = true` creates `/var/lib/nixframe` with default `0700` permissions. The `photos/` subdirectory is `0775` and n8n is in the `nixframe` group, but the parent directory blocks group traversal. The existing tmpfiles rule (`d /var/lib/nixframe 0750`) was racing with `createHome` and losing.

## Test plan
- [ ] `nix flake check` passes
- [ ] Deploy to rpi5 and verify `stat -c %a /var/lib/nixframe` returns `750`
- [ ] Upload a photo via the NixFrame webhook — no EACCES error

🤖 Generated with [Claude Code](https://claude.com/claude-code)