### PR TITLE
feat(openclaw): integrate Official OpenClaw with Telegram support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,7 +117,25 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -195,6 +213,68 @@
         "type": "github"
       }
     },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-openclaw",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767909183,
+        "narHash": "sha256-u/bcU0xePi5bgNoRsiqSIwaGBwDilKKFTz3g0hqOBAo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "cd6e96d56ed4b2a779ac73a1227e0bb1519b3509",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-openclaw": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "home-manager": "home-manager_3",
+        "nix-steipete-tools": "nix-steipete-tools",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771148766,
+        "narHash": "sha256-oQN6821SOxjXiul25cateMSZsUwMJncf5mdOHU343m4=",
+        "owner": "openclaw",
+        "repo": "nix-openclaw",
+        "rev": "3993c506897f5c1e2babcf4d21769fc2334674ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openclaw",
+        "repo": "nix-openclaw",
+        "type": "github"
+      }
+    },
+    "nix-steipete-tools": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1771128277,
+        "narHash": "sha256-wcVJ9uvHx7KZTezCG6IedeRnJFsHF9Oaej+l8XC2wYM=",
+        "owner": "openclaw",
+        "repo": "nix-steipete-tools",
+        "rev": "90516869c19a49f0434787277a9458436867a53b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openclaw",
+        "repo": "nix-steipete-tools",
+        "type": "github"
+      }
+    },
     "nixos-images": {
       "inputs": {
         "nixos-stable": [
@@ -226,7 +306,7 @@
         "argononed": "argononed",
         "flake-compat": "flake-compat",
         "nixos-images": "nixos-images",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1770234563,
@@ -244,16 +324,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770234462,
-        "narHash": "sha256-Ab6VqbckLApCrZlj8+HXJkPhMiquUP84osaSOZzA3HI=",
-        "owner": "nvmd",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "071e76e7df3520f30f8a213b37f2f3f4cd96e937",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
-        "owner": "nvmd",
-        "ref": "modules-with-keys-25.11",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -276,6 +356,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1770234462,
+        "narHash": "sha256-Ab6VqbckLApCrZlj8+HXJkPhMiquUP84osaSOZzA3HI=",
+        "owner": "nvmd",
+        "repo": "nixpkgs",
+        "rev": "071e76e7df3520f30f8a213b37f2f3f4cd96e937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "ref": "modules-with-keys-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1767313136,
         "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
@@ -296,8 +392,9 @@
         "claude-code": "claude-code",
         "home-manager": "home-manager_2",
         "home-manager-unstable": "home-manager-unstable",
+        "nix-openclaw": "nix-openclaw",
         "nixos-raspberrypi": "nixos-raspberrypi",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "tsidp": "tsidp",
         "vscode-server": "vscode-server"
@@ -348,12 +445,27 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tsidp": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1770422603,
@@ -371,7 +483,7 @@
     },
     "vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,15 @@
       url = "github:sadjow/claude-code-nix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    # OpenClaw - AI assistant gateway with Telegram/WhatsApp support
+    # See: https://github.com/openclaw/nix-openclaw
+    nix-openclaw = {
+      url = "github:openclaw/nix-openclaw";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, nixos-raspberrypi, claude-code, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, nixos-raspberrypi, claude-code, nix-openclaw, ... }@inputs:
     let
       # Systems that can run our scripts and packages
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
@@ -118,6 +124,7 @@
             };
             inherit self; # Pass self for accessing flake root
             inherit claude-code; # Pass claude-code flake
+            inherit nix-openclaw; # Pass nix-openclaw for Home Manager
           };
           modules = [
             ./hosts/sancta-kuzea/configuration.nix

--- a/home/root-openclaw.nix
+++ b/home/root-openclaw.nix
@@ -1,0 +1,50 @@
+{ config, pkgs, nix-openclaw, ... }:
+
+{
+  # Import nix-openclaw home-manager module
+  imports = [
+    nix-openclaw.homeManagerModules.default
+  ];
+
+  # Enable OpenClaw
+  programs.openclaw = {
+    enable = true;
+
+    config = {
+      # Gateway configuration
+      gateway = {
+        mode = "local";
+        auth = {
+          # Will be generated on first run or via onboarding
+          tokenFile = "/root/.openclaw/gateway-token";
+        };
+      };
+
+      # Telegram channel configuration
+      channels.telegram = {
+        # Token will be provided via onboarding wizard
+        tokenFile = "/run/agenix/telegram-bot-token";
+        # DM policy: require pairing for security
+        dmPolicy = "pairing";
+        # Can also use allowlist:
+        # allowFrom = [ 123456789 ]; # Your Telegram user ID
+      };
+
+      # Model provider (Anthropic)
+      env = {
+        ANTHROPIC_API_KEY_FILE = "/run/agenix/anthropic-api-key";
+      };
+    };
+
+    # Enable bundled plugins
+    bundledPlugins = {
+      peekaboo = true;     # Screenshot/vision tools
+      summarize = true;    # Text summarization
+      oracle = true;       # General knowledge
+      webSearch = true;    # Web search capability
+    };
+  };
+
+  # Home Manager state version
+  home.stateVersion = "24.11";
+}

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -37,7 +37,8 @@
     ../../modules/users/root.nix
     ../../modules/services/claude.nix
     ../../modules/services/tailscale.nix
-    ../../modules/services/openclaw-container.nix
+    # Disable old container-based OpenClaw (replaced with nix-openclaw)
+    # ../../modules/services/openclaw-container.nix
   ];
 
   # Enable development tools and Claude Code
