### PR TITLE
fix(claude): use glob-free discovery in screenshot plugin

### DIFF
--- a/.claude/plugins/screenshot/commands/screenshot.md
+++ b/.claude/plugins/screenshot/commands/screenshot.md
@@ -26,13 +26,11 @@ Run this as a single bash command to discover the environment:
 
 ```bash
 NIXFRAME_UID=$(id -u nixframe) && \
-sudo -u nixframe bash -c '
-  SWAYSOCK=$(ls -t /run/user/'"$NIXFRAME_UID"'/sway-ipc.*.sock 2>/dev/null | head -1)
-  WAYLAND=$(ls /run/user/'"$NIXFRAME_UID"'/wayland-* 2>/dev/null | grep -v "\.lock$" | head -1)
-  if [ -z "$SWAYSOCK" ] || [ -z "$WAYLAND" ]; then echo "NOT_RUNNING"; else
-    echo "UID='"$NIXFRAME_UID"' SWAYSOCK=$SWAYSOCK WAYLAND=$(basename "$WAYLAND")"
-  fi
-'
+RUNTIME="/run/user/$NIXFRAME_UID" && \
+SWAYSOCK="$RUNTIME/$(sudo -u nixframe ls -t "$RUNTIME" 2>/dev/null | grep '^sway-ipc\..*\.sock$' | head -1)" && \
+WAYLAND=$(sudo -u nixframe ls "$RUNTIME" 2>/dev/null | grep '^wayland-[0-9]*$' | head -1) && \
+if [ "$SWAYSOCK" = "$RUNTIME/" ] || [ -z "$WAYLAND" ]; then echo "NOT_RUNNING"; else \
+echo "UID=$NIXFRAME_UID SWAYSOCK=$SWAYSOCK WAYLAND=$WAYLAND"; fi
 ```
 
 If no Sway socket is found, tell the user that NixFrame's Sway session is not running.


### PR DESCRIPTION
## Summary
- Fix screenshot plugin discovery that silently failed due to two compounding bugs:
  1. **Stale cache**: PR #226 fixed the source file but the plugin cache (what actually loads at runtime) was never updated
  2. **Shell glob expansion**: Even with `sudo`, globs like `*.sock` expand in the calling shell before `sudo` runs — fails when the calling user can't read the `700`-permission runtime directory
- Replace glob-based discovery with `ls $DIR | grep pattern` which avoids shell glob expansion entirely
- Also synced the plugin cache and updated the registry commit SHA in `installed_plugins.json`

## Test plan
- [ ] Start a new Claude Code session and run `/screenshot` — should discover Sway session and capture screenshot successfully
- [ ] Run `/screenshot forecast` — should capture and crop forecast bar
- [ ] Run `/screenshot sidebar` — should capture and crop sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)