### PR TITLE
chore: update claude-code flake input to v2.1.55

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771632347,
-        "narHash": "sha256-kNm0YX9RUwf7GZaWQu2F71ccm4OUMz0xFkXn6mGPfps=",
+        "lastModified": 1771991289,
+        "narHash": "sha256-pqXDeMWpjerWCNAGV7rHJrfr+3pIqJYi4m+HC8mojn0=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "ec90f84b2ea21f6d2272e00d1becbc13030d1895",
+        "rev": "2b67a074abac37578e7b067a1f4405b1ba704b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates `claude-code` flake input from 2026-02-21 to 2026-02-25 (v2.1.55)

## Test plan
- [x] `nixos-rebuild build --flake .#rpi5-full` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)