### PR TITLE
fix(sancta-kuzea): add 2GB swap space to prevent OOM during builds

### DIFF
--- a/hosts/sancta-kuzea/configuration.nix
+++ b/hosts/sancta-kuzea/configuration.nix
@@ -48,6 +48,15 @@
   networking.hostName = "sancta-choir";
   networking.domain = "";
 
+  # Swap space (prevents OOM during builds on 4GB VPS)
+  # 2GB swap provides buffer for memory-intensive builds (Node.js, Rust, etc)
+  swapDevices = [
+    {
+      device = "/swapfile";
+      size = 2048; # 2GB
+    }
+  ];
+
   # SSH authorized keys for remote access
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPw5RFrFfZQUWlyfGSU1Q8BlEHnvIdBtcnCn+uYtEzal nixos-sancta-choir"


### PR DESCRIPTION
## Summary

Adds 2GB swap space to sancta-kuzea configuration to prevent out-of-memory crashes during builds.

## Motivation

The VPS crashed during the initial sancta-kuzea deployment when building memory-intensive packages (open-webui-frontend Node.js build). This left the bootloader corrupted and required rescue mode recovery.

## Changes

- Add `swapDevices` configuration with 2GB swapfile
- Provides buffer for memory spikes during builds
- Complements build-time memory limits (`--max-jobs 1 --cores 1`)

## Defense-in-Depth Strategy

1. **Swap space** (this PR) - Buffer for memory spikes
2. **Build limits** - `--max-jobs 1 --cores 1` prevents parallel OOM
3. **Test build first** - `nixos-rebuild build` before `switch`

## Impact

- No runtime performance cost (swap only used when needed)
- Prevents system crashes during builds
- Critical safety measure for 4GB VPS

Related: Boot failure incident (Feb 15) - see MIGRATION-RESUME.md lessons learned