### PR TITLE
feat(hcloud): add hcloud CLI + API token foundation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -248,6 +248,16 @@
             ];
             text = builtins.readFile ./scripts/bootstrap.sh;
           };
+
+          # Hetzner Cloud CLI wrapper (injects API token from agenix)
+          hcloud-wrap = pkgs.writeShellApplication {
+            name = "hcloud-wrap";
+            runtimeInputs = with pkgs; [
+              hcloud
+              coreutils
+            ];
+            text = builtins.readFile ./scripts/hcloud-wrap.sh;
+          };
         });
 
       # Apps - makes packages runnable with `nix run`
@@ -271,6 +281,12 @@
         bootstrap = {
           type = "app";
           program = "${self.packages.${system}.bootstrap}/bin/nixos-bootstrap";
+        };
+
+        # Hetzner Cloud CLI (with API token injection)
+        hcloud-wrap = {
+          type = "app";
+          program = "${self.packages.${system}.hcloud-wrap}/bin/hcloud-wrap";
         };
       });
     };

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -83,6 +83,9 @@
       file = "${self}/secrets/caldav-credentials.age";
       owner = "nixframe";
     };
+
+    # Hetzner Cloud API token for VPS provisioning
+    hcloud-api-token.file = "${self}/secrets/hcloud-api-token.age";
   };
 
   # Open-WebUI with OpenRouter backend
@@ -504,6 +507,9 @@
     enable = true;
     credentialsFile = config.age.secrets.caldav-credentials.path;
   };
+
+  # Hetzner Cloud CLI for VPS provisioning (RPi5 is the control plane)
+  environment.systemPackages = [ pkgs.hcloud ];
 
   # Add ImageMagick to n8n PATH for HEIC conversion and EXIF auto-orient
   # Allow n8n to write to nixframe photo directory (ProtectSystem=strict blocks it)

--- a/scripts/hcloud-wrap.sh
+++ b/scripts/hcloud-wrap.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Thin wrapper around hcloud CLI that injects the API token from agenix
+# Usage: hcloud-wrap <any hcloud args>
+
+TOKEN_FILE="/run/agenix/hcloud-api-token"
+
+if [ ! -r "$TOKEN_FILE" ]; then
+  echo "Error: Cannot read $TOKEN_FILE" >&2
+  echo "Run with sudo or ensure agenix has decrypted the secret." >&2
+  exit 1
+fi
+
+export HCLOUD_TOKEN
+HCLOUD_TOKEN="$(cat "$TOKEN_FILE")"
+
+exec hcloud "$@"

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -52,4 +52,7 @@ in
 
   # CalDAV credentials for NixFrame calendar (Apple ID + app-specific password)
   "caldav-credentials.age".publicKeys = allKeys;
+
+  # Hetzner Cloud API token (rpi5 only — not needed on VPS instances)
+  "hcloud-api-token.age".publicKeys = users ++ [ rpi5 ];
 }


### PR DESCRIPTION
## Summary
- Add `hcloud` package to rpi5-full system packages and `hcloud-api-token` agenix secret (rpi5-only decryption)
- Create `hcloud-wrap` script + flake app that injects API token from agenix before calling hcloud
- Register `hcloud-api-token.age` in `secrets/secrets.nix`

## Manual step required
After merging, create the encrypted secret:
```bash
cd secrets && agenix -e hcloud-api-token.age
```
Then paste your Hetzner Cloud API token (from https://console.hetzner.cloud → Project → Security → API Tokens).

## Verify
```bash
sudo nix run .#hcloud-wrap -- server list
```

## Test plan
- [x] `nix eval .#packages.aarch64-linux.hcloud-wrap.name` → evaluates
- [x] `nix build .#packages.aarch64-linux.hcloud-wrap` → builds successfully
- [x] `nix eval .#nixosConfigurations.rpi5-full.config.age.secrets.hcloud-api-token.file` → correct path
- [ ] `cd secrets && agenix -e hcloud-api-token.age` → manual secret creation
- [ ] `sudo nix run .#hcloud-wrap -- server list` → end-to-end test after secret exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)