### PR TITLE
Add Trivy security scanner to CI pipeline

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,61 @@
+name: Trivy Security Scan
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: read
+    security-events: write
+
+jobs:
+    trivy-scan:
+        name: Security Scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Run Trivy vulnerability scanner
+              uses: aquasecurity/trivy-action@master
+              with:
+                  scan-type: "fs"
+                  scan-ref: "."
+                  severity: "CRITICAL,HIGH"
+                  format: "table"
+                  exit-code: "1"
+
+            - name: Run Trivy misconfiguration scanner
+              uses: aquasecurity/trivy-action@master
+              with:
+                  scan-type: "config"
+                  scan-ref: "."
+                  severity: "CRITICAL,HIGH"
+                  format: "table"
+                  exit-code: "1"
+
+            - name: Run Trivy secret scanner
+              uses: aquasecurity/trivy-action@master
+              with:
+                  scan-type: "fs"
+                  scan-ref: "."
+                  scanners: "secret"
+                  format: "table"
+                  exit-code: "1"
+
+            - name: Upload Trivy SARIF results
+              if: always()
+              uses: aquasecurity/trivy-action@master
+              with:
+                  scan-type: "fs"
+                  scan-ref: "."
+                  severity: "CRITICAL,HIGH"
+                  format: "sarif"
+                  output: "trivy-results.sarif"
+
+            - name: Upload SARIF to GitHub Security
+              if: always()
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
## Summary
- Add dedicated Trivy security scanning workflow to CI
- Filesystem scan for dependency vulnerabilities (HIGH/CRITICAL)
- IaC/Nix misconfiguration scanning
- Secret detection (leaked keys, passwords, tokens)
- SARIF upload to GitHub Security tab for persistent tracking

Closes #282

## Test plan
- [ ] Trivy vulnerability scan runs without false positives
- [ ] Trivy config scan works on Nix files
- [ ] Secret scanner doesn't flag false positives
- [ ] SARIF results appear in GitHub Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)