### PR TITLE
fix: install agenix CLI in system PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,8 +101,8 @@
             tsidp.nixosModules.default
             agenix.nixosModules.default
             ({ pkgs, ... }: {
-              environment.systemPackages = with pkgs; [
-                agenix
+              environment.systemPackages = [
+                agenix.packages.${pkgs.system}.default
               ];
             })
           ];
@@ -124,8 +124,8 @@
             home-manager.nixosModules.home-manager
             agenix.nixosModules.default
             ({ pkgs, ... }: {
-              environment.systemPackages = with pkgs; [
-                agenix
+              environment.systemPackages = [
+                agenix.packages.${pkgs.system}.default
               ];
             })
           ];
@@ -152,9 +152,9 @@
             home-manager.nixosModules.home-manager
             vscode-server.nixosModules.default
             agenix.nixosModules.default
-            ({ pkgs, lib, ... }: {
-              environment.systemPackages = with pkgs; [
-                agenix
+            ({ pkgs, ... }: {
+              environment.systemPackages = [
+                agenix.packages.${pkgs.system}.default
               ];
             })
           ];
@@ -182,9 +182,9 @@
             home-manager.nixosModules.home-manager
             vscode-server.nixosModules.default
             agenix.nixosModules.default
-            ({ pkgs, lib, ... }: {
-              environment.systemPackages = with pkgs; [
-                agenix
+            ({ pkgs, ... }: {
+              environment.systemPackages = [
+                agenix.packages.${pkgs.system}.default
               ];
             })
           ];


### PR DESCRIPTION
## Summary
- Fix `agenix` CLI not being available in PATH on any host
- `with pkgs; [ agenix ]` resolved to the flake input attrset (not a derivation) since nixpkgs has no `agenix` package — the Nix `with` scoping fell through to the outer scope
- Replace with `agenix.packages.${pkgs.system}.default` to reference the actual CLI derivation from the agenix flake

## Verification
- `which agenix` currently returns "not found" despite being in `systemPackages`
- After fix: `agenix` binary confirmed present in new system closure (`/nix/store/.../sw/bin/agenix`)
- `nixos-rebuild build --flake .#rpi5-full` succeeds

## Test plan
- [ ] CI passes (`nix flake check`)
- [ ] After deploy: `which agenix` returns a valid path
- [ ] `agenix --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)