### PR TITLE
fix(ci): add rpi5-full evaluation to CI pipeline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -157,3 +157,6 @@ jobs:
 
             - name: Evaluate rpi5 (aarch64-linux)
               run: nix eval .#nixosConfigurations.rpi5.config.system.build.toplevel.drvPath
+
+            - name: Evaluate rpi5-full (aarch64-linux)
+              run: nix eval .#nixosConfigurations.rpi5-full.config.system.build.toplevel.drvPath

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -33,11 +33,17 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-platforms = aarch64-linux
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v15
         with:
           name: nix-community
+
+      - name: Set up QEMU for aarch64 emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Get current flake.lock hash
         id: before
@@ -86,14 +92,16 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Verify flake still builds
+      - name: Verify configurations still evaluate
         if: steps.changes.outputs.changed == 'true'
         run: |
           echo "Checking flake validity..."
           nix flake check --all-systems
 
-          echo "Evaluating sancta-choir configuration..."
+          echo "Evaluating configurations..."
           nix eval .#nixosConfigurations.sancta-choir.config.system.build.toplevel.drvPath
+          nix eval .#nixosConfigurations.sancta-claw.config.system.build.toplevel.drvPath
+          nix eval .#nixosConfigurations.rpi5-full.config.system.build.toplevel.drvPath
 
       # Nightly: commit directly to main (security patches, already validated above)
       - name: Push directly to main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Current secrets: `openrouter-api-key`, `openai-api-key`, `tavily-api-key`, `n8n-
 
 ## CI/CD
 
-GitHub Actions on push/PR: `nix flake check`, build sancta-choir + sancta-claw (x86_64), evaluate rpi5 (aarch64 minimal), format check. **Note:** `rpi5-full` is NOT verified in CI — validate locally with `nixos-rebuild build --flake .#rpi5-full`. Main branch protected - use PRs.
+GitHub Actions on push/PR: `nix flake check`, build sancta-choir + sancta-claw (x86_64), evaluate rpi5 + rpi5-full (aarch64), format check. Main branch protected - use PRs.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

- Add `nix eval` for `rpi5-full` in `check.yml` (evaluate-aarch64 job)
- Add QEMU setup + `rpi5-full` and `sancta-claw` eval to `flake-update.yml`
- Update `CLAUDE.md` to reflect new CI coverage

Closes #231

## Details

`rpi5-full` is the only actively deployed configuration but had zero CI validation. This adds evaluation-only checks (not full builds) which catch config errors without triggering the QEMU build incompatibility documented in `flake.nix`.

## Test plan

- [ ] `evaluate-aarch64` CI job passes with the new `rpi5-full` eval step
- [ ] No regression in other CI jobs
- [ ] After merge: trigger `flake-update.yml` via `workflow_dispatch` to verify QEMU + rpi5-full eval works there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)