### PR TITLE
fix(claude): register local plugins via marketplace

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "nixos-config-local",
+  "description": "Local plugins for the nixos-config project",
+  "owner": {
+    "name": "nixos-config"
+  },
+  "plugins": [
+    {
+      "name": "nix-commit",
+      "description": "Git commit commands with automatic nix fmt formatting for NixOS projects",
+      "version": "1.0.0",
+      "author": {
+        "name": "nixos-config"
+      },
+      "source": "./nix-commit",
+      "category": "productivity"
+    },
+    {
+      "name": "local-review",
+      "description": "Code review uncommitted local changes for bugs, security vulnerabilities, and CLAUDE.md compliance",
+      "version": "1.0.0",
+      "author": {
+        "name": "nixos-config"
+      },
+      "source": "./local-review",
+      "category": "productivity"
+    },
+    {
+      "name": "screenshot",
+      "description": "Capture screenshots of the NixFrame digital photo frame display",
+      "version": "1.0.0",
+      "author": {
+        "name": "nixos-config"
+      },
+      "source": "./screenshot",
+      "category": "development"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,8 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "ralph-wiggum@claude-plugins-official": true,
     "explanatory-output-style@claude-plugins-official": true,
-    ".claude/plugins/local-review": true,
-    ".claude/plugins/nix-commit": true,
-    ".claude/plugins/screenshot": true
+    "local-review@nixos-config-local": true,
+    "nix-commit@nixos-config-local": true,
+    "screenshot@nixos-config-local": true
   }
 }


### PR DESCRIPTION
## Summary
- **Fixed**: Local plugins (nix-commit, local-review, screenshot) weren't loading because path-based `enabledPlugins` entries are not recognized by Claude Code's plugin system
- **Added**: `.claude/plugins/.claude-plugin/marketplace.json` — a local marketplace manifest registering all 3 project-local plugins
- **Updated**: `.claude/settings.json` to use proper `<name>@nixos-config-local` marketplace-qualified identifiers

## Context
Claude Code requires plugins to be registered in a marketplace, installed via `claude plugin install`, and enabled — simply placing plugin files in `.claude/plugins/` with path-based entries doesn't work. This adds a local marketplace pointing to the existing plugin directories.

## Test plan
- [ ] `claude plugin marketplace list` shows `nixos-config-local`
- [ ] `claude plugin list` shows all 3 local plugins as enabled
- [ ] `/nix-commit:commit`, `/screenshot:screenshot` appear in skills list after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)