### PR TITLE
feat(hetzner): add lifecycle scripts (create, destroy, manage)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,6 +293,41 @@
             ];
             text = builtins.readFile ./scripts/hcloud-wrap.sh;
           };
+
+          # Hetzner VPS lifecycle: create + provision via nixos-anywhere
+          hetzner-create = pkgs.writeShellApplication {
+            name = "hetzner-create";
+            runtimeInputs = with pkgs; [
+              hcloud
+              openssh
+              coreutils
+              nixos-anywhere
+            ];
+            text = builtins.readFile ./scripts/hetzner-create.sh;
+          };
+
+          # Hetzner VPS lifecycle: destroy with Tailscale cleanup
+          hetzner-destroy = pkgs.writeShellApplication {
+            name = "hetzner-destroy";
+            runtimeInputs = with pkgs; [
+              hcloud
+              jq
+              tailscale
+              coreutils
+            ];
+            text = builtins.readFile ./scripts/hetzner-destroy.sh;
+          };
+
+          # Hetzner VPS management: list, status, ssh, reboot, snapshot, resize, deploy
+          hetzner-manage = pkgs.writeShellApplication {
+            name = "hetzner-manage";
+            runtimeInputs = with pkgs; [
+              hcloud
+              openssh
+              coreutils
+            ];
+            text = builtins.readFile ./scripts/hetzner-manage.sh;
+          };
         });
 
       # Apps - makes packages runnable with `nix run`
@@ -322,6 +357,20 @@
         hcloud-wrap = {
           type = "app";
           program = "${self.packages.${system}.hcloud-wrap}/bin/hcloud-wrap";
+        };
+
+        # Hetzner VPS lifecycle
+        hetzner-create = {
+          type = "app";
+          program = "${self.packages.${system}.hetzner-create}/bin/hetzner-create";
+        };
+        hetzner-destroy = {
+          type = "app";
+          program = "${self.packages.${system}.hetzner-destroy}/bin/hetzner-destroy";
+        };
+        hetzner-manage = {
+          type = "app";
+          program = "${self.packages.${system}.hetzner-manage}/bin/hetzner-manage";
         };
       });
     };

