### PR TITLE
fix(openclaw): provide package from nix-openclaw flake

### DIFF
--- a/home/root-openclaw.nix
+++ b/home/root-openclaw.nix
@@ -11,6 +11,9 @@
   programs.openclaw = {
     enable = true;
 
+    # Explicitly provide the package from nix-openclaw flake
+    package = nix-openclaw.packages.${pkgs.system}.default;
+
     # Configuration will be managed by onboarding wizard
     # The wizard creates ~/.openclaw/config.json with:
     # - Gateway auth token


### PR DESCRIPTION
Explicitly set package from nix-openclaw.packages instead of expecting pkgs overlay