### PR TITLE
fix(openclaw): use correct module path

### DIFF
--- a/home/root-openclaw.nix
+++ b/home/root-openclaw.nix
@@ -3,7 +3,7 @@
 {
   # Import nix-openclaw home-manager module
   imports = [
-    nix-openclaw.homeManagerModules.default
+    nix-openclaw.homeManagerModules.openclaw
   ];
 
   # Enable OpenClaw


### PR DESCRIPTION
Fix nix-openclaw module import path from  to 