### PR TITLE
fix: use DHCP networking for DR portability

### DIFF
--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -246,32 +246,11 @@ in
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 
-  # ── Networking (inline — Hetzner CX33, nbg1-dc3) ───────────────────────
+  # ── Networking (Hetzner Cloud — DHCP for DR portability) ────────────────
   networking.hostName = "sancta-claw";
-  networking.useDHCP = false;
+  networking.useDHCP = true;
   networking.usePredictableInterfaceNames = lib.mkForce false;
-  networking.dhcpcd.enable = false;
   networking.nameservers = [ "8.8.8.8" "185.12.64.1" "185.12.64.2" ];
-
-  networking.interfaces.eth0 = {
-    useDHCP = false;
-    ipv4.addresses = [{
-      address = "46.225.168.24";
-      prefixLength = 32;
-    }];
-    # IPv6: link-local auto-configured by kernel from MAC; no global IPv6 from Hetzner
-    ipv4.routes = [{ address = "172.31.1.1"; prefixLength = 32; }];
-  };
-
-  networking.defaultGateway = {
-    address = "172.31.1.1";
-    interface = "eth0";
-  };
-
-  # MAC address binding for Hetzner Cloud
-  services.udev.extraRules = ''
-    ATTR{address}=="92:00:07:40:d6:20", NAME="eth0"
-  '';
 
   # SSH
   services.openssh = {


### PR DESCRIPTION
## Summary
- Replace static IP/MAC/gateway config with DHCP on sancta-claw
- Hetzner Cloud DHCP assigns the correct IP automatically on any server
- Enables nixos-anywhere to work on fresh DR servers without config changes

## Context
During E2E disaster recovery testing (#335), nixos-anywhere installed NixOS successfully but the test VPS was unreachable because networking was hardcoded to sancta-claw's specific IP (46.225.168.24), MAC address, and gateway.

## Test plan
- [ ] CI passes (nix flake check, build)
- [ ] Deploy to sancta-claw and verify networking still works
- [ ] Re-run nixos-anywhere on test Hetzner VPS to verify DR works

🤖 Generated with [Claude Code](https://claude.com/claude-code)