### PR TITLE
refactor(hetzner): migrate VPS configs to shared hetzner-cloud module

### DIFF
--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -29,17 +29,23 @@
   };
 
   imports = [
-    ./hardware-configuration.nix
     ../common.nix
-    ../../modules/system/host.nix
-    ../../modules/system/networking.nix
+    ../../modules/system/hetzner-cloud.nix
     ../../modules/system/dev-tools.nix
     ../../modules/users/root.nix
     ../../modules/services/claude.nix
     ../../modules/services/tailscale.nix
-    # Disable old container-based OpenClaw (replaced with nix-openclaw)
-    # ../../modules/services/openclaw-container.nix
   ];
+
+  # Hetzner Cloud VPS configuration
+  hetzner-cloud = {
+    enable = true;
+    ipv4Address = "116.203.223.113";
+    macAddress = "92:00:06:bb:96:03";
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
 
   # Enable development tools and Claude Code
   customModules.dev-tools.enable = true;
@@ -61,17 +67,16 @@
     extraSpecialArgs = { inherit self nix-openclaw; };
   };
 
-  # Swap space (prevents OOM during builds on 4GB VPS)
-  swapDevices = [
-    {
-      device = "/swapfile";
-      size = 2048; # 2GB
-    }
-  ];
-
   # Hostname
   networking.hostName = "sancta-choir";
   networking.domain = "";
+
+  # VSCode Server support
+  services.vscode-server.enable = true;
+
+  # Time zone and locale
+  time.timeZone = "Europe/Chisinau";
+  i18n.defaultLocale = "en_US.UTF-8";
 
   # SSH authorized keys for remote access
   users.users.root.openssh.authorizedKeys.keys = [

--- a/hosts/sancta-kuzea/configuration.nix
+++ b/hosts/sancta-kuzea/configuration.nix
@@ -9,17 +9,23 @@
 
 {
   imports = [
-    ./hardware-configuration.nix
     ../common.nix
-    ../../modules/system/host.nix
-    ../../modules/system/networking.nix
+    ../../modules/system/hetzner-cloud.nix
     ../../modules/system/dev-tools.nix
     ../../modules/users/root.nix
     ../../modules/services/claude.nix
     ../../modules/services/tailscale.nix
-    # Will install Official OpenClaw via npm instead of nix-openclaw
-    # nix-openclaw has upstream bugs (bird2/bird3 ambiguity)
   ];
+
+  # Hetzner Cloud VPS configuration (shares IP with sancta-choir during migration)
+  hetzner-cloud = {
+    enable = true;
+    ipv4Address = "116.203.223.113";
+    macAddress = "92:00:06:bb:96:03";
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
 
   # Enable development tools and Claude Code
   customModules.dev-tools.enable = true;
@@ -41,24 +47,18 @@
     # telegram-bot-token.file = "${self}/secrets/telegram-bot-token.age";
   };
 
-  # OpenClaw will be installed via npm globally after deployment
-  # Run: npm install -g openclaw@latest --prefix /usr/local
-  # Then: openclaw onboard --flow quickstart
-
   # CRITICAL: Keep hostname as "sancta-choir" for Phase 1 deployment
   # This maintains Tailscale access during migration
   # Will be changed to "sancta-kuzea" in Phase 2 after verification
   networking.hostName = "sancta-choir";
   networking.domain = "";
 
-  # Swap space (prevents OOM during builds on 4GB VPS)
-  # 2GB swap provides buffer for memory-intensive builds (Node.js, Rust, etc)
-  swapDevices = [
-    {
-      device = "/swapfile";
-      size = 2048; # 2GB
-    }
-  ];
+  # VSCode Server support
+  services.vscode-server.enable = true;
+
+  # Time zone and locale
+  time.timeZone = "Europe/Chisinau";
+  i18n.defaultLocale = "en_US.UTF-8";
 
   # SSH authorized keys for remote access
   users.users.root.openssh.authorizedKeys.keys = [

--- a/modules/system/hetzner-cloud.nix
+++ b/modules/system/hetzner-cloud.nix
@@ -13,6 +13,9 @@ let
   cfg = config.hetzner-cloud;
 in
 {
+  # QEMU guest profile must be at top level (imports can't be conditional)
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
   options.hetzner-cloud = {
     enable = lib.mkEnableOption "Hetzner Cloud VPS configuration";
 
@@ -44,8 +47,6 @@ in
 
   config = lib.mkIf cfg.enable {
     # ── Boot ─────────────────────────────────────────────────────
-    imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
-
     boot.loader.grub.device = "/dev/sda";
     boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "xen_blkfront" "vmw_pvscsi" ];
     boot.initrd.kernelModules = [ "nvme" ];


### PR DESCRIPTION
## Summary
- Replace `host.nix` + `networking.nix` + `hardware-configuration.nix` imports with `hetzner-cloud.nix` in both sancta-choir and sancta-kuzea
- Move general settings (timezone, locale, allowUnfree, vscode-server) from `host.nix` into each host's configuration.nix
- Fix `hetzner-cloud.nix` imports placement (must be top-level, not inside `mkIf`)

## What's preserved
- `host.nix` and `networking.nix` remain on disk (not deleted) — they're no longer imported but kept for reference
- `hardware-configuration.nix` files remain on disk — boot config now comes from `hetzner-cloud.nix`

## Test plan
- [x] `nix eval .#nixosConfigurations.sancta-kuzea.config.hetzner-cloud.ipv4Address` → `"116.203.223.113"`
- [x] `nix eval .#nixosConfigurations.sancta-kuzea.config.networking.defaultGateway.address` → `"172.31.1.1"`
- [x] `nix eval .#nixosConfigurations.sancta-kuzea.config.boot.loader.grub.device` → `"/dev/sda"`
- [x] `nix eval .#nixosConfigurations.sancta-kuzea.config.services.openssh.enable` → `true`
- [ ] Full build comparison (sancta-kuzea store path diff)

## Note
sancta-choir has a pre-existing issue: `nix-openclaw` referenced in Home Manager extraSpecialArgs but not passed via flake specialArgs. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)