### PR TITLE
fix(claude): use sudo in screenshot plugin discovery

### DIFF
--- a/.claude/plugins/screenshot/commands/screenshot.md
+++ b/.claude/plugins/screenshot/commands/screenshot.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(sudo -u nixframe:*), Bash(id:*), Bash(ls:*), Bash(magick:*), Read(*)
+allowed-tools: Bash(sudo -u nixframe:*), Bash(id:*), Bash(magick:*), Read(*)
 description: Capture a screenshot of the NixFrame display
 ---
 
@@ -26,10 +26,13 @@ Run this as a single bash command to discover the environment:
 
 ```bash
 NIXFRAME_UID=$(id -u nixframe) && \
-SWAYSOCK=$(ls -t /run/user/$NIXFRAME_UID/sway-ipc.*.sock 2>/dev/null | head -1) && \
-WAYLAND=$(ls /run/user/$NIXFRAME_UID/wayland-* 2>/dev/null | grep -v '\.lock$' | head -1) && \
-if [ -z "$SWAYSOCK" ] || [ -z "$WAYLAND" ]; then echo "NOT_RUNNING"; else \
-echo "UID=$NIXFRAME_UID SWAYSOCK=$SWAYSOCK WAYLAND=$(basename "$WAYLAND")"; fi
+sudo -u nixframe bash -c '
+  SWAYSOCK=$(ls -t /run/user/'"$NIXFRAME_UID"'/sway-ipc.*.sock 2>/dev/null | head -1)
+  WAYLAND=$(ls /run/user/'"$NIXFRAME_UID"'/wayland-* 2>/dev/null | grep -v "\.lock$" | head -1)
+  if [ -z "$SWAYSOCK" ] || [ -z "$WAYLAND" ]; then echo "NOT_RUNNING"; else
+    echo "UID='"$NIXFRAME_UID"' SWAYSOCK=$SWAYSOCK WAYLAND=$(basename "$WAYLAND")"
+  fi
+'
 ```
 
 If no Sway socket is found, tell the user that NixFrame's Sway session is not running.


### PR DESCRIPTION
## Summary
- Fix `/screenshot` plugin falsely reporting NixFrame as "NOT_RUNNING" due to permission error
- Discovery command now runs inside `sudo -u nixframe bash -c` so glob expansion on `/run/user/1002/` works correctly
- Remove unused `Bash(ls:*)` from allowed-tools (ls now runs inside the sudo subshell)

## Root cause
The `ls /run/user/1002/sway-ipc.*.sock` glob was expanded by the calling shell (running as `nixos`), which can't read the nixframe user's runtime directory (0700 permissions). The `2>/dev/null` silently swallowed the "Permission denied" error, making it look like no Sway socket existed.

## Test plan
- [ ] Run `/screenshot` in a fresh Claude Code session — should successfully discover Sway and capture screenshot
- [ ] Run `/screenshot forecast` and `/screenshot sidebar` — region crops still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)