@@ -47,20 +48,17 @@
   # Agenix secrets (defaults: owner=root, group=root, mode=0400)
   age.secrets = {
     tailscale-auth-key.file = "${self}/secrets/tailscale-auth-key.age";
-    anthropic-api-key.file = "${self}/secrets/anthropic-api-key.age";
-    openclaw-github-token.file = "${self}/secrets/openclaw-github-token.age";
+    # These secrets will be created during OpenClaw onboarding
+    # anthropic-api-key.file = "${self}/secrets/anthropic-api-key.age";
+    # telegram-bot-token.file = "${self}/secrets/telegram-bot-token.age";
   };
 
-  # OpenClaw in systemd-nspawn container (main purpose of this host)
-  services.openclaw-container = {
-    enable = true;
-    anthropicApiKeyFile = config.age.secrets.anthropic-api-key.path;
-    githubTokenFile = config.age.secrets.openclaw-github-token.path;
-    repoUrl = "https://github.com/alexandru-savinov/nixos-config.git";
-    repoBranch = "main";
-    model = "sonnet";
-    maxTurns = 50;
-    maxBudgetUsd = 5.0;
+  # Home Manager for root user (OpenClaw)
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    users.root = import ../../home/root-openclaw.nix;
+    extraSpecialArgs = { inherit self nix-openclaw; };
   };
 
   # Swap space (prevents OOM during builds on 4GB VPS)


### PR DESCRIPTION
## Summary
Replace custom `openclaw-container` module with **Official OpenClaw** package from `nix-openclaw` flake.

## Changes
- ✅ Add `nix-openclaw` flake input
- ✅ Create `home/root-openclaw.nix` for Home Manager configuration  
- ✅ Configure OpenClaw with Telegram channel + Anthropic API
- ✅ Update sancta-choir and sancta-kuzea configurations
- ✅ Disable old `openclaw-container.nix` module

## Benefits
- 🎯 Official package with native Telegram/WhatsApp/Discord support
- 🚀 No manual npm install or build dependencies  
- 🔐 Built-in onboarding wizard for API keys
- 🛠️ Bundled plugins (peekaboo, summarize, oracle, webSearch)
- 📦 Native systemd integration via Home Manager

## Next Steps
1. Deploy to sancta-choir
2. Run `openclaw onboard --flow quickstart` to configure:
   - Anthropic API key
   - Telegram bot token
3. Test Telegram integration

## References  
- [nix-openclaw GitHub](https://github.com/openclaw/nix-openclaw)
- [OpenClaw Documentation](https://docs.openclaw.ai/install/nix)

🤖 Generated with Claude Code