### PR TITLE
docs(claude): add worktree discipline and NixOS module patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ GitHub Actions on push/PR: `nix flake check`, build sancta-choir (x86_64), evalu
 
 ### Worktree Discipline
 
-**Before any git operation** (commit, edit, branch switch), verify you are in the right place:
+**Before editing files or running any git operation** (commit, branch switch, cherry-pick), verify you are in the right place:
 
 ```bash
 pwd                  # confirm directory
 git branch --show-current  # confirm branch
 ```
 
-Never commit changes meant for a feature branch into main, and never commit one feature's changes into another feature's worktree.
+Never commit one feature's changes into another feature's worktree.
 
 ### Pre-Switch Validation
 
@@ -219,10 +219,10 @@ See also: `~/.claude/skills/verify-first/SKILL.md` (installed via `services.clau
 
 Known pitfalls — do not repeat these:
 
-- **Imports must be top-level** — never place `imports = [ ... ]` inside a `lib.mkIf` block; this causes eval errors
-- **`stateVersion` conflicts** — when `common.nix` and a host config both set `system.stateVersion`, use `lib.mkForce` in the host config to resolve
-- **`useGlobalPkgs = true` does NOT suppress Home Manager version mismatch warnings** — it changes package scope, not version pinning; investigate the actual root cause instead
-- **Always run `nix fmt` before committing** — CI runs `nix fmt --check` and will fail without it; use `/nix-commit:commit` to handle this automatically
+- **Imports must be top-level** — never place `imports = [ ... ]` inside a `lib.mkIf` block; `imports` is evaluated before conditional logic by the NixOS module system, so conditional imports cause a module system type error at evaluation time
+- **`stateVersion` conflicts** — bare assignments in host configs normally override `common.nix`, but upstream modules (e.g. `nixos-raspberrypi`) may set `system.stateVersion` at a higher priority; use `lib.mkForce` in the host config to override those
+- **`useGlobalPkgs = true` does NOT suppress Home Manager version mismatch warnings** — it changes package scope, not version pinning; when the mismatch is intentional (e.g. the `nixos-raspberrypi` fork diverges from NixOS/nixpkgs), suppress it with `sharedModules = [ { home.enableNixpkgsReleaseCheck = false; } ]` and document the reason in a comment
+- **Always run `nix fmt` before committing** — CI runs `nix fmt -- --check .` and will fail if files are not formatted; use `/nix-commit:commit` to handle this automatically
 
 ## Adding New Services
 


### PR DESCRIPTION
## Summary

- Add **Worktree Discipline** subsection to `## Git Workflow`: explicit `pwd` + `git branch --show-current` check before any git operation, with a rule against cross-worktree commits
- Add **NixOS Module Patterns** section documenting four recurring pitfalls: `imports` inside `lib.mkIf`, `stateVersion` conflicts, the `useGlobalPkgs` misconception, and the `nix fmt` CI requirement

## Test plan

- [ ] No Nix files changed — CI format check passes trivially
- [ ] Review that both sections are accurate against known session failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)