### PR TITLE
Fix n8n community packages login race condition

### DIFF
--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -925,21 +925,31 @@ in
           fi
           sleep 1
         done
-        sleep 5  # Extra delay for full initialization
 
-        # Login to get session cookie
+        # Login with retries — REST API routes register after healthz
         echo "Authenticating with n8n..."
-        LOGIN_RESPONSE=$(curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" \
-          -X POST \
-          -H "Content-Type: application/json" \
-          -d "{\"emailOrLdapLoginId\":\"admin@localhost.com\",\"password\":\"$ADMIN_PASSWORD\"}" \
-          "$N8N_URL/rest/login" 2>&1)
+        login_attempts=0
+        max_login_attempts=30
+        while true; do
+          LOGIN_RESPONSE=$(curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"emailOrLdapLoginId\":\"admin@localhost.com\",\"password\":\"$ADMIN_PASSWORD\"}" \
+            "$N8N_URL/rest/login" 2>&1)
 
-        if ! echo "$LOGIN_RESPONSE" | jq -e '.data.id' >/dev/null 2>&1; then
-          echo "ERROR: Failed to authenticate with n8n"
-          echo "Response: $LOGIN_RESPONSE"
-          exit 1
-        fi
+          if echo "$LOGIN_RESPONSE" | jq -e '.data.id' >/dev/null 2>&1; then
+            break
+          fi
+
+          login_attempts=$((login_attempts + 1))
+          if [ $login_attempts -ge $max_login_attempts ]; then
+            echo "ERROR: Failed to authenticate with n8n after $max_login_attempts attempts"
+            echo "Response: $LOGIN_RESPONSE"
+            exit 1
+          fi
+          echo "REST API not ready yet, retrying in 2s... (attempt $login_attempts/$max_login_attempts)"
+          sleep 2
+        done
         echo "Authentication successful"
 
         # Get currently installed packages


### PR DESCRIPTION
## Summary
- Replace fragile `sleep 5` delay with a retry loop (up to 30 attempts, 2s apart) for the REST API login
- n8n's `/healthz` endpoint comes up before REST routes like `/rest/login` are registered, causing intermittent `Cannot POST /rest/login` failures on every deploy

## Root cause
The community packages service waits for `/healthz`, then sleeps 5 seconds before attempting login. But n8n's REST API route registration happens asynchronously after the health endpoint is ready — sometimes 5 seconds isn't enough, especially during restarts.

## Test plan
- [x] `nixos-rebuild build --flake .#rpi5-full` succeeds
- [ ] Deploy and verify `n8n-community-packages.service` succeeds without retry messages under normal conditions
- [ ] Verify it retries and recovers when n8n is slow to register REST routes

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)