### PR TITLE
fix(todoist): handle null due date in today filter

### DIFF
--- a/hosts/sancta-claw/kuzea/skills/todoist-natural-language/scripts/todoist.py
+++ b/hosts/sancta-claw/kuzea/skills/todoist-natural-language/scripts/todoist.py
@@ -91,7 +91,7 @@ def list_tasks(filter_str=None, project_id=None, label=None, priority=None, limi
         except Exception:
             now = datetime.now()
         today_str = now.strftime("%Y-%m-%d")
-        tasks = [t for t in tasks if t.get("due", {}).get("date") == today_str]
+        tasks = [t for t in tasks if (t.get("due") or {}).get("date") == today_str]
     
     # Client-side priority filter since API doesn't support it directly
     if priority:


### PR DESCRIPTION
## Summary
- Fix `AttributeError` when Todoist API returns `"due": null` for tasks without a due date
- Change `t.get("due", {}).get("date")` to `(t.get("due") or {}).get("date")` in the today filter (line 94)

## Root cause
`dict.get("due", {})` returns the default `{}` only when the key is **absent**. When the key exists with value `None` (as Todoist returns for tasks with no due date), `None` is returned, and the chained `.get("date")` raises `AttributeError`.

## Test plan
- [ ] Verify `todoist.py list --filter today` no longer crashes when tasks with `"due": null` are present
- [ ] Confirm tasks with valid due dates still filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)