### PR TITLE
feat(sancta-claw): add agent-browser for headless browser automation

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -304,6 +304,11 @@ in
       ProtectSystem = "strict";
       ProtectHome = true; # /var/lib/openclaw is not under /home
       PrivateDevices = true;
+      # /dev/shm is required by Chromium (renderer <-> browser IPC).
+      # PrivateDevices creates a minimal /dev without /dev/shm, so we bind it
+      # explicitly. The host's /dev/shm tmpfs is mounted read-write in the
+      # private namespace; no other devices are exposed.
+      BindPaths = [ "/dev/shm" ];
       ReadWritePaths = [ "/var/lib/openclaw" ];
       PrivateTmp = true;
     };


### PR DESCRIPTION
## What

Adds [agent-browser](https://github.com/vercel-labs/agent-browser) v0.14.0 to sancta-claw, enabling Kuzea to do real browser automation (Google Maps, JS-heavy sites, etc.).

## Architecture

- **Rust CLI** (`cli/`) — fast command dispatcher, communicates with daemon via Unix socket
- **Node.js daemon** — uses `playwright-core` for actual Chromium control
- **`AGENT_BROWSER_HOME`** — points to compiled daemon in Nix store (wrapped via `makeWrapper`)
- **`PLAYWRIGHT_BROWSERS_PATH`** — uses `pkgs.playwright-driver.browsers` from nixpkgs (no runtime download)

## Changes

- `hosts/sancta-claw/configuration.nix`: new `agentBrowser` let-binding with nested derivations
  - `daemonDrv`: pnpm build of the TypeScript daemon
  - `rustCli`: `rustPlatform.buildRustPackage` for the CLI binary
  - Final derivation: combines both, wraps with env vars
- Added `playwright-driver.browsers` to `environment.systemPackages` (pre-built Chromium)
- Added `agentBrowser` to openclaw service PATH

## Testing

All hashes verified by local build on sancta-claw:
```
agent-browser 0.14.0
```
Binary responds to `--version` and `--help` correctly.