### PR TITLE
fix(security): remove claude-yolo user with weak password

### DIFF
--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -156,13 +156,6 @@
     initialPassword = "nixos";
   };
 
-  # Claude YOLO mode user (runs claude --dangerously-skip-permissions)
-  users.users.claude-yolo = {
-    isNormalUser = true;
-    extraGroups = [ "wheel" ];
-    initialPassword = "yolo";
-    description = "Claude Code YOLO mode user";
-  };
 
   # Allow wheel group to sudo without password initially
   security.sudo.wheelNeedsPassword = false;


### PR DESCRIPTION
## Summary

- Remove `claude-yolo` user from rpi5 configuration
- User had `initialPassword = "yolo"` + `wheel` group + passwordless sudo
- Unused in practice — Claude Code runs as whatever user invokes it

Flagged as **MEDIUM** severity by `nix-security-reviewer` agent scan: trivial root access if any Tailscale node is compromised.

## Test plan
- [ ] CI passes (flake check, builds, evaluate aarch64)
- [ ] After deploy, `id claude-yolo` returns "no such user"

🤖 Generated with [Claude Code](https://claude.com/claude-code)