### PR TITLE
fix(unifi-mcp): gate Docker on service.enable to avoid unused daemon

### DIFF
--- a/modules/services/unifi-mcp.nix
+++ b/modules/services/unifi-mcp.nix
@@ -275,8 +275,9 @@ in
       }
     ];
 
-    # Enable Docker if using container mode
-    virtualisation.docker.enable = mkIf cfg.useDocker true;
+    # Enable Docker only when running as a service in container mode
+    # stdio mode uses the binary directly and never needs Docker
+    virtualisation.docker.enable = mkIf (cfg.service.enable && cfg.useDocker) true;
 
     # Generate environment file for both modes
     environment.etc."unifi-mcp/env.template".text = ''


### PR DESCRIPTION
## Summary
- Gate `virtualisation.docker.enable` on `cfg.service.enable && cfg.useDocker` instead of just `cfg.useDocker`
- Prevents Docker daemon from running on hosts using stdio mode (like RPi5) where Docker is never used
- Frees ~100-150Mi RAM on memory-constrained RPi5

## Context

The `useDocker` option defaults to `true`, and Docker enablement was only gated on `cfg.enable && cfg.useDocker`. On RPi5, `service.enable = false` (stdio mode for Claude Code), so Docker was never actually used but still started on boot with 30 tasks and zero containers.

## Test plan
- [ ] CI passes `nix flake check`
- [ ] After deploy to RPi5: `systemctl status docker` shows inactive/not-found
- [ ] `services.unifi-mcp` stdio mode still works (Claude Code MCP integration)

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)