### PR TITLE
fix(n8n): add versionId to all workflow JSON files

### DIFF
--- a/n8n-workflows/example-webhook-handler.json
+++ b/n8n-workflows/example-webhook-handler.json
@@ -32,5 +32,6 @@
     }
   },
   "active": false,
-  "settings": {}
+  "settings": {},
+  "versionId": "09e6fa5c-6b60-422f-a61d-6ab9d431cec8"
 }

--- a/n8n-workflows/image-to-anki-download.json
+++ b/n8n-workflows/image-to-anki-download.json
@@ -156,5 +156,6 @@
     }
   },
   "settings": { "executionOrder": "v1" },
-  "active": true
+  "active": true,
+  "versionId": "9fc3f94c-cb81-429c-b317-16e8dd285439"
 }

--- a/n8n-workflows/image-to-anki-status.json
+++ b/n8n-workflows/image-to-anki-status.json
@@ -50,5 +50,6 @@
     }
   },
   "settings": { "executionOrder": "v1" },
-  "active": true
+  "active": true,
+  "versionId": "67185661-1230-4833-bfcd-dc0ce2e0dda4"
 }

--- a/n8n-workflows/image-to-anki-ui.json
+++ b/n8n-workflows/image-to-anki-ui.json
@@ -85,5 +85,6 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true
+  "active": true,
+  "versionId": "a1a15ee9-0577-4006-a136-59376da3a398"
 }

--- a/n8n-workflows/image-to-anki-worker.json
+++ b/n8n-workflows/image-to-anki-worker.json
@@ -796,5 +796,6 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true
+  "active": true,
+  "versionId": "0e0b0e8f-ee52-4cbf-a5ec-88487cbc0db9"
 }

--- a/n8n-workflows/image-to-anki.json
+++ b/n8n-workflows/image-to-anki.json
@@ -201,5 +201,6 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true
+  "active": true,
+  "versionId": "996e279c-22f9-4690-87bc-e759c714b232"
 }

--- a/n8n-workflows/nixframe-ui.json
+++ b/n8n-workflows/nixframe-ui.json
@@ -85,5 +85,6 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true
+  "active": true,
+  "versionId": "0f47476b-e412-49b0-aeb5-e07bec1fd2d3"
 }

--- a/n8n-workflows/nixframe-upload.json
+++ b/n8n-workflows/nixframe-upload.json
@@ -129,5 +129,6 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true
+  "active": true,
+  "versionId": "56eb1037-049b-4208-b624-cd5f33a6c167"
 }

--- a/n8n-workflows/openclaw-results-to-telegram.json
+++ b/n8n-workflows/openclaw-results-to-telegram.json
@@ -318,7 +318,7 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "1",
+  "versionId": "f26114c3-0429-477c-8f4c-0f250735dbd3",
   "meta": {
     "instanceId": "nixos-config-n8n"
   },

--- a/n8n-workflows/rpi5-system-health-check.json
+++ b/n8n-workflows/rpi5-system-health-check.json
@@ -130,5 +130,6 @@
   "active": true,
   "settings": {
     "executionOrder": "v1"
-  }
+  },
+  "versionId": "e302dc01-174a-48b2-80de-802d4b440201"
 }

--- a/n8n-workflows/telegram-openclaw-bridge.json
+++ b/n8n-workflows/telegram-openclaw-bridge.json
@@ -334,7 +334,7 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "1",
+  "versionId": "4bd39001-d9bf-44cd-bd89-96cd4268f6fe",
   "meta": {
     "instanceId": "nixos-config-n8n"
   },


### PR DESCRIPTION
## Root Cause

n8n 1.123.11 added a `NOT NULL` constraint on `workflow_entity.versionId`. All workflow JSON files lacked a `versionId` field, so n8n failed to import them:

```
SQLITE_CONSTRAINT: NOT NULL constraint failed: workflow_entity.versionId
```

The two OpenClaw workflows (`telegram-openclaw-bridge`, `openclaw-results-to-telegram`) had `"versionId": "1"` which violated the FK constraint to `workflow_history.versionId` — no history entry with `versionId="1"` exists:

```
SQLITE_CONSTRAINT: FOREIGN KEY constraint failed
```

This caused **all** n8n workflow imports to fail on every `nixos-rebuild switch`, leaving webhooks unregistered (404) and workflows inactive.

## Fix

Added proper UUIDs as `versionId` to all 11 workflow JSON files. Fresh UUIDs are used (not the current DB values) to avoid UNIQUE conflicts in `workflow_history` when n8n creates new history entries on import.

## Test plan

- [ ] `sudo nixos-rebuild switch --flake .#rpi5-full` — deploy and verify `n8n-workflow-sync.service` succeeds
- [ ] `systemctl status n8n-workflow-sync.service` — shows `active (exited)` not `failed`
- [ ] Webhooks respond: `curl http://127.0.0.1:5678/webhook/nixframe-ui` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)