--- a/scripts/hetzner-create.sh
+++ b/scripts/hetzner-create.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create and provision a Hetzner Cloud VPS with NixOS via nixos-anywhere
+#
+# Usage: hetzner-create [--name NAME] [--type TYPE] [--location LOC] [--config CONFIG]
+#
+# Requires: hcloud (with HCLOUD_TOKEN set), nixos-anywhere, ssh-keygen
+
+# ── Defaults ────────────────────────────────────────────────────
+NAME=""
+SERVER_TYPE="cx22"          # 2 vCPU, 4GB RAM, 40GB disk
+LOCATION="fsn1"             # Falkenstein, Germany
+CONFIG="hetzner-ephemeral"  # Flake config name
+SSH_KEY_NAME="nixos-deploy" # Hetzner SSH key name
+FLAKE_DIR=""                # Auto-detected
+
+# ── Parse args ──────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)    NAME="$2"; shift 2 ;;
+    --type)    SERVER_TYPE="$2"; shift 2 ;;
+    --location) LOCATION="$2"; shift 2 ;;
+    --config)  CONFIG="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: hetzner-create [--name NAME] [--type TYPE] [--location LOC] [--config CONFIG]"
+      echo ""
+      echo "Options:"
+      echo "  --name      Server name (default: auto-generated)"
+      echo "  --type      Server type (default: cx22 — 2 vCPU, 4GB RAM)"
+      echo "  --location  Datacenter (default: fsn1 — Falkenstein)"
+      echo "  --config    Flake config name (default: hetzner-ephemeral)"
+      echo ""
+      echo "Server types: cx22 (4GB), cx32 (8GB), cx42 (16GB), cx52 (32GB)"
+      echo "Locations: fsn1 (Falkenstein), nbg1 (Nuremberg), hel1 (Helsinki)"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Auto-generate name if not provided
+if [ -z "$NAME" ]; then
+  NAME="nixos-$(date +%Y%m%d-%H%M%S)"
+fi
+
+# Find flake directory (script is in scripts/, flake is one level up)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FLAKE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$FLAKE_DIR/flake.nix" ]; then
+  echo "Error: Cannot find flake.nix (looked in $FLAKE_DIR)" >&2
+  exit 1
+fi
+
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  Hetzner Cloud VPS Provisioning                     ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+echo "  Name:     $NAME"
+echo "  Type:     $SERVER_TYPE"
+echo "  Location: $LOCATION"
+echo "  Config:   $CONFIG"
+echo "  Flake:    $FLAKE_DIR"
+echo ""
+
+# ── Step 1: Register SSH key (idempotent) ───────────────────────
+echo "→ Registering SSH key with Hetzner..."
+SSH_PUB_KEY=$(cat ~/.ssh/id_ed25519.pub 2>/dev/null || cat ~/.ssh/id_rsa.pub 2>/dev/null) || {
+  echo "Error: No SSH public key found (~/.ssh/id_ed25519.pub or id_rsa.pub)" >&2
+  exit 1
+}
+
+if hcloud ssh-key describe "$SSH_KEY_NAME" >/dev/null 2>&1; then
+  echo "  SSH key '$SSH_KEY_NAME' already registered"
+else
+  hcloud ssh-key create --name "$SSH_KEY_NAME" --public-key "$SSH_PUB_KEY"
+  echo "  SSH key '$SSH_KEY_NAME' registered"
+fi
+
+# ── Step 2: Create server ───────────────────────────────────────
+echo ""
+echo "→ Creating server '$NAME' ($SERVER_TYPE in $LOCATION)..."
+hcloud server create \
+  --name "$NAME" \
+  --type "$SERVER_TYPE" \
+  --location "$LOCATION" \
+  --image ubuntu-24.04 \
+  --ssh-key "$SSH_KEY_NAME"
+
+# Get server IP
+SERVER_IP=$(hcloud server ip "$NAME")
+echo "  Server created: $SERVER_IP"
+
+# ── Step 3: Wait for SSH ────────────────────────────────────────
+echo ""
+echo "→ Waiting for SSH to become available..."
+TIMEOUT=120
+ELAPSED=0
+while ! ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  root@"$SERVER_IP" true 2>/dev/null; do
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "Error: SSH not available after ${TIMEOUT}s" >&2
+    exit 1
+  fi
+  echo "  Waiting... (${ELAPSED}s)"
+done
+echo "  SSH is ready"
+
+# ── Step 4: Prepare --extra-files ───────────────────────────────
+echo ""
+echo "→ Preparing extra files..."
+EXTRA_DIR=$(mktemp -d)
+trap 'rm -rf "$EXTRA_DIR"' EXIT
+
+# Inject Tailscale auth key if available
+TS_KEY_FILE="/run/agenix/tailscale-auth-key"
+if [ -r "$TS_KEY_FILE" ]; then
+  mkdir -p "$EXTRA_DIR/etc"
+  cp "$TS_KEY_FILE" "$EXTRA_DIR/etc/tailscale-auth-key"
+  chmod 600 "$EXTRA_DIR/etc/tailscale-auth-key"
+  echo "  Tailscale auth key injected"
+else
+  echo "  Warning: $TS_KEY_FILE not readable (Tailscale won't auto-join)" >&2
+fi
+
+# ── Step 5: Run nixos-anywhere ──────────────────────────────────
+echo ""
+echo "→ Running nixos-anywhere (this will take several minutes)..."
+echo "  Building on remote: $SERVER_IP"
+echo ""
+
+nixos-anywhere \
+  --build-on-remote \
+  --extra-files "$EXTRA_DIR" \
+  --flake "$FLAKE_DIR#$CONFIG" \
+  root@"$SERVER_IP"
+
+# ── Step 6: Summary ─────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  Provisioning Complete                              ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+echo "  Name:       $NAME"
+echo "  IP:         $SERVER_IP"
+echo "  SSH:        ssh root@$SERVER_IP"
+echo "  Tailscale:  Will appear as '$NAME' (if auth key was injected)"
+echo ""
+echo "  Destroy:    nix run .#hetzner-destroy -- --name $NAME"

