### PR TITLE
fix(ci): SHA-pin all GitHub Actions to prevent supply chain attacks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,26 +6,29 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     check:
         name: Check Flake & Formatting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Install Nix
-              uses: cachix/install-nix-action@v30
+              uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
               with:
                   extra_nix_config: |
                       experimental-features = nix-command flakes
 
             - name: Setup Cachix
-              uses: cachix/cachix-action@v15
+              uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
               with:
                   name: nix-community
 
             - name: Cache Nix Store
-              uses: nix-community/cache-nix-action@v6
+              uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
               with:
                   # Cache key based on flake.lock - changes when dependencies update
                   primary-key: nix-${{ runner.os }}-check-${{ hashFiles('flake.lock') }}
@@ -57,21 +60,21 @@ jobs:
                   sudo docker image prune --all --force
                   df -h
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Install Nix
-              uses: cachix/install-nix-action@v30
+              uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
               with:
                   extra_nix_config: |
                       experimental-features = nix-command flakes
 
             - name: Setup Cachix
-              uses: cachix/cachix-action@v15
+              uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
               with:
                   name: nix-community
 
             - name: Cache Nix Store
-              uses: nix-community/cache-nix-action@v6
+              uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
               with:
                   primary-key: nix-${{ runner.os }}-build-x86-${{ hashFiles('flake.lock') }}
                   restore-prefixes-all-matches: |
@@ -94,21 +97,21 @@ jobs:
             matrix:
                 script: [install, deploy, bootstrap]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Install Nix
-              uses: cachix/install-nix-action@v30
+              uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
               with:
                   extra_nix_config: |
                       experimental-features = nix-command flakes
 
             - name: Setup Cachix
-              uses: cachix/cachix-action@v15
+              uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
               with:
                   name: nix-community
 
             - name: Cache Nix Store
-              uses: nix-community/cache-nix-action@v6
+              uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
               with:
                   primary-key: nix-${{ runner.os }}-scripts-${{ matrix.script }}-${{ hashFiles('flake.lock') }}
                   restore-prefixes-all-matches: |
@@ -126,22 +129,22 @@ jobs:
         runs-on: ubuntu-latest
         needs: check
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Install Nix
-              uses: cachix/install-nix-action@v30
+              uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
               with:
                   extra_nix_config: |
                       experimental-features = nix-command flakes
                       extra-platforms = aarch64-linux
 
             - name: Setup Cachix
-              uses: cachix/cachix-action@v15
+              uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
               with:
                   name: nix-community
 
             - name: Cache Nix Store
-              uses: nix-community/cache-nix-action@v6
+              uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
               with:
                   primary-key: nix-${{ runner.os }}-aarch64-${{ hashFiles('flake.lock') }}
                   restore-prefixes-all-matches: |
@@ -151,7 +154,7 @@ jobs:
                   gc-max-store-size: 5G
 
             - name: Set up QEMU for aarch64 emulation
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
               with:
                   platforms: arm64
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -24,24 +24,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
             extra-platforms = aarch64-linux
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: nix-community
 
       - name: Set up QEMU for aarch64 emulation
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm64
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true' && steps.scope.outputs.nightly == 'false'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(deps): update flake inputs"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,12 +19,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Triage issue with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Cache pip downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,10 +15,10 @@ jobs:
         name: Security Scan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Run Trivy vulnerability scanner
-              uses: aquasecurity/trivy-action@master
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
               with:
                   scan-type: "fs"
                   scan-ref: "."
@@ -27,7 +27,7 @@ jobs:
                   exit-code: "1"
 
             - name: Run Trivy misconfiguration scanner
-              uses: aquasecurity/trivy-action@master
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
               with:
                   scan-type: "config"
                   scan-ref: "."
@@ -36,7 +36,7 @@ jobs:
                   exit-code: "1"
 
             - name: Run Trivy secret scanner
-              uses: aquasecurity/trivy-action@master
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
               with:
                   scan-type: "fs"
                   scan-ref: "."
@@ -46,7 +46,7 @@ jobs:
 
             - name: Upload Trivy SARIF results
               if: always()
-              uses: aquasecurity/trivy-action@master
+              uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
               with:
                   scan-type: "fs"
                   scan-ref: "."
@@ -56,6 +56,6 @@ jobs:
 
             - name: Upload SARIF to GitHub Security
               if: always()
-              uses: github/codeql-action/upload-sarif@v3
+              uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
               with:
                   sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
## Summary

- **SHA-pin all 11 unique GitHub Actions** across 7 workflows (was only `auto-approve-sancta-claw.yml`)
- **Add `permissions: contents: read`** to `check.yml` (previously inherited defaults with write on push)
- **Fix critical `trivy-action@master`** → pinned to release `v0.35.0` SHA

Mutable tags like `@v4` can be silently replaced with malicious code, as seen in the [tj-actions/changed-files supply chain attack](https://thehackernews.com/2025/03/github-action-compromise-puts-cicd.html). SHA pinning makes action references immutable.

### Actions pinned
| Action | Version | Workflows |
|--------|---------|-----------|
| `actions/checkout` | v4 | 7 |
| `cachix/install-nix-action` | v30 | 3 |
| `cachix/cachix-action` | v15 | 3 |
| `nix-community/cache-nix-action` | v6 | 1 |
| `docker/setup-qemu-action` | v3 | 2 |
| `anthropics/claude-code-action` | v1 | 3 |
| `aquasecurity/trivy-action` | v0.35.0 | 1 |
| `github/codeql-action/upload-sarif` | v3 | 1 |
| `actions/setup-python` | v5 | 1 |
| `actions/cache` | v4 | 1 |
| `peter-evans/create-pull-request` | v6 | 1 |

### Not changed
- `auto-approve-sancta-claw.yml` — already fully SHA-pinned
- `id-token: write` permissions — required by claude-code-action for OIDC
- Workflow logic, triggers, or secrets — hardening only

## Test plan
- [ ] `check` workflow passes (triggers on this PR)
- [ ] `trivy` workflow passes (triggers on this PR)
- [ ] `python-tests` workflow passes (triggers on this PR if paths match)
- [ ] `claude-code-review` workflow passes (triggers on this PR)
- [ ] After merge, verify nightly `flake-update` run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)