### PR TITLE
fix(openclaw-container): fix service startup and networking issues

### DIFF
--- a/modules/services/openclaw-container.nix
+++ b/modules/services/openclaw-container.nix
@@ -20,6 +20,7 @@ let
     networking = {
       useHostResolvConf = false;
       nameservers = [ "1.1.1.1" "8.8.8.8" ];
+      defaultGateway = "192.168.84.1";
     };
 
     # OpenClaw service (reuse existing module)


### PR DESCRIPTION
## Summary
Fixes three critical bugs that prevented OpenClaw from running inside the systemd-nspawn container during sancta-kuzea deployment.

## Bugs Fixed

### 1. ExecStartPre PATH Bug
**Problem:** openclaw-git-setup.service failed with "No such file or directory" because ExecStartPre script used relative command names (mkdir, tr, chown) that aren't in PATH when running with `+` prefix.

**Solution:** Replace all relative commands with absolute paths using ${pkgs.coreutils}/bin/ prefix.

### 2. Read-Only Mount Conflict
**Problem:** Git setup script tried to write .gitconfig in /var/lib/openclaw which is mounted read-only from host.

**Solution:** Add check to skip git config if .gitconfig exists and is not writable.

### 3. Missing Default Route
**Problem:** Container had no default gateway, causing "Network is unreachable" for all internet access.

**Solution:** Add `networking.defaultGateway = "192.168.84.1"` to container config.

## Testing
These fixes will be deployed to sancta-choir after merge to verify OpenClaw container functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)