### PR TITLE
feat(hetzner): add shared Hetzner Cloud module + disko config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,6 +82,26 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771469470,
+        "narHash": "sha256-GnqdqhrguKNN3HtVfl6z+zbV9R9jhHFm3Z8nu7R6ml0=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "4707eec8d1d2db5182ea06ed48c820a86a42dc13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1767039857,
@@ -390,6 +410,7 @@
       "inputs": {
         "agenix": "agenix",
         "claude-code": "claude-code",
+        "disko": "disko",
         "home-manager": "home-manager_2",
         "home-manager-unstable": "home-manager-unstable",
         "nix-openclaw": "nix-openclaw",

--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,15 @@
       url = "github:openclaw/nix-openclaw";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # Disko - declarative disk partitioning for nixos-anywhere
+    # See: https://github.com/nix-community/disko
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, nixos-raspberrypi, claude-code, nix-openclaw, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable, vscode-server, tsidp, agenix, nixos-raspberrypi, claude-code, nix-openclaw, disko, ... }@inputs:
     let
       # Systems that can run our scripts and packages
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
@@ -85,6 +91,14 @@
         #   specialArgs = { pkgs-unstable = import nixpkgs-unstable { system = "..."; }; };
         # Enable with: customModules.dev-tools.enable = true;
         dev-tools = ./modules/system/dev-tools.nix;
+
+        # Hetzner Cloud VPS configuration (boot, networking, SSH, firewall)
+        # Enable with: hetzner-cloud.enable = true; hetzner-cloud.ipv4Address = "...";
+        hetzner-cloud = ./modules/system/hetzner-cloud.nix;
+
+        # Disko disk layout for Hetzner (GPT + BIOS boot + ext4)
+        # Used with nixos-anywhere for automated provisioning
+        hetzner-disko = ./modules/system/hetzner-disko.nix;
       };
 
       # NixOS system configurations

--- a/modules/system/hetzner-cloud.nix
+++ b/modules/system/hetzner-cloud.nix
@@ -1,0 +1,101 @@
+# Shared NixOS module for Hetzner Cloud VPS instances
+# Consolidates boot, networking, SSH, and firewall configuration
+#
+# Usage in host config:
+#   imports = [ ../../modules/system/hetzner-cloud.nix ];
+#   hetzner-cloud.enable = true;
+#   hetzner-cloud.ipv4Address = "1.2.3.4";
+#   hetzner-cloud.macAddress = "aa:bb:cc:dd:ee:ff";  # optional
+
+{ config, pkgs, lib, modulesPath, ... }:
+
+let
+  cfg = config.hetzner-cloud;
+in
+{
+  options.hetzner-cloud = {
+    enable = lib.mkEnableOption "Hetzner Cloud VPS configuration";
+
+    ipv4Address = lib.mkOption {
+      type = lib.types.str;
+      description = "Static IPv4 address assigned by Hetzner";
+      example = "116.203.223.113";
+    };
+
+    ipv4Gateway = lib.mkOption {
+      type = lib.types.str;
+      default = "172.31.1.1";
+      description = "IPv4 gateway (Hetzner Cloud default is 172.31.1.1)";
+    };
+
+    macAddress = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "MAC address for udev eth0 binding (optional)";
+      example = "92:00:06:bb:96:03";
+    };
+
+    nameservers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "185.12.64.1" "185.12.64.2" ];
+      description = "DNS nameservers (defaults to Hetzner DNS)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # ── Boot ─────────────────────────────────────────────────────
+    imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+    boot.loader.grub.device = "/dev/sda";
+    boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "xen_blkfront" "vmw_pvscsi" ];
+    boot.initrd.kernelModules = [ "nvme" ];
+
+    # ── Networking ───────────────────────────────────────────────
+    networking.useDHCP = false;
+    networking.usePredictableInterfaceNames = lib.mkForce false;
+    networking.dhcpcd.enable = false;
+    networking.nameservers = cfg.nameservers;
+
+    networking.interfaces.eth0 = {
+      useDHCP = false;
+      ipv4.addresses = [{
+        address = cfg.ipv4Address;
+        prefixLength = 32;
+      }];
+      ipv4.routes = [{ address = cfg.ipv4Gateway; prefixLength = 32; }];
+    };
+
+    networking.defaultGateway = {
+      address = cfg.ipv4Gateway;
+      interface = "eth0";
+    };
+
+    # MAC address binding (stable interface naming)
+    services.udev.extraRules = lib.mkIf (cfg.macAddress != null) ''
+      ATTR{address}=="${cfg.macAddress}", NAME="eth0"
+    '';
+
+    # ── Swap ─────────────────────────────────────────────────────
+    swapDevices = [{
+      device = "/swapfile";
+      size = 2048; # 2GB — prevents OOM during builds on 4GB VPS
+    }];
+
+    # ── SSH ──────────────────────────────────────────────────────
+    services.openssh = {
+      enable = true;
+      settings = {
+        PermitRootLogin = "prohibit-password";
+        PasswordAuthentication = false;
+      };
+    };
+
+    # ── Firewall ─────────────────────────────────────────────────
+    networking.firewall.enable = true;
+    networking.firewall.allowedTCPPorts = [ 22 ];
+
+    # ── Filesystem (for existing instances without disko) ────────
+    # New instances should use hetzner-disko.nix instead
+    fileSystems."/" = lib.mkDefault { device = "/dev/sda1"; fsType = "ext4"; };
+  };
+}

--- a/modules/system/hetzner-disko.nix
+++ b/modules/system/hetzner-disko.nix
@@ -1,0 +1,34 @@
+# Disko disk configuration for Hetzner Cloud VPS
+# GPT partition table with BIOS boot + ext4 root on /dev/sda
+#
+# Used by nixos-anywhere for automated disk partitioning.
+# Existing instances (sancta-choir, sancta-kuzea) don't need this —
+# they already have partitioned disks and use fileSystems from hetzner-cloud.nix.
+
+{ ... }:
+
+{
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/sda";
+    content = {
+      type = "gpt";
+      partitions = {
+        # BIOS boot partition (required for GRUB on GPT)
+        boot = {
+          size = "1M";
+          type = "EF02"; # BIOS boot
+        };
+        # Root filesystem
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Create `modules/system/hetzner-cloud.nix` — shared NixOS module consolidating boot (QEMU guest, GRUB), static networking, SSH hardening, firewall, and swap for Hetzner VPS instances
- Create `modules/system/hetzner-disko.nix` — declarative disk partitioning (GPT + BIOS boot + ext4 root) for nixos-anywhere
- Add `disko` flake input (follows nixpkgs)
- Export both as `nixosModules.hetzner-cloud` and `nixosModules.hetzner-disko`

## Module options
```nix
hetzner-cloud.enable = true;
hetzner-cloud.ipv4Address = "116.203.223.113";
hetzner-cloud.ipv4Gateway = "172.31.1.1";  # default
hetzner-cloud.macAddress = "92:00:06:bb:96:03";  # optional
hetzner-cloud.nameservers = [ "185.12.64.1" "185.12.64.2" ];  # default
```

## Test plan
- [x] `nix eval .#nixosModules.hetzner-cloud` → resolves to module path
- [x] `nix eval .#nixosModules.hetzner-disko` → resolves to module path
- [x] `nix fmt` passes
- [ ] Used by PR 3 (VPS migration) to verify equivalent build output

## Note
`nix flake check` has a pre-existing failure on main (sancta-choir missing nix-openclaw specialArg) — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)