### PR TITLE
feat(sancta-claw): declarative browser executablePath for openclaw

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -115,8 +115,8 @@ let
       };
     in
     # AGENT_BROWSER_EXECUTABLE_PATH bypasses playwright-core's revision check,
-    # allowing the nixpkgs-provided Chromium to be used even when the npm package
-    # revision differs. chromiumBin is defined in the outer let block.
+      # allowing the nixpkgs-provided Chromium to be used even when the npm package
+      # revision differs. chromiumBin is defined in the outer let block.
     pkgs.stdenv.mkDerivation {
       pname = "agent-browser";
       version = "0.14.0";
@@ -143,37 +143,37 @@ let
   # Declarative browser config for OpenClaw: inject Chromium path (shared
   # chromiumBin binding above) into openclaw.json at service start.
   openclawBrowserConfigScript = pkgs.writeShellScript "openclaw-browser-config" ''
-    ${pkgs.python3}/bin/python3 - <<'PYEOF'
-import json, os
+        ${pkgs.python3}/bin/python3 - <<'PYEOF'
+    import json, os
 
-config_path = "/var/lib/openclaw/.openclaw/openclaw.json"
+    config_path = "/var/lib/openclaw/.openclaw/openclaw.json"
 
-if os.path.exists(config_path):
-    try:
-        with open(config_path) as f:
-            config = json.load(f)
-    except (json.JSONDecodeError, OSError):
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            config = {}
+    else:
         config = {}
-else:
-    config = {}
 
-config["browser"] = {
-    "enabled": True,
-    "executablePath": "${chromiumBin}",
-    "headless": True,
-    # noSandbox is required: the openclaw user lacks CAP_SYS_ADMIN for
-    # Chromium's user-namespace sandbox, and the setuid helper is not
-    # available in the Nix store.  Defense-in-depth is provided by systemd
-    # hardening (NoNewPrivileges, ProtectSystem=strict, PrivateDevices).
-    "noSandbox": True,
-}
+    config["browser"] = {
+        "enabled": True,
+        "executablePath": "${chromiumBin}",
+        "headless": True,
+        # noSandbox is required: the openclaw user lacks CAP_SYS_ADMIN for
+        # Chromium's user-namespace sandbox, and the setuid helper is not
+        # available in the Nix store.  Defense-in-depth is provided by systemd
+        # hardening (NoNewPrivileges, ProtectSystem=strict, PrivateDevices).
+        "noSandbox": True,
+    }
 
-tmp = config_path + ".tmp"
-with open(tmp, "w") as f:
-    json.dump(config, f, indent=2)
-    f.write("\n")
-os.replace(tmp, config_path)
-PYEOF
+    tmp = config_path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, config_path)
+    PYEOF
   '';
 in
 {


### PR DESCRIPTION
## Summary
- Add `ExecStartPre` script to `openclaw` systemd service that computes chromium headless shell path from `pkgs.playwright-driver.browsersJSON` at build time and merges browser config into `openclaw.json` before service start
- Browser config: `enabled=true`, `executablePath` from playwright-driver, `headless=true`, `noSandbox=true`
- Replaces manual `/var/lib/openclaw/.openclaw/openclaw.json` browser config that was lost on rebuilds

## How it works
1. Nix evaluates `playwright-driver.browsersJSON."chromium-headless-shell".revision` at build time
2. Constructs the full store path: `${playwright-driver.browsers}/chromium_headless_shell-${rev}/chrome-linux/headless_shell`
3. `ExecStartPre` runs a Python script (as `openclaw` user) that reads existing `openclaw.json`, merges the `browser` section, and writes atomically via `os.replace`
4. Idempotent: re-running produces identical output; other config keys are preserved

## Test plan
- [ ] `nix fmt -- --check .` passes (CI)
- [ ] `nix flake check` passes (CI)
- [ ] After deploy: verify `openclaw.json` contains correct `browser.executablePath` pointing to nix store
- [ ] After deploy: verify openclaw service starts successfully with browser automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)