### PR TITLE
fix(nixframe): remove accent borders causing ugly corner junction

### DIFF
--- a/modules/services/nixframe.nix
+++ b/modules/services/nixframe.nix
@@ -288,7 +288,6 @@ let
     .sidebar {
       background-color: rgba(0, 0, 0, 0.85);
       padding: 40px;
-      border-left: 1px solid rgba(196, 168, 130, 0.15);
     }
 
     .clock {
@@ -306,7 +305,6 @@ let
     .forecast-bar {
       background-color: rgba(0, 0, 0, 0.85);
       padding: 16px 40px;
-      border-top: 1px solid rgba(196, 168, 130, 0.15);
     }
 
     .forecast-slot {


### PR DESCRIPTION
## Summary
- Removed `border-left` from `.sidebar` and `border-top` from `.forecast-bar` in the Eww SCSS
- These two accent borders created a visible L-shaped intersection at the bottom-right corner where the sidebar and forecast bar meet
- Both panels share `rgba(0,0,0,0.85)` background, so without the borders they blend seamlessly

## Test plan
- [x] Deployed with `sudo nixos-rebuild switch --flake .#rpi5-full`
- [x] Verified via screenshot: bottom-right corner is now clean with no visible seam
- [x] Forecast bar inter-slot separators still render correctly (those are `.forecast-slot` borders, not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)