### PR TITLE
fix: move ConditionPathExists from [Service] to [Unit] section

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -208,6 +208,10 @@ in
       NPM_CONFIG_PREFIX = "/var/lib/openclaw/.npm-global";
     };
 
+    # ConditionPathExists prevents noisy restart loops if binary is missing
+    # (must be in [Unit], not [Service] — systemd ignores it in [Service])
+    unitConfig.ConditionPathExists = "/var/lib/openclaw/.npm-global/bin/openclaw";
+
     serviceConfig = {
       Type = "simple";
       User = "openclaw";
@@ -216,9 +220,6 @@ in
       # Inject TODOIST_API_KEY from agenix secret into the service environment.
       # File format: TODOIST_API_KEY=<token> (single line, no quotes needed).
       EnvironmentFile = config.age.secrets.kuzea-todoist-credentials.path;
-      # Binary installed manually: sudo -u openclaw npm install -g openclaw
-      # ConditionPathExists prevents noisy restart loops if binary is missing
-      ConditionPathExists = "/var/lib/openclaw/.npm-global/bin/openclaw";
       # Post-deploy setup (run once):
       #   sudo -u openclaw npm install -g openclaw
       #   sudo -u openclaw openclaw configure
@@ -258,14 +259,15 @@ in
     # PartOf propagates stop/restart of openclaw to this unit
     partOf = [ "openclaw.service" ];
 
+    # Skip if openclaw binary not installed (ConditionPathExists on openclaw.service
+    # causes it to be skipped, but a skipped unit still satisfies Requires=)
+    unitConfig.ConditionPathExists = "/var/lib/openclaw/.npm-global/bin/openclaw";
+
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
       # Two sequential 60s wait loops = 120s max; default 90s would kill us
       TimeoutStartSec = 150;
-      # Skip if openclaw binary not installed (ConditionPathExists on openclaw.service
-      # causes it to be skipped, but a skipped unit still satisfies Requires=)
-      ConditionPathExists = "/var/lib/openclaw/.npm-global/bin/openclaw";
       NoNewPrivileges = true;
     };
 


### PR DESCRIPTION
## Summary
- Move `ConditionPathExists` from `serviceConfig` (maps to `[Service]`) to `unitConfig` (maps to `[Unit]`) for both `openclaw.service` and `openclaw-tailscale-serve.service`
- systemd ignores `ConditionPathExists` in `[Service]` — it only works in `[Unit]`
- This was causing journal warnings (`Unknown key 'ConditionPathExists' in section [Service], ignoring`) and the condition was never evaluated

## Test plan
- [x] `nix flake check` passes
- [x] `nix fmt` clean
- [ ] Deploy to sancta-claw and verify no more `Unknown key` warnings in journal
- [ ] Verify service skips cleanly when binary is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)