### PR TITLE
fix(sancta-choir): authorize rpi5 key to replace manual authorized_keys

### DIFF
--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -114,6 +114,7 @@
   # SSH authorized keys for remote access
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPw5RFrFfZQUWlyfGSU1Q8BlEHnvIdBtcnCn+uYtEzal nixos-sancta-choir"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL2btaYomBlcKG+snrIrBuTXcEaBKEGQoAaF59YWwkal nixos@rpi5"
   ];
 
   # Fresh install — NixOS 25.05


### PR DESCRIPTION
## Summary
Add rpi5's SSH key to sancta-choir's declaratively-managed authorized keys, matching the pattern in sancta-claw. This lets us clean up the /root/.ssh/authorized_keys file that was manually injected via rescue mode during the Open-WebUI deployment.

## Test plan
- [x] \`nix flake check\` (will run in CI)
- [ ] Deploy and remove manual file: \`rm /root/.ssh/authorized_keys\` on sancta-choir
- [ ] Verify SSH from rpi5 still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)