--- a/scripts/hetzner-destroy.sh
+++ b/scripts/hetzner-destroy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Destroy a Hetzner Cloud VPS with optional Tailscale cleanup
+#
+# Usage: hetzner-destroy --name NAME [--yes]
+
+NAME=""
+YES_FLAG=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)  NAME="$2"; shift 2 ;;
+    --yes|-y) YES_FLAG=true; shift ;;
+    --help|-h)
+      echo "Usage: hetzner-destroy --name NAME [--yes]"
+      echo ""
+      echo "Options:"
+      echo "  --name    Server name (required)"
+      echo "  --yes     Skip confirmation prompt"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$NAME" ]; then
+  echo "Error: --name is required" >&2
+  echo "Usage: hetzner-destroy --name NAME [--yes]" >&2
+  exit 1
+fi
+
+# Verify server exists
+if ! hcloud server describe "$NAME" >/dev/null 2>&1; then
+  echo "Error: Server '$NAME' not found" >&2
+  exit 1
+fi
+
+SERVER_IP=$(hcloud server ip "$NAME")
+echo "Server: $NAME ($SERVER_IP)"
+
+# Confirm unless --yes
+if [ "$YES_FLAG" != true ]; then
+  if [ ! -t 0 ]; then
+    echo "Error: Interactive confirmation required (use --yes for non-interactive)" >&2
+    exit 1
+  fi
+  read -p "Destroy server '$NAME'? This cannot be undone. (y/N): " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Cancelled."
+    exit 0
+  fi
+fi
+
+# Remove from Tailscale (best-effort)
+echo "→ Removing from Tailscale (best-effort)..."
+if command -v tailscale >/dev/null 2>&1; then
+  # Try to find and remove the device by hostname
+  DEVICE_ID=$(tailscale status --json 2>/dev/null | jq -r ".Peer[] | select(.HostName == \"$NAME\") | .ID" 2>/dev/null || true)
+  if [ -n "$DEVICE_ID" ]; then
+    tailscale admin remove "$DEVICE_ID" 2>/dev/null && echo "  Removed Tailscale device $DEVICE_ID" || echo "  Could not remove Tailscale device (remove manually from admin console)"
+  else
+    echo "  Device '$NAME' not found in Tailscale peers (may not have joined yet)"
+  fi
+else
+  echo "  tailscale CLI not found (remove device manually from admin console)"
+fi
+
+# Delete server
+echo "→ Deleting server '$NAME'..."
+hcloud server delete "$NAME"
+
+echo ""
+echo "Server '$NAME' destroyed."

