### PR TITLE
fix(n8n): use existing DB versionIds for active workflows

### DIFF
--- a/n8n-workflows/image-to-anki-download.json
+++ b/n8n-workflows/image-to-anki-download.json
@@ -157,5 +157,5 @@
   },
   "settings": { "executionOrder": "v1" },
   "active": true,
-  "versionId": "9fc3f94c-cb81-429c-b317-16e8dd285439"
+  "versionId": "c91d7f27-e850-4bc0-b3b4-9e39ca570af1"
 }

--- a/n8n-workflows/image-to-anki-status.json
+++ b/n8n-workflows/image-to-anki-status.json
@@ -51,5 +51,5 @@
   },
   "settings": { "executionOrder": "v1" },
   "active": true,
-  "versionId": "67185661-1230-4833-bfcd-dc0ce2e0dda4"
+  "versionId": "66e806e1-334f-4bcb-97bc-abc1160e32fe"
 }

--- a/n8n-workflows/image-to-anki-ui.json
+++ b/n8n-workflows/image-to-anki-ui.json
@@ -86,5 +86,5 @@
     "executionOrder": "v1"
   },
   "active": true,
-  "versionId": "a1a15ee9-0577-4006-a136-59376da3a398"
+  "versionId": "63c2e70a-325c-45e8-b979-5db59b265faa"
 }

--- a/n8n-workflows/image-to-anki-worker.json
+++ b/n8n-workflows/image-to-anki-worker.json
@@ -797,5 +797,5 @@
     "executionOrder": "v1"
   },
   "active": true,
-  "versionId": "0e0b0e8f-ee52-4cbf-a5ec-88487cbc0db9"
+  "versionId": "3ce96117-ef79-481b-bf9c-6c6065c0cca5"
 }

--- a/n8n-workflows/image-to-anki.json
+++ b/n8n-workflows/image-to-anki.json
@@ -202,5 +202,5 @@
     "executionOrder": "v1"
   },
   "active": true,
-  "versionId": "996e279c-22f9-4690-87bc-e759c714b232"
+  "versionId": "28701dde-acfd-460c-a39f-fdd4d9660115"
 }

--- a/n8n-workflows/nixframe-ui.json
+++ b/n8n-workflows/nixframe-ui.json
@@ -86,5 +86,5 @@
     "executionOrder": "v1"
   },
   "active": true,
-  "versionId": "0f47476b-e412-49b0-aeb5-e07bec1fd2d3"
+  "versionId": "cfdaad63-b4e1-43b7-95ea-3b524a017714"
 }

--- a/n8n-workflows/nixframe-upload.json
+++ b/n8n-workflows/nixframe-upload.json
@@ -130,5 +130,5 @@
     "executionOrder": "v1"
   },
   "active": true,
-  "versionId": "56eb1037-049b-4208-b624-cd5f33a6c167"
+  "versionId": "a7a03d95-685d-4358-bdd7-1173182103b7"
 }

--- a/n8n-workflows/rpi5-system-health-check.json
+++ b/n8n-workflows/rpi5-system-health-check.json
@@ -131,5 +131,5 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "e302dc01-174a-48b2-80de-802d4b440201"
+  "versionId": "0af4b9ac-0554-4f59-a189-c9deb91b01e6"
 }


### PR DESCRIPTION
## Summary
- PR #267 added random UUIDs as `versionId` to all workflow JSONs to fix the NOT NULL constraint in n8n 1.123.11
- This fixed inactive workflows but broke active ones: n8n sets `activeVersionId = versionId` on import, and `activeVersionId` is a FK into `workflow_history.versionId`
- Our new UUIDs had no matching `workflow_history` entries → `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed`
- Fix: use the versionIds **already in the DB** for all `active=true` workflows — these have existing `workflow_history` entries so the FK is satisfied

## Root Cause
```
workflow_entity.activeVersionId → workflow_history.versionId  (ON DELETE RESTRICT)
```
When n8n imports an active workflow, it sets `activeVersionId = versionId_from_json`. If that UUID doesn't exist in `workflow_history`, the FK check fails.

## Test Plan
- [x] Tested all 11 workflow imports locally — zero SQLITE_CONSTRAINT errors
- [ ] After merge, redeploy and confirm `n8n-workflow-sync.service` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)