### PR TITLE
feat(nixframe): add weather + calendar widgets with warm ambient theme

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -470,7 +470,30 @@
   # ──────────────────────────────────────────────────────────────
   # Displays rotating slideshow with clock sidebar on the TV.
   # Upload photos: https://rpi5.tail4249a9.ts.net:5678/webhook/nixframe-ui
-  services.nixframe.enable = true;
+  services.nixframe = {
+    enable = true;
+
+    # Weather widget — shows temperature + description from wttr.in
+    weather = {
+      enable = true;
+      location = "Chisinau";
+    };
+
+    # Calendar widget — syncs iCloud CalDAV, shows upcoming events
+    calendar = {
+      enable = true;
+      username = "savinalexandru90@gmail.com";
+      passwordFile = config.age.secrets.icloud-nixframe-password.path;
+    };
+  };
+
+  # iCloud calendar password for NixFrame vdirsyncer sync
+  age.secrets.icloud-nixframe-password = {
+    file = "${self}/secrets/icloud-nixframe-password.age";
+    owner = "nixframe";
+    group = "nixframe";
+    mode = "0400";
+  };
 
   # Add ImageMagick to n8n PATH for HEIC conversion and EXIF auto-orient
   # Allow n8n to write to nixframe photo directory (ProtectSystem=strict blocks it)

--- a/secrets/icloud-nixframe-password.age
+++ b/secrets/icloud-nixframe-password.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 Z9wNEQ 7E5yDfoPW64oS1fMEWl5ZEdGz8RzNllDbNBifWNY3Hs
+T7oW+ITeH32PF/yaTJgaWU/jNXZ8DxJkhSknJFPKePg
+-> ssh-ed25519 iZo3tw rJ2bYViMiu0lCM38kmwbpNilTwrK7rfDayIQhWoMv08
+ZtCGioEiuOUDMg40F8oQslYF9BdEZKzpTdS6YQLwoVw
+--- ZgcAAxum/sWZO2measQkmDrYzfkF5wHdNFlP5+aYZ6c
+””Æ[­›L®"ð1yt³G¥‚÷,Ô;ž/h·0^U(lì{rR‘ÒoÍüé‚ÎXz‡“òæTB

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -20,6 +20,9 @@ let
 
   # Keys for sancta-choir only
   sanctaChoirKeys = users ++ [ sancta-choir ];
+
+  # Keys for rpi5 only
+  rpi5Keys = users ++ [ rpi5 ];
 in
 {
   # Tailscale - shared across all hosts
@@ -51,4 +54,7 @@ in
 
   # UniFi Network MCP - controller password for AI-assisted network management
   "unifi-password.age".publicKeys = allKeys;
+
+  # NixFrame iCloud calendar - rpi5 only (calendar sync runs on nixframe host)
+  "icloud-nixframe-password.age".publicKeys = rpi5Keys;
 }


### PR DESCRIPTION
## Summary

- Add optional **weather widget** (wttr.in, 30-min poll, 2-hour cache fallback) with amber accent
- Add optional **iCloud calendar widget** (vdirsyncer + khal, 15-min systemd timer sync) with sage accent
- Redesign sidebar theme: warm ambient palette (charcoal-brown bg, warm white clock, muted sand date)
- Both widgets independently toggleable via `services.nixframe.weather.enable` / `services.nixframe.calendar.enable`

### New Module Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `weather.enable` | bool | false | Enable weather widget |
| `weather.location` | str | "Chisinau" | wttr.in location |
| `calendar.enable` | bool | false | Enable iCloud calendar |
| `calendar.username` | str | "" | iCloud email |
| `calendar.passwordFile` | str | "" | Agenix-managed password path |
| `calendar.maxEvents` | int | 5 | Max events to display |
| `calendar.daysAhead` | int | 7 | Days ahead to query |

### Files Changed

| File | Changes |
|------|---------|
| `modules/services/nixframe.nix` | Weather/calendar scripts, configs, options, warm theme SCSS, conditional Eww yuck layout, systemd timer |
| `secrets/secrets.nix` | Add `icloud-nixframe-password.age` (rpi5-only keys) |
| `secrets/icloud-nixframe-password.age` | Placeholder encrypted secret (needs real password via `agenix -e`) |
| `hosts/rpi5-full/configuration.nix` | Enable weather + calendar, add agenix secret ref |

### Rollback

```nix
services.nixframe.weather.enable = false;
services.nixframe.calendar.enable = false;
```

## Test plan

- [ ] `nix flake check` passes (verified)
- [ ] `nixos-rebuild build --flake .#rpi5-full` succeeds (verified)
- [ ] Replace placeholder secret: `cd secrets && agenix -e icloud-nixframe-password.age`
- [ ] Deploy: `sudo nixos-rebuild switch --flake .#rpi5-full`
- [ ] Verify warm theme visible on TV (brown bg, not pure black)
- [ ] Verify weather: `eww state | grep weather` shows temperature
- [ ] Verify calendar timer: `systemctl list-timers nixframe-calendar-sync`
- [ ] Verify fallback: disconnect network → weather shows cached → after 2h shows "—"
- [ ] Verify disable: set `weather.enable = false` → sidebar shows just clock/date

🤖 Generated with [Claude Code](https://claude.com/claude-code)