--- a/scripts/hetzner-manage.sh
+++ b/scripts/hetzner-manage.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Manage Hetzner Cloud VPS instances
+#
+# Usage: hetzner-manage <command> [--name NAME] [options]
+#
+# Commands:
+#   list      List all servers
+#   status    Show server details
+#   ssh       SSH into server
+#   reboot    Reboot server
+#   snapshot  Create server snapshot
+#   resize    Resize server (poweroff → change-type → poweron)
+#   deploy    SSH in and rebuild NixOS config
+
+COMMAND="${1:-}"
+shift 2>/dev/null || true
+
+NAME=""
+SERVER_TYPE=""
+FLAKE_CONFIG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)   NAME="$2"; shift 2 ;;
+    --type)   SERVER_TYPE="$2"; shift 2 ;;
+    --config) FLAKE_CONFIG="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: hetzner-manage <command> [--name NAME] [options]"
+      echo ""
+      echo "Commands:"
+      echo "  list              List all servers"
+      echo "  status --name N   Show server details"
+      echo "  ssh --name N      SSH into server"
+      echo "  reboot --name N   Reboot server"
+      echo "  snapshot --name N Create server snapshot"
+      echo "  resize --name N --type TYPE  Resize (poweroff → resize → poweron)"
+      echo "  deploy --name N [--config C] SSH in and nixos-rebuild switch"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+require_name() {
+  if [ -z "$NAME" ]; then
+    echo "Error: --name is required for '$COMMAND'" >&2
+    exit 1
+  fi
+}
+
+case "$COMMAND" in
+  list)
+    hcloud server list
+    ;;
+
+  status)
+    require_name
+    hcloud server describe "$NAME"
+    ;;
+
+  ssh)
+    require_name
+    SERVER_IP=$(hcloud server ip "$NAME")
+    exec ssh -o StrictHostKeyChecking=no root@"$SERVER_IP"
+    ;;
+
+  reboot)
+    require_name
+    echo "Rebooting '$NAME'..."
+    hcloud server reboot "$NAME"
+    echo "Reboot initiated."
+    ;;
+
+  snapshot)
+    require_name
+    SNAPSHOT_DESC="$NAME-$(date +%Y%m%d-%H%M%S)"
+    echo "Creating snapshot '$SNAPSHOT_DESC'..."
+    hcloud server create-image --type snapshot --description "$SNAPSHOT_DESC" "$NAME"
+    echo "Snapshot created."
+    ;;
+
+  resize)
+    require_name
+    if [ -z "$SERVER_TYPE" ]; then
+      echo "Error: --type is required for resize" >&2
+      echo "Example: hetzner-manage resize --name myserver --type cx32" >&2
+      exit 1
+    fi
+    echo "Resizing '$NAME' to $SERVER_TYPE..."
+    echo "→ Powering off..."
+    hcloud server poweroff "$NAME"
+    # Poll for poweroff
+    TIMEOUT=60
+    ELAPSED=0
+    while [ "$(hcloud server describe "$NAME" -o format='{{.Status}}')" != "off" ]; do
+      sleep 2
+      ELAPSED=$((ELAPSED + 2))
+      if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+        echo "Error: Server did not power off within ${TIMEOUT}s" >&2
+        exit 1
+      fi
+    done
+    echo "→ Changing type..."
+    hcloud server change-type "$NAME" "$SERVER_TYPE"
+    echo "→ Powering on..."
+    hcloud server poweron "$NAME"
+    echo "Resize complete. New type: $SERVER_TYPE"
+    ;;
+
+  deploy)
+    require_name
+    SERVER_IP=$(hcloud server ip "$NAME")
+    REMOTE_CONFIG="${FLAKE_CONFIG:-$NAME}"
+    echo "Deploying to '$NAME' ($SERVER_IP) with config '$REMOTE_CONFIG'..."
+    echo "→ Building..."
+    # shellcheck disable=SC2029
+    ssh -o StrictHostKeyChecking=no root@"$SERVER_IP" \
+      "cd /etc/nixos && git pull && nixos-rebuild build --flake .#$REMOTE_CONFIG"
+    echo "→ Switching..."
+    # shellcheck disable=SC2029
+    ssh -o StrictHostKeyChecking=no root@"$SERVER_IP" \
+      "nixos-rebuild switch --flake /etc/nixos#$REMOTE_CONFIG"
+    echo "Deploy complete."
+    ;;
+
+  "")
+    echo "Error: No command specified" >&2
+    echo "Usage: hetzner-manage <command> [--name NAME] [options]" >&2
+    echo "Commands: list, status, ssh, reboot, snapshot, resize, deploy" >&2
+    exit 1
+    ;;
+
+  *)
+    echo "Error: Unknown command '$COMMAND'" >&2
+    echo "Commands: list, status, ssh, reboot, snapshot, resize, deploy" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- `hetzner-create.sh` — Full provisioning: register SSH key, create server, poll for SSH, inject Tailscale auth key via `--extra-files`, run nixos-anywhere with `--build-on-remote`
- `hetzner-destroy.sh` — Teardown with interactive confirmation, best-effort Tailscale device removal
- `hetzner-manage.sh` — Operations on existing VPS: list, status, ssh, reboot, snapshot, resize (poweroff→change-type→poweron), deploy (git pull + nixos-rebuild)
- All three registered as flake packages + apps

## Usage
```bash
# Create a new ephemeral VPS
sudo nix run .#hetzner-create -- --name my-dev --type cx22

# Manage it
nix run .#hetzner-manage -- list
nix run .#hetzner-manage -- ssh --name my-dev
nix run .#hetzner-manage -- snapshot --name my-dev

# Destroy it
sudo nix run .#hetzner-destroy -- --name my-dev
```

Note: `hetzner-create` and `hetzner-destroy` need `sudo` because they read agenix secrets from `/run/agenix/`.

## Test plan
- [x] `nix build .#packages.aarch64-linux.hetzner-create` → builds (ShellCheck passes)
- [x] `nix build .#packages.aarch64-linux.hetzner-destroy` → builds (ShellCheck passes)
- [x] `nix build .#packages.aarch64-linux.hetzner-manage` → builds (ShellCheck passes)
- [ ] End-to-end: create ephemeral cx22, SSH, confirm Tailscale, destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)