### PR TITLE
feat(sancta-claw): increase swap from 2GB to 12GB

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -174,11 +174,11 @@ in
     sharedModules = [{ home.enableNixpkgsReleaseCheck = false; }];
   };
 
-  # ── Swap (2GB — prevents OOM during builds on CX33) ────────────────────
+  # ── Swap (12GB — prevents OOM during builds and heavy workloads on CX33) ────────────────────
   swapDevices = [
     {
       device = "/swapfile";
-      size = 2048;
+      size = 12288;
     }
   ];
 


### PR DESCRIPTION
## Summary
- Increase swapfile from 2GB to 12GB (total ~16GB with zram)
- Server was hitting 100% swap (5.8G/5.8G) with two CC agents running concurrent nix evaluations + whisper benchmarks
- SSH was timing out due to swap thrashing with only 12KiB swap free

## Test plan
- [x] Verified with temporary /swapfile2 on live server — immediate relief
- [ ] nixos-rebuild switch to make permanent

🤖 Generated with [Claude Code](https://claude.com/claude-code)