### PR TITLE
secrets: encrypt kuzea caldav + github token

### DIFF
--- a/secrets/kuzea-caldav-credentials.age
+++ b/secrets/kuzea-caldav-credentials.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 Z9wNEQ RM8LbXilNJLYgF7gHq+XQNrm5RRUkUUquhwHgl2iZnQ
+M2gJqp+x1qQPmceCxq3Lqf2emmX5XqDjL52XU3oxeXg
+-> ssh-ed25519 3W3iQw K4RqKPgjar9PSJEIn8c8DsELHVnI/gHfFiZabp1DKUs
+NeexdE9TFDYINYt/Id4+J/lR9KGCdJzCjBbQfrzZb0s
+-> ssh-ed25519 iZo3tw pjBCbxmTuLDxaNlczLyteW8IYlKaVQKuBb9C1AX37kU
+lUUJMsCnrez0UNyOlLM0DN0WGB1LBlDB0Oz7UBz0wJY
+--- G/RYaaWqQvoi7frZ8sAYUP3wJCRNjzK6naen5yu1Cyo
+èjo+µ1ÚÔÞiß6;1ò“ÌsÑÿ*z4$Ú¿î×þßx„št¹nÕb‡¸·]½p yš›ÀL–ÜùœC92;Š—5È‹&¡GòÌÎÿMTÄ~è~NÅ¢HV

--- a/secrets/kuzea-github-token.age
+++ b/secrets/kuzea-github-token.age
@@ -1,0 +1,10 @@
+age-encryption.org/v1
+-> ssh-ed25519 Z9wNEQ zqyhNwJO/iMV/lIa74YCsRfkUfgUauq8u2S4rnFvUno
+lUWdRjYWyMZoS4ll+9Ol7EC2YbX2GgwgkeTCdjNBkoU
+-> ssh-ed25519 3W3iQw OCw0QzvS25Vj7khoMvUGJEPf4ApQwYys9wMh2RmUPUY
+bYklAXNJTWduT1QCz5ngFT3QWhOPRjwT7q7r1M7mxA8
+-> ssh-ed25519 iZo3tw /taBO+hrHTWoUXEWgm+ySpOVh+lPGQLv3Q6B3y5U3j4
+IA1DoVmC9hs5n/8g3c6ECRrnS5zEp92tE3gieeUw00U
+--- ymk9xBmsZ2ZKb7QfaaYSE0A4usbsCG52JJ9v2IjU/84
+kè£^adG@²‡P`Ÿž6ç²omiÌ˜½\Šše–
+ÎÄ^"HòÕpxb¡€É¤o:Kã­hø¤³Ë¶X/„ºqè(äm\ˆî_ÞÓñ¶ØŒ/ö“O3¸S#÷¿æøÀ³C±³Öe•#ýj±E	Ð’¿È>°ê"Ä=<§


### PR DESCRIPTION
## Summary
- Encrypted `kuzea-caldav-credentials.age` (iCloud CalDAV credentials for Kuzea)
- Encrypted `kuzea-github-token.age` (GitHub fine-grained PAT for nixos-config)
- Both encrypted to `clawKeys` (root-sancta-choir + sancta-claw + rpi5)

## Context
Follow-up to PR #284 — the secrets entries were added in `secrets.nix` but the actual `.age` files needed to be encrypted and committed separately.

## Post-merge
Rebuild sancta-claw:
```bash
ssh root@sancta-claw 'nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#sancta-claw'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)