### PR TITLE
fix(openclaw): add overlay for pkgs.openclaw

### DIFF
--- a/hosts/sancta-kuzea/configuration.nix
+++ b/hosts/sancta-kuzea/configuration.nix
@@ -8,6 +8,11 @@
 }:
 
 {
+  # Add nix-openclaw overlay to provide pkgs.openclaw
+  nixpkgs.overlays = [
+    nix-openclaw.overlays.default
+  ];
+
   imports = [
     ./hardware-configuration.nix
     ../common.nix


### PR DESCRIPTION
Add nix-openclaw.overlays.default to provide pkgs.openclaw package