### PR TITLE
fix: relax tailscale grep pattern in smoke test

### DIFF
--- a/hosts/sancta-claw/smoke-test.nix
+++ b/hosts/sancta-claw/smoke-test.nix
@@ -39,7 +39,7 @@ let
       check "systemd: sshd running" systemctl is-active --quiet sshd
 
       # Tailscale connectivity
-      check "tailscale: node online" bash -c 'tailscale status --json | grep -q "\"BackendState\":\"Running\""'
+      check "tailscale: node online" bash -c 'tailscale status --json | grep -q "BackendState.*Running"'
 
       # Agenix secrets decrypted
       check "agenix: secrets present (>=5)" test "$(find /run/agenix/ -type f 2>/dev/null | wc -l)" -ge 5


### PR DESCRIPTION
## Summary
- Fix smoke test `tailscale: node online` check that always fails
- The JSON output has a space after `:` (`"BackendState": "Running"`) but grep expected no space
- Use flexible regex `BackendState.*Running` instead

## Test plan
- [ ] Run `/etc/sancta-claw/smoke-test.sh` on sancta-claw — should pass 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)