### PR TITLE
chore(flake): update claude-code 2.1.42 → 2.1.49

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771013219,
-        "narHash": "sha256-EyR1pOL4vWyefDij3/HyZd3qjG6gzfk2BcjbAFQiXdY=",
+        "lastModified": 1771545934,
+        "narHash": "sha256-z2ZijehdcpfRnwu717pFirzHUoYfHHlo1Eu+Ajfme4U=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "3f8cff15b530cc4f09ed2497932a66662f7a8422",
+        "rev": "d09b5d8e0678cd5c87443d85d48983f866ef6f1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update `claude-code` flake input from 2.1.42 (Feb 13) to 2.1.49 (Feb 20)
- Only changes `flake.lock` — no code or config modifications

## Test plan
- [x] Verified `nix eval` resolves to `claude-code-2.1.49` store path
- [x] Deployed locally with `nixos-rebuild switch --flake .#rpi5-full` — successful
- [x] Confirmed `claude --version` outputs `2.1.49`

🤖 Generated with [Claude Code](https://claude.com/claude-code)