### PR TITLE
feat(dev-tools): add Playwright CLI with NixOS browser support

### DIFF
--- a/modules/system/dev-tools.nix
+++ b/modules/system/dev-tools.nix
@@ -43,6 +43,16 @@
       # Profiling and debugging
       strace # Syscall tracer (proven useful, tiny)
       nix-tree # Interactive closure size browser
+
+      # Browser automation
+      playwright-test # CLI: playwright test, codegen, screenshot, pdf
+      playwright-driver.browsers # Pre-built Chromium for NixOS
     ];
+
+    # Playwright needs to find nix-provided browsers instead of downloading its own
+    environment.sessionVariables = {
+      PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+      PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+    };
   };
 }


### PR DESCRIPTION
## Summary
- Add `playwright-test` and `playwright-driver.browsers` to dev-tools module
- Set `PLAYWRIGHT_BROWSERS_PATH` to point at nix-store Chromium so Playwright works on NixOS without FHS-path hacks
- Set `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` to bypass NixOS-incompatible library checks

## Test plan
- [x] `nix flake check` passes
- [x] `nixos-rebuild build --flake .#rpi5-full` succeeds
- [ ] After deploy: `playwright --version` prints 1.56.1
- [ ] After deploy: `playwright screenshot https://example.com /tmp/test.png` works

## Notes
- Only Chromium available via nixpkgs (no Firefox/WebKit)
- All binaries fetched from binary cache (~292 MiB download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)