### PR TITLE
fix(openclaw-container): pass claude-code flake input to container

### DIFF
--- a/modules/services/openclaw-container.nix
+++ b/modules/services/openclaw-container.nix
@@ -1,7 +1,7 @@
 # OpenClaw Container Module
 # Runs OpenClaw in a systemd-nspawn container with network isolation
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, claude-code ? null, ... }:
 
 with lib;
 
@@ -11,7 +11,7 @@ let
   # Container configuration (inner NixOS system)
   containerConfig = { config, pkgs, ... }: {
     imports = [
-      ./openclaw.nix
+      (import ./openclaw.nix { inherit config pkgs lib claude-code; })
     ];
 
     boot.isContainer = true;


### PR DESCRIPTION
## Summary
Fixes the openclaw-container module to properly pass the claude-code flake input to the container configuration.

## Problem
The container module wasn't receiving the claude-code argument, causing the OpenClaw service inside the container to fail during deployment.

## Solution
- Updated module signature to accept optional claude-code argument
- Modified container import to explicitly pass claude-code to the openclaw module

## Testing
Deployed successfully to sancta-choir VPS during Phase 1 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)