### PR TITLE
feat(claude): enable experimental Agent Teams

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -49,6 +49,7 @@
   # Enable development tools and Claude Code
   customModules.dev-tools.enable = true;
   customModules.claude.enable = true;
+  customModules.claude.agentTeams.enable = true;
 
   # Allow unfree packages (Open-WebUI license changed in v0.6+)
   # CRITICAL: Do NOT override boot.kernelPackages - nvmd/nixos-raspberrypi provides

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -50,6 +50,7 @@
   # Enable development tools and Claude Code
   customModules.dev-tools.enable = true;
   customModules.claude.enable = true;
+  customModules.claude.agentTeams.enable = true;
 
   # Agenix secrets (defaults: owner=root, group=root, mode=0400)
   age.secrets = {

--- a/modules/services/claude.nix
+++ b/modules/services/claude.nix
@@ -1,5 +1,8 @@
 { config, pkgs, lib, claude-code ? null, ... }:
 
+let
+  cfg = config.customModules.claude;
+in
 {
   # Claude Code - AI-powered coding assistant
   # Auto-updated hourly via github:sadjow/claude-code-nix flake
@@ -10,29 +13,58 @@
 
   options.customModules.claude = {
     enable = lib.mkEnableOption "Claude Code package";
-  };
 
-  config = lib.mkIf config.customModules.claude.enable {
-    assertions = [
-      {
-        assertion = claude-code != null;
-        message = ''
-          The claude module requires the claude-code flake input to be passed via specialArgs.
+    agentTeams = {
+      enable = lib.mkEnableOption "Claude Code Agent Teams (experimental)";
 
-          Add this to your flake inputs:
-            claude-code = {
-              url = "github:sadjow/claude-code-nix";
-              inputs.nixpkgs.follows = "nixpkgs-unstable";
-            };
-
-          Then pass it to specialArgs in your nixosSystem:
-            specialArgs = { inherit claude-code; };
+      teammateMode = lib.mkOption {
+        type = lib.types.enum [ "auto" "in-process" "tmux" ];
+        default = "auto";
+        description = ''
+          Display mode for agent team teammates.
+          - "auto": split panes if running in tmux, in-process otherwise
+          - "in-process": all teammates in the main terminal (Shift+Up/Down to navigate)
+          - "tmux": force split-pane mode (requires tmux)
         '';
-      }
-    ];
-
-    environment.systemPackages = [
-      claude-code.packages.${pkgs.system}.default
-    ];
+      };
+    };
   };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = claude-code != null;
+          message = ''
+            The claude module requires the claude-code flake input to be passed via specialArgs.
+
+            Add this to your flake inputs:
+              claude-code = {
+                url = "github:sadjow/claude-code-nix";
+                inputs.nixpkgs.follows = "nixpkgs-unstable";
+              };
+
+            Then pass it to specialArgs in your nixosSystem:
+              specialArgs = { inherit claude-code; };
+          '';
+        }
+      ];
+
+      environment.systemPackages = [
+        claude-code.packages.${pkgs.system}.default
+      ];
+    }
+
+    (lib.mkIf cfg.agentTeams.enable {
+      environment.sessionVariables = {
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      };
+
+      # teammateMode is a Claude Code settings.json key (no env var equivalent).
+      # Use --teammate-mode flag per session, or set in ~/.claude/settings.json:
+      #   { "teammateMode": "in-process" }
+      # The "auto" default uses split panes when inside tmux, in-process otherwise.
+      # tmux is provided by customModules.dev-tools.
+    })
+  ]);
 }


### PR DESCRIPTION
## Summary
- Extend `modules/services/claude.nix` with `agentTeams.enable` option and `teammateMode` setting
- Sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` via `environment.sessionVariables` when enabled
- Enable agent teams on both rpi5 and sancta-choir hosts

## Test plan
- [x] `nix flake check` passes
- [x] `nixos-rebuild switch --flake .#rpi5-full` succeeds
- [x] Verified `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` present in `/etc/set-environment`
- [ ] Verify on sancta-choir after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)