### PR TITLE
fix(agent-browser): fix node_modules resolution and Chromium path

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -110,14 +110,12 @@ let
       };
     in
     let
-      # Locate headless_shell inside playwright-driver.browsers at eval time.
-      # AGENT_BROWSER_EXECUTABLE_PATH lets the daemon use this binary regardless
-      # of the playwright-core npm revision (avoids revision-mismatch errors).
-      chromiumDir = pkgs.lib.findFirst
-        (n: pkgs.lib.hasPrefix "chromium_headless_shell" n)
-        (throw "agent-browser: no chromium_headless_shell-* directory found in pkgs.playwright-driver.browsers; check nixpkgs playwright-driver packaging")
-        (builtins.attrNames (builtins.readDir (toString pkgs.playwright-driver.browsers)));
-      chromiumBin = "${pkgs.playwright-driver.browsers}/${chromiumDir}/chrome-linux/headless_shell";
+      # AGENT_BROWSER_EXECUTABLE_PATH bypasses playwright-core's revision check,
+      # allowing the nixpkgs-provided Chromium to be used even when the npm package
+      # revision differs. The revision is read from playwright-driver.browsersJSON
+      # (a pure Nix attrset, no IFD or directory scan at eval time).
+      chromiumRevision = pkgs.playwright-driver.browsersJSON."chromium-headless-shell".revision;
+      chromiumBin = "${pkgs.playwright-driver.browsers}/chromium_headless_shell-${chromiumRevision}/chrome-linux/headless_shell";
     in
     pkgs.stdenv.mkDerivation {
       pname = "agent-browser";


### PR DESCRIPTION
Follow-up to #304. Two runtime bugs discovered after rebuild and testing.

## Bug 1: node_modules symlinks broken by `cp -rL`

pnpm uses a virtual store: `node_modules/webdriverio -> .pnpm/webdriverio@x/...`

`cp -rL` dereferenced the symlink to a real directory, breaking Node.js transitive-dep resolution (e.g., `jszip` unreachable from webdriverio). Fix: `cp -r` to preserve pnpm virtual-store symlinks in both `daemonDrv` and the outer derivation.

## Bug 2: playwright-core revision mismatch

`nixpkgs playwright-driver.browsers` has `chromium_headless_shell-1169`, but `playwright-core@1.57.0` (npm, from agent-browser's lockfile) expects revision `1200`. Playwright refused to launch.

Fix: use `AGENT_BROWSER_EXECUTABLE_PATH` (read by the daemon at launch via `process.env`) to point directly at the nixpkgs `headless_shell` binary, bypassing the revision check. Path computed at Nix eval time via `builtins.readDir` on `playwright-driver.browsers`.

## Verified

Tested manually: `agent-browser open https://maps.google.com` → directions rendered correctly (Google Maps: 36 min by car, 27 min transit).