### PR TITLE
fix(nixframe): survive power surges by auto-detecting HDMI output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Custom NixOS modules wrap upstream services with Tailscale integration and ageni
 |--------|------|-------------|
 | `services.open-webui-tailscale` | 8080 | AI gateway (OpenRouter + Tavily Search) |
 | `services.n8n-tailscale` | 5678 | Workflow automation with execution pruning |
-| `services.nixframe` | VT 7 / HDMI-A-2 | Digital photo frame with n8n upload |
+| `services.nixframe` | VT 7 / HDMI | Digital photo frame with n8n upload |
 | `services.gatus-tailscale` | 3001 | Declarative status monitoring |
 | `services.qdrant-tailscale` | 6333 | Vector database for RAG on ARM |
 | `services.openclaw` | - | AI programming partner (Claude Code, file-based inbox) |

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -30,7 +30,7 @@
     ../../modules/services/n8n.nix
     ../../modules/services/qdrant.nix # External vector DB for RAG on ARM
     ../../modules/services/gatus.nix # Declarative status monitoring
-    ../../modules/services/nixframe.nix # Digital photo frame on HDMI-A-2
+    ../../modules/services/nixframe.nix # Digital photo frame (auto-detects HDMI output)
     ../../modules/services/backup-pull.nix # Pull backups from sancta-claw
   ];
 
@@ -501,7 +501,7 @@
   };
 
   # ──────────────────────────────────────────────────────────────
-  # NixFrame — Digital photo frame on HDMI-A-2
+  # NixFrame — Digital photo frame (auto-detects HDMI output)
   # ──────────────────────────────────────────────────────────────
   # Displays rotating slideshow with clock sidebar on the TV.
   # Upload photos: https://rpi5.tail4249a9.ts.net:5678/webhook/nixframe-ui

--- a/modules/services/nixframe.nix
+++ b/modules/services/nixframe.nix
@@ -1,6 +1,6 @@
 # NixFrame — Digital Photo Frame for Raspberry Pi 5
 #
-# Displays a rotating slideshow on HDMI-A-2 with a clock/date sidebar.
+# Displays a rotating slideshow with a clock/date sidebar on any connected HDMI output.
 # Photos are uploaded via n8n webhook (mobile-friendly web form).
 #
 # Components:
@@ -9,12 +9,12 @@
 #
 # Display isolation:
 #   VT 1: root auto-login + btop (plain console, output depends on fbcon)
-#   VT 7: nixframe auto-login + Sway (configured to target HDMI-A-2 only)
+#   VT 7: nixframe auto-login + Sway (targets all connected outputs by default)
 #   Sway takes GPU control when VT 7 is active, returns it on VT switch.
 #
 # Usage in host configuration:
 #   services.nixframe.enable = true;
-#   # All defaults match RPi5 + Samsung 4K TV on HDMI-A-2
+#   # All defaults match RPi5 + Samsung 4K TV (auto-detects HDMI port)
 #
 # Access upload form via Tailscale HTTPS:
 #   https://rpi5.tail4249a9.ts.net:5678/webhook/nixframe-ui
@@ -896,7 +896,7 @@ let
 
   # Generated Sway config
   swayConfig = pkgs.writeText "sway-nixframe.conf" ''
-    # Target HDMI-A-2 for photo frame display
+    # Target all outputs — resilient to HDMI port changes after power surges
     output ${cfg.output} {
       resolution ${cfg.resolution}
       bg #000000 solid_color
@@ -940,8 +940,8 @@ in
 
     output = mkOption {
       type = types.str;
-      default = "HDMI-A-2";
-      description = "Sway output name for the display.";
+      default = "*";
+      description = "Sway output name for the display (* = all connected outputs).";
     };
 
     resolution = mkOption {
@@ -1060,10 +1060,26 @@ in
     # ──────────────────────────────────────────────────────────────
     systemd.services."getty@tty${toString cfg.vt}" = {
       overrideStrategy = "asDropin";
+      wantedBy = [ "getty.target" ];
       serviceConfig.ExecStart = [
         "" # Clear the default ExecStart
         "@${pkgs.util-linux}/sbin/agetty agetty --autologin nixframe --noclear %I $TERM"
       ];
+    };
+
+    # Switch to VT 7 at boot so Sway can acquire the DRM session.
+    # Without this, VT 1 (root/btop) stays active and Sway times out
+    # with "Timeout waiting session to become active" because the
+    # nixframe user cannot open /dev/tty0 to switch VTs itself.
+    systemd.services.nixframe-activate-vt = {
+      description = "Activate NixFrame display VT";
+      after = [ "getty@tty${toString cfg.vt}.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.kbd}/bin/chvt ${toString cfg.vt}";
+      };
     };
 
     # Auto-start Sway when nixframe logs into tty7


### PR DESCRIPTION
## Summary

- **HDMI output wildcard**: Changed default from `HDMI-A-2` to `*` so sway targets whichever HDMI port the TV is connected to, resilient to DRM connector remapping after power surges
- **getty@tty7 boot start**: Added `wantedBy = ["getty.target"]` so the nixframe auto-login starts reliably at boot (previously required manual `systemctl start`)
- **VT activation service**: Added `nixframe-activate-vt` systemd oneshot that runs `chvt 7` at boot, allowing sway's libseat to acquire the DRM session without `/dev/tty0` permissions

## Test plan

- [x] `nixos-rebuild switch` deployed successfully
- [x] Sway running on HDMI-A-1 at 3840x2160 (Samsung TV detected)
- [x] All components active: imv slideshow, eww sidebar, weather bar, calendar
- [x] Screenshot verified display is fully functional
- [ ] Verify recovery after reboot (`sudo reboot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)