### PR TITLE
fix(sancta-choir): disable broken nix-openclaw Home Manager integration

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -59,7 +59,7 @@
   home-manager = {
     useGlobalPkgs = true;
     useUserPackages = true;
-    sharedModules = [ { home.enableNixpkgsReleaseCheck = false; } ];
+    sharedModules = [{ home.enableNixpkgsReleaseCheck = false; }];
   };
 
   # Allow unfree packages (Open-WebUI license changed in v0.6+)

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -53,12 +53,12 @@
     # telegram-bot-token.file = "${self}/secrets/telegram-bot-token.age";
   };
 
-  # Home Manager for root user (OpenClaw)
+  # Home Manager settings (root user config provided by modules/users/root.nix)
+  # nix-openclaw Home Manager integration disabled — upstream bird2/bird3
+  # alias bug (same issue as sancta-kuzea). Will use npm install instead.
   home-manager = {
     useGlobalPkgs = true;
     useUserPackages = true;
-    users.root = import ../../home/root-openclaw.nix;
-    extraSpecialArgs = { inherit self nix-openclaw; };
   };
 
   # Swap space (prevents OOM during builds on 4GB VPS)

--- a/modules/services/openclaw-container.nix
+++ b/modules/services/openclaw-container.nix
@@ -149,7 +149,7 @@ in
     };
 
     # Host networking configuration
-    networking.bridges.cnt-openclaw.interfaces = [];
+    networking.bridges.cnt-openclaw.interfaces = [ ];
     networking.interfaces.cnt-openclaw.ipv4.addresses = [{
       address = "192.168.84.1";
       prefixLength = 24;


### PR DESCRIPTION
## Summary

- Disables nix-openclaw Home Manager integration on sancta-choir due to upstream `bird2/bird3` alias bug (same issue sancta-kuzea already worked around)
- Removes `users.root = import ../../home/root-openclaw.nix` and `extraSpecialArgs` — base HM config provided by `modules/users/root.nix`
- Fixes pre-existing `nix fmt` issues in two files (required for CI formatting checks)

## Root cause

The sancta-choir config had three cascading errors hidden behind each other:
1. `nix-openclaw` not passed in `specialArgs` → `undefined variable` (the visible CI error)
2. `nix-openclaw` overlay not applied → `pkgs.openclaw` missing (masked by #1)
3. `nix-openclaw` upstream `bird` alias ambiguity bug (masked by #1 and #2)

Since sancta-kuzea already disabled nix-openclaw for the same upstream bug, the cleanest fix is to do the same for sancta-choir rather than working around the broken upstream.

## Test plan

- [x] `nix flake check --all-systems` passes (0 errors)
- [x] `nix fmt -- --check .` passes (0/36 reformatted)
- [ ] CI passes (flake check + formatting + sancta-choir build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)