### PR TITLE
fix(open-webui): update webuiUrl default to rpi5

### DIFF
--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -280,7 +280,7 @@ in
 
     webuiUrl = mkOption {
       type = types.str;
-      default = "https://sancta-choir.tail4249a9.ts.net";
+      default = "https://rpi5.tail4249a9.ts.net";
       example = "https://myhost.tail<hex>.ts.net";
       description = "Public URL for OpenWebUI (used for OAuth callbacks).";
     };


### PR DESCRIPTION
## Summary
- Update `webuiUrl` module default from `sancta-choir` to `rpi5`

## Changes
- **Modified:** `modules/services/open-webui.nix` — single-line default value change

## Context
The `sancta-choir` host is deprecated. The module default should reflect the only active deployment target (`rpi5`). Both hosts already override this value explicitly in their configs, so this change only affects the module default.

## Test plan
- [x] `nix fmt` passes
- [x] `nix flake check` passes
- [x] `nixos-rebuild build --flake .#rpi5-full` succeeds

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)