### PR TITLE
feat(sancta-claw): migrate OpenClaw to free+ZDR OpenRouter ladder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+
+# ralphex scratch state (per-plan reconnaissance, progress logs, worktrees)
+.ralphex/

--- a/flake.nix
+++ b/flake.nix
@@ -270,6 +270,11 @@
           module-eval = import ./tests/module-eval.nix {
             inherit pkgs nixpkgs self;
           };
+
+          # End-to-end ZDR proxy test: boots a VM with the proxy + a stub
+          # OpenRouter, verifies provider.zdr=true is injected on the wire
+          # and non-ZDR models are rejected before reaching the upstream.
+          openclaw-zdr-proxy = pkgs.testers.nixosTest (import ./tests/openclaw-zdr-proxy.nix { inherit pkgs; });
         };
 
       # Apps - makes packages runnable with `nix run`

--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -1,4 +1,5 @@
-{ lib
+{ config
+, lib
 , self
 , ...
 }:
@@ -67,7 +68,16 @@
       kuzea-tavily-api-key = kuzeaSecret "kuzea-tavily-api-key";
       # OpenAI API key for memory embeddings (semantic recall)
       openai-api-key = kuzeaSecret "openai-api-key";
+      # OpenRouter API key — drives the ZDR proxy (sancta-claw only consumer
+      # on this host); also used by n8n on rpi5 (raw key format, kept that way).
+      openrouter-api-key = kuzeaSecret "openrouter-api-key";
     };
+
+  # ── OpenClaw ZDR proxy (local OpenRouter sidecar) ──────────────────────
+  services.openclaw-zdr-proxy = {
+    enable = true;
+    apiKeyFile = config.age.secrets.openrouter-api-key.path;
+  };
 
   # ── Home Manager (scaffolding — required by root.nix, no user configs yet) ──
   home-manager = {

--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -20,6 +20,7 @@
     ../../modules/users/root.nix
     ../../modules/services/claude.nix
     ../../modules/services/tailscale.nix
+    ../../modules/services/openclaw-zdr-proxy.nix
     ../../modules/system/ssh-hardened.nix
   ];
 

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -202,14 +202,10 @@ let
     # Drop legacy anthropic/* and claude-cli/* entries left behind by
     # pre-migration runs. The pre-migration Anthropic-via-Pro state is
     # itself broken (third-party Pro auth rejection — the reason for
-    # this migration), so there is no rollback canary value.
-    for legacy in (
-        "anthropic/claude-opus-4-6",
-        "anthropic/claude-sonnet-4-6",
-    ):
-        models.pop(legacy, None)
+    # this migration), so there is no rollback canary value. Prefix
+    # sweep covers any future model variants under either namespace.
     for key in list(models):
-        if key.startswith("claude-cli/"):
+        if key.startswith(("anthropic/", "claude-cli/")):
             models.pop(key, None)
 
     # Register the three rungs as empty entries — baseUrl is provider-level

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -142,9 +142,13 @@ let
       '';
     };
 
-  # Declarative browser config for OpenClaw: inject Chromium path (shared
-  # chromiumBin binding above) into openclaw.json at service start.
-  openclawBrowserConfigScript = pkgs.writeShellScript "openclaw-browser-config" ''
+  # Declarative browser + model config for OpenClaw, idempotent on every
+  # `systemctl start openclaw`. Reads the on-disk openclaw.json (or starts
+  # empty), merges the templated fields, atomic-replaces.
+  #
+  # Body is extracted to a let-binding so the module-eval test can grep
+  # for required substrings without IFD (see system.build.* below).
+  openclawBrowserConfigBody = ''
         ${pkgs.python3}/bin/python3 - <<'PYEOF'
     import json, os
 
@@ -171,19 +175,53 @@ let
         "noSandbox": True,
     }
 
-    # Ensure both sonnet and opus are in the allowed-models list so Kuzea
-    # can switch to opus via /model or session_status without a manual edit.
-    # Uses anthropic/ prefix with API key auth (claude-cli/ backend was removed
-    # in OpenClaw 2026.4.x — Anthropic requires standard API keys now).
+    # Provider-level override: route every openrouter/* model through the
+    # local ZDR proxy on 127.0.0.1:5780. The proxy injects provider.zdr=true
+    # and rejects any model not on the OpenRouter ZDR allow-list. Auth is
+    # supplied by the openrouter:zdr-proxy entry in auth-profiles.json
+    # (separate ExecStartPre), not by an env-var marker here.
+    models_root = config.setdefault("models", {})
+    providers = models_root.setdefault("providers", {})
+    openrouter_provider = providers.setdefault("openrouter", {})
+    openrouter_provider["baseUrl"] = "http://127.0.0.1:5780/v1"
+
+    # Free + ZDR ladder, all picked from /api/v1/endpoints/zdr.
+    # Primary: qwen3-coder (Venice, 262K, coder-tuned).
+    # Fallbacks isolate provider outages: glm-4.5-air (Z.AI, 131K)
+    # then qwen3-next-80b (Venice, 262K, general).
     agents = config.setdefault("agents", {})
     defaults = agents.setdefault("defaults", {})
     models = defaults.setdefault("models", {})
     model = defaults.setdefault("model", {})
-    model["primary"] = "anthropic/claude-opus-4-6"
-    models.setdefault("anthropic/claude-sonnet-4-6", {})
-    models.setdefault("anthropic/claude-opus-4-6", {})
+    model["primary"] = "qwen/qwen3-coder:free"
+    model["fallbacks"] = [
+        "z-ai/glm-4.5-air:free",
+        "qwen/qwen3-next-80b-a3b-instruct:free",
+    ]
 
-    # Compaction: preserve 4 recent turns so Kuzea keeps conversational
+    # Drop legacy anthropic/* and claude-cli/* entries left behind by
+    # pre-migration runs. The pre-migration Anthropic-via-Pro state is
+    # itself broken (third-party Pro auth rejection — the reason for
+    # this migration), so there is no rollback canary value.
+    for legacy in (
+        "anthropic/claude-opus-4-6",
+        "anthropic/claude-sonnet-4-6",
+    ):
+        models.pop(legacy, None)
+    for key in list(models):
+        if key.startswith("claude-cli/"):
+            models.pop(key, None)
+
+    # Register the three rungs as empty entries — baseUrl is provider-level
+    # above; auth flows from auth-profiles.json keyed by provider.
+    for rung in (
+        "qwen/qwen3-coder:free",
+        "z-ai/glm-4.5-air:free",
+        "qwen/qwen3-next-80b-a3b-instruct:free",
+    ):
+        models.setdefault(rung, {})
+
+    # Compaction: preserve 8 recent turns so Kuzea keeps conversational
     # context after auto-compaction instead of losing the thread.
     compaction = defaults.setdefault("compaction", {})
     compaction["mode"] = "safeguard"
@@ -209,8 +247,15 @@ let
     os.replace(tmp, config_path)
     PYEOF
   '';
+  openclawBrowserConfigScript = pkgs.writeShellScript "openclaw-browser-config" openclawBrowserConfigBody;
 in
 {
+  # Expose the rendered config-injection script body so the module-eval
+  # test can grep for required substrings (model ladder + proxy URL)
+  # without IFD. system.build accepts arbitrary values (lazyAttrsOf
+  # types.unspecified), so a plain string lives here cleanly.
+  system.build.openclawBrowserConfigBody = openclawBrowserConfigBody;
+
   # Build tools for OpenClaw npm native compilation (llama.cpp, etc.)
   # Kept permanently for npm update -g openclaw recompilation
   environment.systemPackages = with pkgs; [
@@ -300,6 +345,27 @@ in
           ${pkgs.jq}/bin/jq --arg key "$KEY" \
             '.profiles["openai:manual"] = {"type": "token", "provider": "openai", "token": $key}' \
             "$AUTH_FILE" > "$AUTH_FILE.tmp" && mv "$AUTH_FILE.tmp" "$AUTH_FILE"
+        '')
+        (pkgs.writeShellScript "openclaw-inject-openrouter-auth" ''
+          set -euo pipefail
+          AUTH_FILE="$HOME/.openclaw/agents/main/agent/auth-profiles.json"
+          KEY="$(cat ${config.age.secrets.openrouter-api-key.path})"
+          # Idempotent: register openrouter:zdr-proxy and strip the broken
+          # anthropic:default profile (third-party Pro auth, the cause of
+          # this migration). lastGood.anthropic is also cleared so OpenClaw
+          # does not retry the dead profile.
+          mkdir -p "$(dirname "$AUTH_FILE")"
+          [ -f "$AUTH_FILE" ] || echo '{"profiles":{},"version":1}' > "$AUTH_FILE"
+          ${pkgs.jq}/bin/jq --arg key "$KEY" '
+              .profiles["openrouter:zdr-proxy"] = {
+                "type": "token",
+                "provider": "openrouter",
+                "token": $key
+              }
+              | del(.profiles["anthropic:default"])
+              | del(.lastGood.anthropic)
+            ' "$AUTH_FILE" > "$AUTH_FILE.tmp" && mv "$AUTH_FILE.tmp" "$AUTH_FILE"
+          chmod 0600 "$AUTH_FILE"
         '')
         (pkgs.writeShellScript "openclaw-setup-vdirsyncer" ''
                     set -euo pipefail

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -292,15 +292,40 @@ in
 
   systemd.services.openclaw = {
     description = "OpenClaw AI Agent";
-    after = [ "network-online.target" "tailscaled.service" ];
-    wants = [ "network-online.target" ];
+    # `wants` on the proxy is a soft dependency: a proxy crash shouldn't
+    # block openclaw, but ordering avoids ECONNREFUSED on first chat
+    # completion when both units come up at boot.
+    after = [
+      "network-online.target"
+      "tailscaled.service"
+      "openclaw-zdr-proxy.service"
+    ];
+    wants = [
+      "network-online.target"
+      "openclaw-zdr-proxy.service"
+    ];
     wantedBy = [ "multi-user.target" ];
 
     environment = {
       HOME = "/var/lib/openclaw";
       # kuzeaTranscribe: openai-whisper + ffmpeg (OGG/Opus -> WAV) via runtimeInputs.
       # Model auto-downloads to ~/.cache/whisper/ (override with WHISPER_CACHE_DIR).
-      PATH = lib.mkForce "/var/lib/openclaw/.npm-global/bin:${lib.makeBinPath (with pkgs; [ nodejs_22 git coreutils bash kuzeaTranscribe agentBrowser nixd vdirsyncer khal ])}:/run/current-system/sw/bin";
+      PATH = lib.mkForce "/var/lib/openclaw/.npm-global/bin:${
+        lib.makeBinPath (
+          with pkgs;
+          [
+            nodejs_22
+            git
+            coreutils
+            bash
+            kuzeaTranscribe
+            agentBrowser
+            nixd
+            vdirsyncer
+            khal
+          ]
+        )
+      }:/run/current-system/sw/bin";
       # npm global prefix
       NPM_CONFIG_PREFIX = "/var/lib/openclaw/.npm-global";
       # Doctor recommendations: skip self-respawn and cache Node.js bytecode

--- a/hosts/sancta-claw/openclaw-watchers.nix
+++ b/hosts/sancta-claw/openclaw-watchers.nix
@@ -1,6 +1,99 @@
 { pkgs, ... }:
 
+let
+  # Extracted into a let-binding so the rendered body can be exposed via
+  # `system.build.openclawHealthProbeBody` for the module-eval test
+  # (mirrors openclawBrowserConfigBody / smokeTestBody — pure eval, no IFD).
+  openclawHealthProbeBody = ''
+    set -uo pipefail
+    STATE_FILE="/var/lib/openclaw/.health-failures"
+    ANNOUNCED_FILE="/var/lib/openclaw/.zdr-migration-announced"
+    MAX_FAILURES=3
+    OC_CONFIG="/var/lib/openclaw/.openclaw/openclaw.json"
+
+    if curl -sf -o /dev/null --max-time 10 http://127.0.0.1:18789/healthz; then
+      PREV_FAILURES=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+      echo 0 > "$STATE_FILE"
+
+      # First-success Telegram alert after migration: fires once when the
+      # gateway transitions from a failing state back to healthy AND the
+      # one-shot announcement marker does not yet exist. Subsequent green
+      # probes are silent. Marker is plain `touch` — survives reboots.
+      if [ "$PREV_FAILURES" -gt 0 ] && [ ! -f "$ANNOUNCED_FILE" ]; then
+        TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
+        CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
+        PRIMARY=$(jq -r '.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
+        if [ -n "$TOKEN" ]; then
+          curl -sf -X POST \
+            "https://api.telegram.org/bot$TOKEN/sendMessage" \
+            -d "chat_id=$CHAT_ID" \
+            -d "text=✅ [sancta-claw] OpenClaw is healthy on free+ZDR ladder: primary=$PRIMARY" \
+            --max-time 10 || true
+        fi
+        touch "$ANNOUNCED_FILE"
+      fi
+      exit 0
+    fi
+
+    FAILURES=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+    FAILURES=$((FAILURES + 1))
+    echo "$FAILURES" > "$STATE_FILE"
+
+    if [ "$FAILURES" -ge "$MAX_FAILURES" ]; then
+      # Crash-loop detection: if we've restarted 3+ times in 30 minutes,
+      # stop restarting and alert instead. Prevents infinite restart loops
+      # when gateway crashes due to bad config (learned from PR #398 incident).
+      RESTART_LOG_DIR="/var/lib/openclaw/.health-restarts"
+      CRASH_LOOP_MAX=3
+      CRASH_LOOP_WINDOW_MIN=30
+      mkdir -p "$RESTART_LOG_DIR"
+
+      # Count restarts within the window
+      RECENT_RESTARTS=$(find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN" 2>/dev/null | wc -l)
+
+      NOW=$(date +%s)
+      TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
+      CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
+      PRIMARY=$(jq -r '.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
+
+      if [ "$RECENT_RESTARTS" -ge "$CRASH_LOOP_MAX" ]; then
+        echo "Crash loop detected ($RECENT_RESTARTS restarts in $CRASH_LOOP_WINDOW_MIN min). NOT restarting." >&2
+        # Alert: manual intervention needed
+        if [ -n "$TOKEN" ]; then
+          curl -sf -X POST \
+            "https://api.telegram.org/bot$TOKEN/sendMessage" \
+            -d "chat_id=$CHAT_ID" \
+            -d "text=🔴 OpenClaw crash loop detected ($RECENT_RESTARTS restarts in ''${CRASH_LOOP_WINDOW_MIN}min) on primary=$PRIMARY. Auto-restart STOPPED. Manual intervention needed." \
+            --max-time 10 || true
+        fi
+        exit 1
+      fi
+
+      echo "Gateway unhealthy after $FAILURES consecutive checks, restarting..." >&2
+      echo 0 > "$STATE_FILE"
+      touch "$RESTART_LOG_DIR/$NOW"
+      systemctl restart openclaw
+
+      # Clean up old restart log entries (older than window)
+      find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "+$CRASH_LOOP_WINDOW_MIN" -delete 2>/dev/null || true
+
+      # Notify via Telegram
+      if [ -n "$TOKEN" ]; then
+        curl -sf -X POST \
+          "https://api.telegram.org/bot$TOKEN/sendMessage" \
+          -d "chat_id=$CHAT_ID" \
+          -d "text=⚠️ OpenClaw gateway was unhealthy ($FAILURES consecutive failures) on primary=$PRIMARY. Auto-restarted. ($((RECENT_RESTARTS + 1))/$CRASH_LOOP_MAX before crash-loop lockout)" \
+          --max-time 10 || true
+      fi
+    fi
+  '';
+in
 {
+  # Expose the rendered probe body so the module-eval test can grep for
+  # the `.zdr-migration-announced` marker without IFD. Same approach as
+  # system.build.openclawBrowserConfigBody / smokeTestBody.
+  system.build.openclawHealthProbeBody = openclawHealthProbeBody;
+
   # ── Restart trigger (no sudo, no NoNewPrivileges change) ────────────────
   # Kuzea self-restart via file-based trigger:
   #   touch /var/lib/openclaw/restart-trigger
@@ -84,68 +177,7 @@
     ];
     serviceConfig = {
       Type = "oneshot";
-      ExecStart = pkgs.writeShellScript "openclaw-health-probe" ''
-        set -uo pipefail
-        STATE_FILE="/var/lib/openclaw/.health-failures"
-        MAX_FAILURES=3
-        OC_CONFIG="/var/lib/openclaw/.openclaw/openclaw.json"
-
-        if curl -sf -o /dev/null --max-time 10 http://127.0.0.1:18789/healthz; then
-          echo 0 > "$STATE_FILE"
-          exit 0
-        fi
-
-        FAILURES=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
-        FAILURES=$((FAILURES + 1))
-        echo "$FAILURES" > "$STATE_FILE"
-
-        if [ "$FAILURES" -ge "$MAX_FAILURES" ]; then
-          # Crash-loop detection: if we've restarted 3+ times in 30 minutes,
-          # stop restarting and alert instead. Prevents infinite restart loops
-          # when gateway crashes due to bad config (learned from PR #398 incident).
-          RESTART_LOG_DIR="/var/lib/openclaw/.health-restarts"
-          CRASH_LOOP_MAX=3
-          CRASH_LOOP_WINDOW_MIN=30
-          mkdir -p "$RESTART_LOG_DIR"
-
-          # Count restarts within the window
-          RECENT_RESTARTS=$(find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN" 2>/dev/null | wc -l)
-
-          NOW=$(date +%s)
-          TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
-          CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
-
-          if [ "$RECENT_RESTARTS" -ge "$CRASH_LOOP_MAX" ]; then
-            echo "Crash loop detected ($RECENT_RESTARTS restarts in $CRASH_LOOP_WINDOW_MIN min). NOT restarting." >&2
-            # Alert: manual intervention needed
-            if [ -n "$TOKEN" ]; then
-              curl -sf -X POST \
-                "https://api.telegram.org/bot$TOKEN/sendMessage" \
-                -d "chat_id=$CHAT_ID" \
-                -d "text=🔴 OpenClaw crash loop detected ($RECENT_RESTARTS restarts in ''${CRASH_LOOP_WINDOW_MIN}min). Auto-restart STOPPED. Manual intervention needed." \
-                --max-time 10 || true
-            fi
-            exit 1
-          fi
-
-          echo "Gateway unhealthy after $FAILURES consecutive checks, restarting..." >&2
-          echo 0 > "$STATE_FILE"
-          touch "$RESTART_LOG_DIR/$NOW"
-          systemctl restart openclaw
-
-          # Clean up old restart log entries (older than window)
-          find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "+$CRASH_LOOP_WINDOW_MIN" -delete 2>/dev/null || true
-
-          # Notify via Telegram
-          if [ -n "$TOKEN" ]; then
-            curl -sf -X POST \
-              "https://api.telegram.org/bot$TOKEN/sendMessage" \
-              -d "chat_id=$CHAT_ID" \
-              -d "text=⚠️ OpenClaw gateway was unhealthy ($FAILURES consecutive failures). Auto-restarted. ($((RECENT_RESTARTS + 1))/$CRASH_LOOP_MAX before crash-loop lockout)" \
-              --max-time 10 || true
-          fi
-        fi
-      '';
+      ExecStart = pkgs.writeShellScript "openclaw-health-probe" openclawHealthProbeBody;
     };
   };
 }

--- a/hosts/sancta-claw/openclaw-watchers.nix
+++ b/hosts/sancta-claw/openclaw-watchers.nix
@@ -22,7 +22,7 @@ let
       if [ "$PREV_FAILURES" -gt 0 ] && [ ! -f "$ANNOUNCED_FILE" ]; then
         TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
         CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
-        PRIMARY=$(jq -r '.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
+        PRIMARY=$(jq -r '.agents.defaults.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
         if [ -n "$TOKEN" ]; then
           curl -sf -X POST \
             "https://api.telegram.org/bot$TOKEN/sendMessage" \
@@ -54,7 +54,7 @@ let
       NOW=$(date +%s)
       TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
       CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
-      PRIMARY=$(jq -r '.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
+      PRIMARY=$(jq -r '.agents.defaults.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
 
       if [ "$RECENT_RESTARTS" -ge "$CRASH_LOOP_MAX" ]; then
         echo "Crash loop detected ($RECENT_RESTARTS restarts in $CRASH_LOOP_WINDOW_MIN min). NOT restarting." >&2

--- a/hosts/sancta-claw/openclaw-watchers.nix
+++ b/hosts/sancta-claw/openclaw-watchers.nix
@@ -23,14 +23,17 @@ let
         TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
         CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
         PRIMARY=$(jq -r '.agents.defaults.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
+        # Only mark "announced" after a real send. If the Telegram token is
+        # missing (config not yet imperative-injected), retry on the next
+        # green probe rather than silencing forever.
         if [ -n "$TOKEN" ]; then
           curl -sf -X POST \
             "https://api.telegram.org/bot$TOKEN/sendMessage" \
             -d "chat_id=$CHAT_ID" \
             -d "text=✅ [sancta-claw] OpenClaw is healthy on free+ZDR ladder: primary=$PRIMARY" \
             --max-time 10 || true
+          touch "$ANNOUNCED_FILE"
         fi
-        touch "$ANNOUNCED_FILE"
       fi
       exit 0
     fi

--- a/hosts/sancta-claw/smoke-test.nix
+++ b/hosts/sancta-claw/smoke-test.nix
@@ -9,61 +9,80 @@
 { pkgs, ... }:
 
 let
+  smokeTestBody = ''
+    set -euo pipefail
+    PASS=0
+    FAIL=0
+
+    check() {
+      local name="$1"
+      shift
+      if "$@" &>/dev/null; then
+        echo "  PASS  $name"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL  $name"
+        FAIL=$((FAIL + 1))
+      fi
+    }
+
+    echo "=== sancta-claw smoke test ==="
+    echo
+
+    # Core services
+    check "systemd: openclaw running" systemctl is-active --quiet openclaw
+    check "systemd: tailscaled running" systemctl is-active --quiet tailscaled
+    check "systemd: sshd running" systemctl is-active --quiet sshd
+
+    # Tailscale connectivity
+    check "tailscale: node online" bash -c 'tailscale status --json | grep -q "BackendState.*Running"'
+
+    # Agenix secrets decrypted
+    check "agenix: secrets present (>=5)" test "$(find /run/agenix/ -type f 2>/dev/null | wc -l)" -ge 5
+
+    # OpenClaw workspace files
+    check "workspace: SOUL.md exists" test -f /var/lib/openclaw/.openclaw/workspace/SOUL.md
+    check "workspace: MEMORY.md exists" test -f /var/lib/openclaw/.openclaw/workspace/MEMORY.md
+    check "workspace: openclaw.json exists" test -f /var/lib/openclaw/.openclaw/openclaw.json
+
+    # OpenClaw binary
+    check "openclaw: binary installed" test -x /var/lib/openclaw/.npm-global/bin/openclaw
+
+    # Git config
+    check "git: .gitconfig exists" test -f /var/lib/openclaw/.gitconfig
+
+    # OpenClaw ZDR proxy + free+ZDR ladder verification
+    check "openclaw: zdr proxy active" systemctl is-active --quiet openclaw-zdr-proxy
+    check "openclaw: primary model is free+zdr" \
+      bash -c 'jq -e ".model.primary | test(\"^(qwen|z-ai|meta-llama|nousresearch|inclusionai|tencent|cognitivecomputations)/\")" /var/lib/openclaw/.openclaw/openclaw.json'
+    check "openclaw: zdr proxy healthz" \
+      curl -sf --max-time 5 http://127.0.0.1:5780/healthz
+    # `$(cat ...)` is meant for the inner `bash -c` shell at runtime, not
+    # the outer one. Reading the agenix key at invocation keeps it out of
+    # the rendered nix-store script.
+    # shellcheck disable=SC2016
+    check "openclaw: end-to-end completion" \
+      bash -c 'curl -sf --max-time 30 -X POST http://127.0.0.1:5780/v1/chat/completions -H "authorization: Bearer $(cat /run/agenix/openrouter-api-key)" -H "content-type: application/json" -d "{\"model\":\"qwen/qwen3-coder:free\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word OK\"}]}" | jq -e ".choices[0].message.content | test(\"OK\"; \"i\")"'
+
+    echo
+    echo "Results: $PASS passed, $FAIL failed"
+
+    if [ "$FAIL" -gt 0 ]; then
+      exit 1
+    fi
+  '';
   smokeTestScript = pkgs.writeShellApplication {
     name = "sancta-claw-smoke-test";
-    runtimeInputs = with pkgs; [ coreutils systemd tailscale ];
-    text = ''
-      set -euo pipefail
-      PASS=0
-      FAIL=0
-
-      check() {
-        local name="$1"
-        shift
-        if "$@" &>/dev/null; then
-          echo "  PASS  $name"
-          PASS=$((PASS + 1))
-        else
-          echo "  FAIL  $name"
-          FAIL=$((FAIL + 1))
-        fi
-      }
-
-      echo "=== sancta-claw smoke test ==="
-      echo
-
-      # Core services
-      check "systemd: openclaw running" systemctl is-active --quiet openclaw
-      check "systemd: tailscaled running" systemctl is-active --quiet tailscaled
-      check "systemd: sshd running" systemctl is-active --quiet sshd
-
-      # Tailscale connectivity
-      check "tailscale: node online" bash -c 'tailscale status --json | grep -q "BackendState.*Running"'
-
-      # Agenix secrets decrypted
-      check "agenix: secrets present (>=5)" test "$(find /run/agenix/ -type f 2>/dev/null | wc -l)" -ge 5
-
-      # OpenClaw workspace files
-      check "workspace: SOUL.md exists" test -f /var/lib/openclaw/.openclaw/workspace/SOUL.md
-      check "workspace: MEMORY.md exists" test -f /var/lib/openclaw/.openclaw/workspace/MEMORY.md
-      check "workspace: openclaw.json exists" test -f /var/lib/openclaw/.openclaw/openclaw.json
-
-      # OpenClaw binary
-      check "openclaw: binary installed" test -x /var/lib/openclaw/.npm-global/bin/openclaw
-
-      # Git config
-      check "git: .gitconfig exists" test -f /var/lib/openclaw/.gitconfig
-
-      echo
-      echo "Results: $PASS passed, $FAIL failed"
-
-      if [ "$FAIL" -gt 0 ]; then
-        exit 1
-      fi
-    '';
+    runtimeInputs = with pkgs; [ coreutils systemd tailscale curl jq ];
+    text = smokeTestBody;
   };
 in
 {
+  # Expose the rendered smoke-test body so the module-eval test can grep
+  # for required check titles without IFD. Mirrors the
+  # system.build.openclawBrowserConfigBody pattern in openclaw-service.nix.
+  system.build.smokeTestBody = smokeTestBody;
+
   environment.etc."sancta-claw/smoke-test.sh" = {
     source = "${smokeTestScript}/bin/sancta-claw-smoke-test";
     mode = "0755";

--- a/hosts/sancta-claw/smoke-test.nix
+++ b/hosts/sancta-claw/smoke-test.nix
@@ -54,15 +54,16 @@ let
     # OpenClaw ZDR proxy + free+ZDR ladder verification
     check "openclaw: zdr proxy active" systemctl is-active --quiet openclaw-zdr-proxy
     check "openclaw: primary model is free+zdr" \
-      bash -c 'jq -e ".model.primary | test(\"^(qwen|z-ai|meta-llama|nousresearch|inclusionai|tencent|cognitivecomputations)/\")" /var/lib/openclaw/.openclaw/openclaw.json'
+      bash -c 'jq -e ".agents.defaults.model.primary | test(\"^(qwen|z-ai|meta-llama|nousresearch|inclusionai|tencent|cognitivecomputations)/\")" /var/lib/openclaw/.openclaw/openclaw.json'
     check "openclaw: zdr proxy healthz" \
       curl -sf --max-time 5 http://127.0.0.1:5780/healthz
-    # `$(cat ...)` is meant for the inner `bash -c` shell at runtime, not
-    # the outer one. Reading the agenix key at invocation keeps it out of
-    # the rendered nix-store script.
+    # Read the agenix key into a shell variable BEFORE invoking curl so the
+    # bearer token is not exposed in argv (visible via ps auxww). The single
+    # quotes keep `$(cat ...)` and `$KEY` unexpanded by the outer nix-store
+    # shell — they're evaluated by the inner `bash -c` at runtime.
     # shellcheck disable=SC2016
     check "openclaw: end-to-end completion" \
-      bash -c 'curl -sf --max-time 30 -X POST http://127.0.0.1:5780/v1/chat/completions -H "authorization: Bearer $(cat /run/agenix/openrouter-api-key)" -H "content-type: application/json" -d "{\"model\":\"qwen/qwen3-coder:free\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word OK\"}]}" | jq -e ".choices[0].message.content | test(\"OK\"; \"i\")"'
+      bash -c 'KEY=$(cat /run/agenix/openrouter-api-key); curl -sf --max-time 30 -X POST http://127.0.0.1:5780/v1/chat/completions -H "authorization: Bearer $KEY" -H "content-type: application/json" -d "{\"model\":\"qwen/qwen3-coder:free\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word OK\"}]}" | jq -e ".choices[0].message.content | test(\"OK\"; \"i\")"'
 
     echo
     echo "Results: $PASS passed, $FAIL failed"

--- a/hosts/sancta-claw/smoke-test.nix
+++ b/hosts/sancta-claw/smoke-test.nix
@@ -57,13 +57,15 @@ let
       bash -c 'jq -e ".agents.defaults.model.primary | test(\"^(qwen|z-ai|meta-llama|nousresearch|inclusionai|tencent|cognitivecomputations)/\")" /var/lib/openclaw/.openclaw/openclaw.json'
     check "openclaw: zdr proxy healthz" \
       curl -sf --max-time 5 http://127.0.0.1:5780/healthz
-    # Read the agenix key into a shell variable BEFORE invoking curl so the
-    # bearer token is not exposed in argv (visible via ps auxww). The single
-    # quotes keep `$(cat ...)` and `$KEY` unexpanded by the outer nix-store
-    # shell — they're evaluated by the inner `bash -c` at runtime.
+    # The proxy ignores the client `Authorization` header and uses its own
+    # configured OPENROUTER_API_KEY (from agenix via EnvironmentFile), so a
+    # placeholder bearer is sufficient here. This avoids leaking the real key
+    # via argv (`ps auxww` / /proc/<pid>/cmdline) — bash's `$VAR` expansion
+    # would inline a real secret into curl's command line before `execve`.
+    # `bash -c` is used so the curl|jq pipeline runs as one shell command.
     # shellcheck disable=SC2016
     check "openclaw: end-to-end completion" \
-      bash -c 'KEY=$(cat /run/agenix/openrouter-api-key); curl -sf --max-time 30 -X POST http://127.0.0.1:5780/v1/chat/completions -H "authorization: Bearer $KEY" -H "content-type: application/json" -d "{\"model\":\"qwen/qwen3-coder:free\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word OK\"}]}" | jq -e ".choices[0].message.content | test(\"OK\"; \"i\")"'
+      bash -c 'curl -sf --max-time 30 -X POST http://127.0.0.1:5780/v1/chat/completions -H "authorization: Bearer placeholder" -H "content-type: application/json" -d "{\"model\":\"qwen/qwen3-coder:free\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word OK\"}]}" | jq -e ".choices[0].message.content | test(\"OK\"; \"i\")"'
 
     echo
     echo "Results: $PASS passed, $FAIL failed"
@@ -74,7 +76,13 @@ let
   '';
   smokeTestScript = pkgs.writeShellApplication {
     name = "sancta-claw-smoke-test";
-    runtimeInputs = with pkgs; [ coreutils systemd tailscale curl jq ];
+    runtimeInputs = with pkgs; [
+      coreutils
+      systemd
+      tailscale
+      curl
+      jq
+    ];
     text = smokeTestBody;
   };
 in

--- a/modules/services/openclaw-zdr-proxy.nix
+++ b/modules/services/openclaw-zdr-proxy.nix
@@ -7,9 +7,6 @@
 #
 # Binds to 127.0.0.1 only — accessed by the local OpenClaw service. No
 # Tailscale Serve, no firewall changes.
-#
-# This file declares the option surface and import hook only. The systemd
-# unit and Flask implementation are added in subsequent tasks.
 
 { config, pkgs, lib, ... }:
 
@@ -17,6 +14,29 @@ with lib;
 
 let
   cfg = config.services.openclaw-zdr-proxy;
+
+  proxyPkg = import ./openclaw-zdr-proxy { inherit pkgs; };
+
+  # Materialise the raw agenix key into an EnvironmentFile-compatible
+  # `KEY=VALUE` line at /run/openclaw-zdr-proxy/env. The agenix file holds
+  # the raw key (other consumers like n8n on rpi5 expect this format), so
+  # the translation must happen at unit-start time.
+  setupEnvScript = pkgs.writeShellScript "openclaw-zdr-proxy-setup-env" ''
+    set -euo pipefail
+    KEY_FILE="${cfg.apiKeyFile}"
+    if [ ! -r "$KEY_FILE" ]; then
+      echo "ERROR: OpenRouter API key file not readable: $KEY_FILE" >&2
+      exit 1
+    fi
+    KEY="$(${pkgs.coreutils}/bin/tr -d '\n' < "$KEY_FILE")"
+    if [ -z "$KEY" ]; then
+      echo "ERROR: OpenRouter API key file is empty: $KEY_FILE" >&2
+      exit 1
+    fi
+    umask 077
+    ${pkgs.coreutils}/bin/install -m 0600 /dev/null /run/openclaw-zdr-proxy/env
+    echo "OPENROUTER_API_KEY=$KEY" > /run/openclaw-zdr-proxy/env
+  '';
 in
 {
   options.services.openclaw-zdr-proxy = {
@@ -31,8 +51,9 @@ in
     apiKeyFile = mkOption {
       type = types.path;
       description = ''
-        Path to a file containing the OpenRouter API key as
-        `OPENROUTER_API_KEY=sk-...`. Loaded via systemd `EnvironmentFile`.
+        Path to a file containing the OpenRouter API key (raw value, no
+        `KEY=` prefix). The unit's `ExecStartPre` translates it into a
+        systemd `EnvironmentFile` at `/run/openclaw-zdr-proxy/env`.
         Typically `config.age.secrets.openrouter-api-key.path`.
       '';
     };
@@ -54,5 +75,45 @@ in
     };
   };
 
-  config = mkIf cfg.enable { };
+  config = mkIf cfg.enable {
+    systemd.services.openclaw-zdr-proxy = {
+      description = "OpenClaw ZDR enforcement proxy (OpenRouter sidecar)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      environment = {
+        OPENCLAW_ZDR_PROXY_PORT = toString cfg.port;
+        OPENCLAW_ZDR_UPSTREAM = cfg.upstreamUrl;
+        OPENCLAW_ZDR_CACHE_TTL = toString cfg.allowListCacheTtl;
+      };
+
+      serviceConfig = {
+        User = "openclaw";
+        Group = "openclaw";
+        RuntimeDirectory = "openclaw-zdr-proxy";
+        RuntimeDirectoryMode = "0700";
+        EnvironmentFile = "/run/openclaw-zdr-proxy/env";
+
+        ExecStartPre = [ setupEnvScript ];
+        ExecStart = "${proxyPkg}/bin/openclaw-zdr-proxy";
+
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        # Sandboxing — proxy is stateless and only needs outbound HTTPS
+        # plus a localhost listener; everything else can be locked down.
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        ReadWritePaths = [ ];
+      };
+    };
+  };
 }

--- a/modules/services/openclaw-zdr-proxy.nix
+++ b/modules/services/openclaw-zdr-proxy.nix
@@ -8,7 +8,11 @@
 # Binds to 127.0.0.1 only — accessed by the local OpenClaw service. No
 # Tailscale Serve, no firewall changes.
 
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 
 with lib;
 
@@ -93,7 +97,12 @@ in
         Group = "openclaw";
         RuntimeDirectory = "openclaw-zdr-proxy";
         RuntimeDirectoryMode = "0700";
-        EnvironmentFile = "/run/openclaw-zdr-proxy/env";
+        # `-` prefix marks the file optional for the unit's environment
+        # initialization, which systemd performs once per ExecStartPre/ExecStart.
+        # Without it, systemd tries to read /run/openclaw-zdr-proxy/env before
+        # ExecStartPre (`setupEnvScript`) has had a chance to create it, the
+        # read fails, and the unit enters `failed` state in a restart loop.
+        EnvironmentFile = "-/run/openclaw-zdr-proxy/env";
 
         ExecStartPre = [ setupEnvScript ];
         ExecStart = "${proxyPkg}/bin/openclaw-zdr-proxy";
@@ -111,7 +120,11 @@ in
         ProtectKernelTunables = true;
         ProtectKernelModules = true;
         ProtectControlGroups = true;
-        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
         ReadWritePaths = [ ];
       };
     };

--- a/modules/services/openclaw-zdr-proxy.nix
+++ b/modules/services/openclaw-zdr-proxy.nix
@@ -1,0 +1,58 @@
+# OpenClaw ZDR Proxy
+#
+# Local Flask sidecar proxy that enforces OpenRouter Zero Data Retention (ZDR)
+# at every request. Sits between the OpenClaw agent and OpenRouter, injecting
+# `provider.zdr = true` and validating the request model against a fail-closed
+# allow-list fetched from `https://openrouter.ai/api/v1/endpoints/zdr`.
+#
+# Binds to 127.0.0.1 only — accessed by the local OpenClaw service. No
+# Tailscale Serve, no firewall changes.
+#
+# This file declares the option surface and import hook only. The systemd
+# unit and Flask implementation are added in subsequent tasks.
+
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.openclaw-zdr-proxy;
+in
+{
+  options.services.openclaw-zdr-proxy = {
+    enable = mkEnableOption "OpenClaw ZDR enforcement proxy (local sidecar)";
+
+    port = mkOption {
+      type = types.port;
+      default = 5780;
+      description = "Localhost port the proxy listens on.";
+    };
+
+    apiKeyFile = mkOption {
+      type = types.path;
+      description = ''
+        Path to a file containing the OpenRouter API key as
+        `OPENROUTER_API_KEY=sk-...`. Loaded via systemd `EnvironmentFile`.
+        Typically `config.age.secrets.openrouter-api-key.path`.
+      '';
+    };
+
+    upstreamUrl = mkOption {
+      type = types.str;
+      default = "https://openrouter.ai/api/v1";
+      description = "OpenRouter API base URL the proxy forwards to.";
+    };
+
+    allowListCacheTtl = mkOption {
+      type = types.int;
+      default = 3600;
+      description = ''
+        Seconds to cache the ZDR allow-list before refreshing. The proxy
+        fails closed: if upstream refresh fails AND cache is older than
+        2 * this value, all requests return 503.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable { };
+}

--- a/modules/services/openclaw-zdr-proxy/default.nix
+++ b/modules/services/openclaw-zdr-proxy/default.nix
@@ -30,9 +30,14 @@ pkgs.writeShellApplication {
     set -euo pipefail
     : "''${OPENCLAW_ZDR_PROXY_PORT:=5780}"
     cd ${proxySource}
+    # --workers 1: the AllowListCache is per-process. Multiple workers each
+    # maintain an independent cache (independent refresh timers, independent
+    # fail-closed windows), which makes the fail-closed contract per-worker
+    # rather than per-service. Workload is one local OpenClaw client; a
+    # single sync worker is sufficient.
     exec gunicorn \
       --bind "127.0.0.1:''${OPENCLAW_ZDR_PROXY_PORT}" \
-      --workers 2 \
+      --workers 1 \
       --access-logfile - \
       --error-logfile - \
       --log-level info \

--- a/modules/services/openclaw-zdr-proxy/default.nix
+++ b/modules/services/openclaw-zdr-proxy/default.nix
@@ -1,0 +1,41 @@
+# OpenClaw ZDR Proxy package
+#
+# Wraps `proxy.py` with a Python interpreter that has Flask, Requests, and
+# Gunicorn available, then exposes `bin/openclaw-zdr-proxy` which launches
+# the WSGI app under gunicorn bound to 127.0.0.1.
+#
+# Imported by `modules/services/openclaw-zdr-proxy.nix` to construct the
+# `ExecStart=` for the systemd unit.
+
+{ pkgs }:
+
+let
+  pythonEnv = pkgs.python3.withPackages (
+    ps: with ps; [
+      flask
+      requests
+      gunicorn
+    ]
+  );
+
+  proxySource = pkgs.runCommand "openclaw-zdr-proxy-source" { } ''
+    mkdir -p $out
+    cp ${./proxy.py} $out/proxy.py
+  '';
+in
+pkgs.writeShellApplication {
+  name = "openclaw-zdr-proxy";
+  runtimeInputs = [ pythonEnv ];
+  text = ''
+    set -euo pipefail
+    : "''${OPENCLAW_ZDR_PROXY_PORT:=5780}"
+    cd ${proxySource}
+    exec gunicorn \
+      --bind "127.0.0.1:''${OPENCLAW_ZDR_PROXY_PORT}" \
+      --workers 2 \
+      --access-logfile - \
+      --error-logfile - \
+      --log-level info \
+      proxy:app
+  '';
+}

--- a/modules/services/openclaw-zdr-proxy/default.nix
+++ b/modules/services/openclaw-zdr-proxy/default.nix
@@ -30,14 +30,15 @@ pkgs.writeShellApplication {
     set -euo pipefail
     : "''${OPENCLAW_ZDR_PROXY_PORT:=5780}"
     cd ${proxySource}
-    # --workers 1: the AllowListCache is per-process. Multiple workers each
-    # maintain an independent cache (independent refresh timers, independent
-    # fail-closed windows), which makes the fail-closed contract per-worker
-    # rather than per-service. Workload is one local OpenClaw client; a
-    # single sync worker is sufficient.
+    # --workers 1 + --threads 4: keep the AllowListCache shared (per-process,
+    # protected by threading.Lock) while still serving concurrent requests.
+    # A sync worker blocks on streaming completions for the lifetime of the
+    # response; threads avoid head-of-line blocking. Setting --threads >1
+    # auto-selects the gthread worker class.
     exec gunicorn \
       --bind "127.0.0.1:''${OPENCLAW_ZDR_PROXY_PORT}" \
       --workers 1 \
+      --threads 4 \
       --access-logfile - \
       --error-logfile - \
       --log-level info \

--- a/modules/services/openclaw-zdr-proxy/proxy.py
+++ b/modules/services/openclaw-zdr-proxy/proxy.py
@@ -1,0 +1,292 @@
+"""
+OpenClaw ZDR enforcement proxy.
+
+A Flask sidecar that sits between OpenClaw and OpenRouter. Every request:
+
+1. Has its `model` field validated against a fail-closed allow-list fetched
+   from `${UPSTREAM}/endpoints/zdr` (cached, lazy refresh).
+2. Has `provider.zdr = true` injected (matches the open-webui pipe pattern).
+3. Has `provider.allow = [<cached_allow_list>]` injected so OpenRouter only
+   routes to ZDR endpoints even if a future upstream change made the global
+   ZDR flag insufficient.
+
+Fail-closed semantics: if the upstream allow-list refresh fails AND the
+existing cache is older than `2 * cacheTtl` seconds, the proxy returns 503
+for everything — including chat completions and `/healthz` — rather than
+serving requests against a potentially stale list.
+
+Configuration via environment variables (read at import time):
+
+- OPENROUTER_API_KEY              — bearer token (required at runtime)
+- OPENCLAW_ZDR_PROXY_PORT         — listen port (default 5780, used by main)
+- OPENCLAW_ZDR_UPSTREAM            — upstream base URL (default OpenRouter)
+- OPENCLAW_ZDR_CACHE_TTL           — allow-list cache TTL seconds (default 3600)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Iterable
+
+import requests
+from flask import Flask, Response, jsonify, request, stream_with_context
+
+logger = logging.getLogger("openclaw-zdr-proxy")
+
+DEFAULT_UPSTREAM = "https://openrouter.ai/api/v1"
+DEFAULT_CACHE_TTL = 3600
+DEFAULT_PORT = 5780
+
+# Indirection for tests to advance time via monkeypatch.
+_TIME_FN: Callable[[], float] = time.time
+
+
+class AllowListCache:
+    """Holds the ZDR model allow-list and last successful refresh time."""
+
+    def __init__(self, ttl: int) -> None:
+        self.ttl = ttl
+        self._lock = threading.Lock()
+        self._models: set[str] = set()
+        self._last_success: float | None = None
+
+    @property
+    def models(self) -> set[str]:
+        with self._lock:
+            return set(self._models)
+
+    @property
+    def last_success(self) -> float | None:
+        return self._last_success
+
+    def is_fresh(self, now: float) -> bool:
+        """True if cache was successfully refreshed within ttl."""
+        return self._last_success is not None and (now - self._last_success) < self.ttl
+
+    def is_usable(self, now: float) -> bool:
+        """True if cache exists and is within 2*ttl of last success.
+
+        Outside this window we fail closed.
+        """
+        return self._last_success is not None and (now - self._last_success) < (
+            2 * self.ttl
+        )
+
+    def update(self, models: Iterable[str], now: float) -> None:
+        with self._lock:
+            self._models = set(models)
+            self._last_success = now
+
+
+def _parse_zdr_response(payload: dict[str, Any]) -> set[str]:
+    """Extract model IDs from the OpenRouter `/endpoints/zdr` response."""
+    data = payload.get("data") or []
+    if not isinstance(data, list):
+        return set()
+
+    out: set[str] = set()
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or ""
+        if name:
+            parts = name.rsplit(" | ", 1)
+            model_id = parts[1] if len(parts) > 1 else name
+            if model_id:
+                out.add(model_id)
+        # Some shapes also carry a top-level `id`.
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id:
+            out.add(item_id)
+    return out
+
+
+def _fetch_zdr_models(upstream: str, api_key: str, timeout: float = 30.0) -> set[str]:
+    url = f"{upstream.rstrip('/')}/endpoints/zdr"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://github.com/alexandru-savinov/nixos-config",
+        "X-Title": "openclaw-zdr-proxy",
+    }
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    return _parse_zdr_response(response.json())
+
+
+def _refresh_allow_list(app: Flask) -> bool:
+    """Try to refresh the cache. Return True on success."""
+    cache: AllowListCache = app.config["ALLOW_LIST_CACHE"]
+    upstream: str = app.config["UPSTREAM_URL"]
+    api_key = app.config["API_KEY_PROVIDER"]()
+    if not api_key:
+        logger.error("OPENROUTER_API_KEY is empty; cannot refresh ZDR allow-list")
+        return False
+    fetcher: Callable[[str, str], set[str]] = app.config["ZDR_FETCHER"]
+    try:
+        models = fetcher(upstream, api_key)
+    except Exception as exc:
+        logger.warning("ZDR allow-list refresh failed: %s", exc)
+        return False
+
+    cache.update(models, _TIME_FN())
+    logger.info("Refreshed ZDR allow-list: %d models", len(models))
+    return True
+
+
+def _ensure_allow_list(app: Flask) -> bool:
+    """Refresh the cache if missing or stale. Returns True if cache is usable."""
+    cache: AllowListCache = app.config["ALLOW_LIST_CACHE"]
+    now = _TIME_FN()
+    if cache.is_fresh(now):
+        return True
+
+    refreshed = _refresh_allow_list(app)
+    if refreshed:
+        return True
+
+    return cache.is_usable(_TIME_FN())
+
+
+def create_app(
+    upstream_url: str | None = None,
+    cache_ttl: int | None = None,
+    api_key_provider: Callable[[], str] | None = None,
+    zdr_fetcher: Callable[[str, str], set[str]] | None = None,
+) -> Flask:
+    """Build the Flask app. All side-effecting collaborators are injectable."""
+    app = Flask(__name__)
+    app.config["UPSTREAM_URL"] = upstream_url or os.environ.get(
+        "OPENCLAW_ZDR_UPSTREAM", DEFAULT_UPSTREAM
+    )
+    ttl = cache_ttl if cache_ttl is not None else int(
+        os.environ.get("OPENCLAW_ZDR_CACHE_TTL", str(DEFAULT_CACHE_TTL))
+    )
+    app.config["ALLOW_LIST_CACHE"] = AllowListCache(ttl=ttl)
+    app.config["API_KEY_PROVIDER"] = api_key_provider or (
+        lambda: os.environ.get("OPENROUTER_API_KEY", "")
+    )
+    app.config["ZDR_FETCHER"] = zdr_fetcher or _fetch_zdr_models
+
+    @app.route("/healthz")
+    def healthz():
+        cache: AllowListCache = app.config["ALLOW_LIST_CACHE"]
+        # Try a refresh if we have no successful fetch yet, but never on every
+        # probe — health checks should not pummel the upstream.
+        if cache.last_success is None:
+            _refresh_allow_list(app)
+        if cache.is_usable(_TIME_FN()):
+            return jsonify({"status": "ok", "models": len(cache.models)}), 200
+        return jsonify({"status": "fail-closed", "models": 0}), 503
+
+    @app.route("/v1/models")
+    def models_passthrough():
+        if not _ensure_allow_list(app):
+            return jsonify({"error": "zdr allow-list unavailable"}), 503
+        cache: AllowListCache = app.config["ALLOW_LIST_CACHE"]
+        now = int(_TIME_FN())
+        return jsonify(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": model_id,
+                        "object": "model",
+                        "created": now,
+                        "owned_by": "openrouter",
+                    }
+                    for model_id in sorted(cache.models)
+                ],
+            }
+        )
+
+    @app.route("/v1/chat/completions", methods=["POST"])
+    def chat_completions():
+        if not _ensure_allow_list(app):
+            return jsonify({"error": "zdr allow-list unavailable"}), 503
+
+        body = request.get_json(silent=True) or {}
+        model_id = body.get("model", "")
+        if not isinstance(model_id, str) or not model_id:
+            return jsonify({"error": "missing model"}), 400
+
+        cache: AllowListCache = app.config["ALLOW_LIST_CACHE"]
+        allow = cache.models
+        if model_id not in allow:
+            return (
+                jsonify(
+                    {
+                        "error": {
+                            "type": "zdr_blocked",
+                            "message": f"model {model_id!r} is not in the ZDR allow-list",
+                        }
+                    }
+                ),
+                403,
+            )
+
+        api_key = app.config["API_KEY_PROVIDER"]()
+        if not api_key:
+            return jsonify({"error": "OPENROUTER_API_KEY not configured"}), 500
+
+        upstream = app.config["UPSTREAM_URL"].rstrip("/")
+        chat_url = f"{upstream}/chat/completions"
+
+        provider = {**body.get("provider", {}), "zdr": True, "allow": sorted(allow)}
+        payload = {**body, "provider": provider}
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/alexandru-savinov/nixos-config",
+            "X-Title": "openclaw-zdr-proxy",
+        }
+
+        stream = bool(body.get("stream"))
+        try:
+            upstream_resp = requests.post(
+                url=chat_url,
+                json=payload,
+                headers=headers,
+                stream=stream,
+                timeout=300,
+            )
+        except requests.RequestException as exc:
+            logger.error("upstream POST failed: %s", exc)
+            return jsonify({"error": f"upstream error: {exc}"}), 502
+
+        if stream:
+            def generate():
+                for line in upstream_resp.iter_lines():
+                    if not line:
+                        continue
+                    decoded = line.decode("utf-8", errors="replace")
+                    if decoded.startswith(":"):
+                        continue
+                    yield decoded + "\n"
+
+            return Response(
+                stream_with_context(generate()),
+                status=upstream_resp.status_code,
+                mimetype="text/event-stream",
+            )
+
+        return Response(
+            upstream_resp.content,
+            status=upstream_resp.status_code,
+            mimetype=upstream_resp.headers.get("content-type", "application/json"),
+        )
+
+    return app
+
+
+# WSGI entry point used by gunicorn (`gunicorn proxy:app`).
+app = create_app()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("OPENCLAW_ZDR_PROXY_PORT", str(DEFAULT_PORT)))
+    app.run(host="127.0.0.1", port=port)

--- a/modules/services/openclaw-zdr-proxy/proxy.py
+++ b/modules/services/openclaw-zdr-proxy/proxy.py
@@ -242,7 +242,11 @@ def create_app(
         upstream = app.config["UPSTREAM_URL"].rstrip("/")
         chat_url = f"{upstream}/chat/completions"
 
-        provider = {**body.get("provider", {}), "zdr": True, "allow": sorted(allow)}
+        # `body.get("provider", {})` returns None — not the default — when the
+        # client explicitly sends `"provider": null`. `{**None}` raises
+        # TypeError, so coalesce explicitly.
+        provider_in = body.get("provider") or {}
+        provider = {**provider_in, "zdr": True, "allow": sorted(allow)}
         payload = {**body, "provider": provider}
 
         headers = {

--- a/modules/services/openclaw-zdr-proxy/proxy.py
+++ b/modules/services/openclaw-zdr-proxy/proxy.py
@@ -60,20 +60,27 @@ class AllowListCache:
 
     @property
     def last_success(self) -> float | None:
-        return self._last_success
+        with self._lock:
+            return self._last_success
 
     def is_fresh(self, now: float) -> bool:
         """True if cache was successfully refreshed within ttl."""
-        return self._last_success is not None and (now - self._last_success) < self.ttl
+        with self._lock:
+            return (
+                self._last_success is not None
+                and (now - self._last_success) < self.ttl
+            )
 
     def is_usable(self, now: float) -> bool:
         """True if cache exists and is within 2*ttl of last success.
 
         Outside this window we fail closed.
         """
-        return self._last_success is not None and (now - self._last_success) < (
-            2 * self.ttl
-        )
+        with self._lock:
+            return (
+                self._last_success is not None
+                and (now - self._last_success) < (2 * self.ttl)
+            )
 
     def update(self, models: Iterable[str], now: float) -> None:
         with self._lock:
@@ -259,19 +266,21 @@ def create_app(
             return jsonify({"error": f"upstream error: {exc}"}), 502
 
         if stream:
+            # Pass raw bytes through unchanged so SSE event delimiters
+            # (blank lines per spec) and `: keep-alive` comments survive.
+            # `iter_lines()` strips terminators and merges events.
             def generate():
-                for line in upstream_resp.iter_lines():
-                    if not line:
-                        continue
-                    decoded = line.decode("utf-8", errors="replace")
-                    if decoded.startswith(":"):
-                        continue
-                    yield decoded + "\n"
+                try:
+                    for chunk in upstream_resp.iter_content(chunk_size=None):
+                        if chunk:
+                            yield chunk
+                finally:
+                    upstream_resp.close()
 
             return Response(
                 stream_with_context(generate()),
                 status=upstream_resp.status_code,
-                mimetype="text/event-stream",
+                mimetype=upstream_resp.headers.get("content-type", "text/event-stream"),
             )
 
         return Response(

--- a/tests/e2e_test_openwebui_zdr.py
+++ b/tests/e2e_test_openwebui_zdr.py
@@ -9,60 +9,17 @@ import time
 from pathlib import Path
 
 import pytest
-from flask import Flask, jsonify, request
 from werkzeug.serving import make_server
 
+sys.path.insert(0, str(Path(__file__).parent))
+from stubs.openrouter_stub import create_stub_openrouter  # noqa: E402
 
-# ----------------------------------------------------------------------
-# Stub OpenRouter server
-# ----------------------------------------------------------------------
+
 def _find_free_port() -> int:
     """Return a free TCP port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
-
-
-def create_stub_openrouter():
-    """Create a Flask app that mimics the two OpenRouter endpoints we need."""
-    app = Flask(__name__)
-
-    # In‑memory data for the stub
-    # ZDR endpoint returns {"name": "Provider | model-id", ...} format
-    ZDR_MODELS = [
-        {"name": "OpenAI | openrouter/gpt-4o-mini"},
-        {"name": "OpenAI | openrouter/gpt-4o"},
-    ]
-
-    ALL_MODELS = [
-        {"id": "openrouter/gpt-4o-mini", "name": "GPT‑4o Mini"},
-        {"id": "openrouter/gpt-4o", "name": "GPT‑4o"},
-        {"id": "openrouter/gpt-4o-32k", "name": "GPT‑4o 32k"},
-    ]
-
-    @app.route("/v1/endpoints/zdr")
-    def zdr_endpoints():
-        return jsonify({"data": ZDR_MODELS})
-
-    @app.route("/v1/models")
-    def models():
-        return jsonify({"data": ALL_MODELS})
-
-    @app.route("/v1/chat/completions", methods=["POST"])
-    def chat():
-        payload = request.get_json(silent=True) or {}
-        # Echo back the prompt to make verification easy
-        content = payload.get("prompt", "no-prompt")
-        # Also include request metadata so tests can verify provider.zdr was set
-        response = {
-            "choices": [{"message": {"content": f"stub-response: {content}"}}],
-            "_request_metadata": {
-                "provider": payload.get("provider", {}),
-            },
-        }
-        return jsonify(response)
-
-    return app
 
 
 class FlaskThread(threading.Thread):
@@ -106,7 +63,17 @@ def provision_pipe(db_path: Path, function_path: Path):
 def stub_openrouter():
     """Start the stub OpenRouter server for the duration of the module."""
     port = _find_free_port()
-    app = create_stub_openrouter()
+    app = create_stub_openrouter(
+        zdr_models=[
+            {"name": "OpenAI | openrouter/gpt-4o-mini"},
+            {"name": "OpenAI | openrouter/gpt-4o"},
+        ],
+        all_models=[
+            {"id": "openrouter/gpt-4o-mini", "name": "GPT-4o Mini"},
+            {"id": "openrouter/gpt-4o", "name": "GPT-4o"},
+            {"id": "openrouter/gpt-4o-32k", "name": "GPT-4o 32k"},
+        ],
+    )
     server = FlaskThread(app, port)
     server.start()
     # Give the server a moment to start

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -551,6 +551,26 @@ let
         builtins.throw
           "FAIL: sancta-claw openclaw-zdr-proxy wiring — port=${toString proxy.port} (expected 5780), apiKeyFile=${agenixPath} (expected /run/agenix/openrouter-api-key)";
 
+    # Verify the rendered openclaw browser-config script registers the
+    # free+ZDR ladder and routes through the local proxy. Reads the body
+    # string from system.build (exposed by openclaw-service.nix) — pure
+    # eval, no IFD, no derivation realization.
+    openclaw-free-zdr-ladder-rendered =
+      let
+        body = self.nixosConfigurations.sancta-claw.config.system.build.openclawBrowserConfigBody;
+        required = [
+          "qwen/qwen3-coder:free"
+          "z-ai/glm-4.5-air:free"
+          "qwen/qwen3-next-80b-a3b-instruct:free"
+          "127.0.0.1:5780"
+        ];
+        missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
+      in
+      if missing == [ ] then true
+      else
+        builtins.throw
+          "FAIL: openclawBrowserConfigBody missing substrings: ${builtins.toJSON missing}";
+
   };
 
   # ── Build the check derivation ──────────────────────────────────

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -571,6 +571,25 @@ let
         builtins.throw
           "FAIL: openclawBrowserConfigBody missing substrings: ${builtins.toJSON missing}";
 
+    # Verify the rendered openclaw health-check probe contains the
+    # one-shot first-success Telegram alert sentinel and includes the
+    # active primary model in failure messages. Reads the body string
+    # from system.build.openclawHealthProbeBody — pure eval, no IFD.
+    sancta-claw-openclaw-health-probe-zdr-alert =
+      let
+        body = self.nixosConfigurations.sancta-claw.config.system.build.openclawHealthProbeBody;
+        required = [
+          ".zdr-migration-announced"
+          "free+ZDR ladder"
+          "primary=$PRIMARY"
+        ];
+        missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
+      in
+      if missing == [ ] then true
+      else
+        builtins.throw
+          "FAIL: openclawHealthProbeBody missing substrings: ${builtins.toJSON missing}";
+
     # Verify the rendered sancta-claw smoke-test script asserts on the
     # ZDR proxy + free+ZDR ladder + end-to-end round-trip. Reads the body
     # string from system.build (exposed by smoke-test.nix) — pure eval,

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -571,6 +571,26 @@ let
         builtins.throw
           "FAIL: openclawBrowserConfigBody missing substrings: ${builtins.toJSON missing}";
 
+    # Verify the rendered sancta-claw smoke-test script asserts on the
+    # ZDR proxy + free+ZDR ladder + end-to-end round-trip. Reads the body
+    # string from system.build (exposed by smoke-test.nix) — pure eval,
+    # same approach as openclaw-free-zdr-ladder-rendered.
+    sancta-claw-smoke-test-zdr-checks =
+      let
+        body = self.nixosConfigurations.sancta-claw.config.system.build.smokeTestBody;
+        required = [
+          "openclaw: zdr proxy active"
+          "openclaw: primary model is free+zdr"
+          "openclaw: zdr proxy healthz"
+          "openclaw: end-to-end completion"
+        ];
+        missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
+      in
+      if missing == [ ] then true
+      else
+        builtins.throw
+          "FAIL: sancta-claw smokeTestBody missing check titles: ${builtins.toJSON missing}";
+
   };
 
   # ── Build the check derivation ──────────────────────────────────

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -510,6 +510,47 @@ let
       specialArgs = { claude-code = null; };
     };
 
+    # ── OpenClaw ZDR Proxy ────────────────────────────────────────
+    openclaw-zdr-proxy-minimal = shouldEval "openclaw-zdr-proxy: minimal config" {
+      modules = [
+        ../modules/services/openclaw-zdr-proxy.nix
+        {
+          services.openclaw-zdr-proxy = {
+            enable = true;
+            apiKeyFile = "/run/agenix/openrouter-api-key";
+          };
+          # The proxy unit runs as user `openclaw`, normally created by
+          # the host-level openclaw service. Declare it here so the
+          # isolated module eval doesn't fail user-validation.
+          users.users.openclaw = { isSystemUser = true; group = "openclaw"; };
+          users.groups.openclaw = { };
+        }
+      ];
+    };
+
+    openclaw-zdr-proxy-disabled = shouldEval "openclaw-zdr-proxy: disabled" {
+      modules = [
+        ../modules/services/openclaw-zdr-proxy.nix
+        { services.openclaw-zdr-proxy.enable = false; }
+      ];
+    };
+
+    # Verify wiring on the actual sancta-claw host config: the proxy is
+    # enabled with the default port and reads the OpenRouter API key
+    # from agenix. This catches misconfigurations in the host module
+    # (wrong path, missing secret, port drift) without a full build.
+    openclaw-zdr-proxy-sancta-claw-wiring =
+      let
+        proxy = self.nixosConfigurations.sancta-claw.config.services.openclaw-zdr-proxy;
+        agenixPath = toString proxy.apiKeyFile;
+        portOk = proxy.port == 5780;
+        pathOk = agenixPath == "/run/agenix/openrouter-api-key";
+      in
+      if portOk && pathOk then true
+      else
+        builtins.throw
+          "FAIL: sancta-claw openclaw-zdr-proxy wiring — port=${toString proxy.port} (expected 5780), apiKeyFile=${agenixPath} (expected /run/agenix/openrouter-api-key)";
+
   };
 
   # ── Build the check derivation ──────────────────────────────────

--- a/tests/openclaw-zdr-proxy.nix
+++ b/tests/openclaw-zdr-proxy.nix
@@ -1,0 +1,122 @@
+# NixOS integration test for the OpenClaw ZDR enforcement proxy.
+#
+# Boots a single VM that runs:
+#   - the proxy (modules/services/openclaw-zdr-proxy.nix)
+#   - a stub OpenRouter (tests/stubs/openrouter_stub.py) on :9999
+#
+# Verifies end-to-end:
+#   1. Proxy starts and serves /healthz after lazily refreshing the
+#      ZDR allow-list from the stub.
+#   2. A POST through the proxy reaches the upstream with provider.zdr=true
+#      injected on the wire (introspected via the stub's /__last_payload).
+#   3. A model not present in the ZDR allow-list is rejected with HTTP 4xx
+#      before the request ever leaves the proxy.
+#
+# Wired into flake.nix as `checks.x86_64-linux.openclaw-zdr-proxy`. Returns
+# the test args; flake.nix wraps with `pkgs.testers.nixosTest`.
+
+{ pkgs }:
+
+let
+  pythonStubEnv = pkgs.python3.withPackages (ps: with ps; [ flask ]);
+in
+{
+  name = "openclaw-zdr-proxy-test";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ../modules/services/openclaw-zdr-proxy.nix ];
+
+      # The proxy unit runs as user `openclaw`. In production this user is
+      # created by openclaw-service.nix on sancta-claw; in this isolated test
+      # we provision it minimally.
+      users.users.openclaw = {
+        isSystemUser = true;
+        group = "openclaw";
+        home = "/var/lib/openclaw";
+        createHome = true;
+      };
+      users.groups.openclaw = { };
+
+      # Mock OpenRouter API key. The proxy's ExecStartPre reads this raw value
+      # (no `KEY=` prefix) and translates it into an EnvironmentFile.
+      environment.etc."openrouter-test-key".text = "sk-test";
+
+      # Stub OpenRouter on :9999. Listens on 127.0.0.1 by default
+      # (see tests/stubs/openrouter_stub.py `__main__`).
+      systemd.services.openrouter-stub = {
+        description = "Stub OpenRouter API for nixosTest";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "openclaw-zdr-proxy.service" ];
+        environment.PORT = "9999";
+        serviceConfig = {
+          ExecStart = "${pythonStubEnv}/bin/python ${./stubs/openrouter_stub.py}";
+          Restart = "on-failure";
+        };
+      };
+
+      services.openclaw-zdr-proxy = {
+        enable = true;
+        apiKeyFile = "/etc/openrouter-test-key";
+        # Stub registers /v1/endpoints/zdr, /v1/chat/completions, etc.
+        upstreamUrl = "http://127.0.0.1:9999/v1";
+        allowListCacheTtl = 60;
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    # 1. Stub up first — the proxy will fetch the ZDR allow-list from it.
+    machine.wait_for_unit("openrouter-stub.service")
+    machine.wait_for_open_port(9999)
+
+    # 2. Proxy up.
+    machine.wait_for_unit("openclaw-zdr-proxy.service")
+    machine.wait_for_open_port(5780)
+
+    # 3. /healthz triggers a lazy refresh against the stub. After this call
+    #    at least one gunicorn worker has a populated allow-list cache.
+    machine.succeed("curl -sf --max-time 10 http://127.0.0.1:5780/healthz")
+
+    # 4. POST a ZDR-allowed model. Use a file so JSON quoting can't trip up
+    #    the test shell. The proxy must inject provider.zdr=true and forward.
+    machine.succeed(
+        "printf '%s' "
+        "'{\"model\":\"qwen/qwen3-coder:free\","
+        "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}' "
+        "> /tmp/zdr-req.json"
+    )
+    out = machine.succeed(
+        "curl -sf --max-time 15 -X POST "
+        "-H 'authorization: Bearer sk-test' "
+        "-H 'content-type: application/json' "
+        "--data @/tmp/zdr-req.json "
+        "http://127.0.0.1:5780/v1/chat/completions"
+    )
+    assert "choices" in out, f"chat completion missing choices: {out!r}"
+
+    # 5. Verify the upstream stub recorded provider.zdr=true on the wire.
+    last = machine.succeed("curl -sf http://127.0.0.1:9999/__last_payload").strip()
+    assert '"zdr": true' in last, f"ZDR flag missing from upstream payload: {last}"
+
+    # 6. Non-ZDR model must be rejected by the proxy. curl -f exits non-zero
+    #    on 4xx, so machine.fail captures the rejection.
+    machine.succeed(
+        "printf '%s' "
+        "'{\"model\":\"openrouter/gpt-4o-32k\","
+        "\"messages\":[{\"role\":\"user\",\"content\":\"x\"}]}' "
+        "> /tmp/non-zdr-req.json"
+    )
+    machine.fail(
+        "curl -sf --max-time 15 -X POST "
+        "-H 'authorization: Bearer sk-test' "
+        "-H 'content-type: application/json' "
+        "--data @/tmp/non-zdr-req.json "
+        "http://127.0.0.1:5780/v1/chat/completions"
+    )
+
+    print("openclaw-zdr-proxy nixosTest passed: ZDR injection and rejection verified")
+  '';
+}

--- a/tests/stubs/openrouter_stub.py
+++ b/tests/stubs/openrouter_stub.py
@@ -1,0 +1,113 @@
+"""
+Reusable Flask stub of the OpenRouter API for tests.
+
+Implements the small subset of OpenRouter that this repo's tests need:
+
+- GET  /api/v1/endpoints/zdr   — list of ZDR-compliant models
+- GET  /v1/endpoints/zdr       — same (alternate prefix used by some clients)
+- GET  /v1/models              — full model catalogue
+- POST /v1/chat/completions    — echoes the prompt; records payload
+- GET  /__last_payload         — introspection: last POST body received
+
+The stub is used by:
+- tests/e2e_test_openwebui_zdr.py (open-webui pipe e2e)
+- tests/test_openclaw_zdr_proxy.py (zdr proxy unit tests)
+- tests/openclaw-zdr-proxy.nix (nixosTest end-to-end)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+
+DEFAULT_ZDR_MODELS: list[dict[str, Any]] = [
+    {"name": "Venice | qwen/qwen3-coder:free", "model_name": "Qwen3 Coder (free)"},
+    {"name": "Z.AI | z-ai/glm-4.5-air:free", "model_name": "GLM 4.5 Air (free)"},
+    {
+        "name": "Venice | qwen/qwen3-next-80b-a3b-instruct:free",
+        "model_name": "Qwen3 Next 80B (free)",
+    },
+    {"name": "OpenAI | openrouter/gpt-4o-mini", "model_name": "GPT-4o Mini"},
+    {"name": "OpenAI | openrouter/gpt-4o", "model_name": "GPT-4o"},
+]
+
+
+DEFAULT_ALL_MODELS: list[dict[str, Any]] = [
+    {"id": "qwen/qwen3-coder:free", "name": "Qwen3 Coder (free)"},
+    {"id": "z-ai/glm-4.5-air:free", "name": "GLM 4.5 Air (free)"},
+    {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "name": "Qwen3 Next 80B (free)"},
+    {"id": "openrouter/gpt-4o-mini", "name": "GPT-4o Mini"},
+    {"id": "openrouter/gpt-4o", "name": "GPT-4o"},
+    {"id": "openrouter/gpt-4o-32k", "name": "GPT-4o 32k (NOT ZDR)"},
+]
+
+
+def _zdr_payload(zdr_models: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"data": list(zdr_models)}
+
+
+def create_stub_openrouter(
+    zdr_models: list[dict[str, Any]] | None = None,
+    all_models: list[dict[str, Any]] | None = None,
+) -> Flask:
+    """Build a Flask app that mimics the OpenRouter API."""
+    app = Flask(__name__)
+    app.config["ZDR_MODELS"] = list(
+        zdr_models if zdr_models is not None else DEFAULT_ZDR_MODELS
+    )
+    app.config["ALL_MODELS"] = list(
+        all_models if all_models is not None else DEFAULT_ALL_MODELS
+    )
+    app.config["LAST_PAYLOAD"] = None
+
+    def _zdr_response():
+        return jsonify(_zdr_payload(app.config["ZDR_MODELS"]))
+
+    # OpenRouter exposes /api/v1/endpoints/zdr; some test setups mount the stub
+    # at a base that already includes /api so /v1/endpoints/zdr is also valid.
+    app.add_url_rule("/api/v1/endpoints/zdr", "zdr_api_v1", _zdr_response)
+    app.add_url_rule("/v1/endpoints/zdr", "zdr_v1", _zdr_response)
+
+    @app.route("/v1/models")
+    def models():
+        return jsonify({"data": app.config["ALL_MODELS"]})
+
+    @app.route("/v1/chat/completions", methods=["POST"])
+    def chat():
+        payload = request.get_json(silent=True) or {}
+        app.config["LAST_PAYLOAD"] = payload
+        prompt = payload.get("prompt") or (
+            payload.get("messages", [{}])[-1].get("content") if payload.get("messages") else "no-prompt"
+        )
+        return jsonify(
+            {
+                "id": "chatcmpl-stub",
+                "object": "chat.completion",
+                "model": payload.get("model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": f"stub-response: {prompt}"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "_request_metadata": {"provider": payload.get("provider", {})},
+            }
+        )
+
+    @app.route("/__last_payload")
+    def last_payload():
+        body = app.config.get("LAST_PAYLOAD")
+        return (json.dumps(body) if body is not None else "null"), 200, {"Content-Type": "application/json"}
+
+    return app
+
+
+if __name__ == "__main__":
+    import os
+
+    port = int(os.environ.get("PORT", "9999"))
+    create_stub_openrouter().run(host="127.0.0.1", port=port)

--- a/tests/test_openclaw_zdr_proxy.py
+++ b/tests/test_openclaw_zdr_proxy.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for the OpenClaw ZDR enforcement proxy.
+
+The proxy module is at modules/services/openclaw-zdr-proxy/proxy.py
+(non-package layout, so we load it via importlib).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import socket
+import sys
+import threading
+import time
+
+import pytest
+from werkzeug.serving import make_server
+
+ROOT = pathlib.Path(__file__).parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
+from stubs.openrouter_stub import create_stub_openrouter  # noqa: E402
+
+
+def _load_proxy():
+    module_path = (
+        ROOT / "modules" / "services" / "openclaw-zdr-proxy" / "proxy.py"
+    )
+    spec = importlib.util.spec_from_file_location("openclaw_zdr_proxy", str(module_path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+proxy_mod = _load_proxy()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _ServerThread(threading.Thread):
+    def __init__(self, app, port: int):
+        super().__init__(daemon=True)
+        self.srv = make_server("127.0.0.1", port, app)
+
+    def run(self):
+        self.srv.serve_forever()
+
+    def shutdown(self):
+        self.srv.shutdown()
+
+
+@pytest.fixture
+def stub_server():
+    port = _free_port()
+    app = create_stub_openrouter(
+        zdr_models=[
+            {"name": "Venice | qwen/qwen3-coder:free"},
+            {"name": "Z.AI | z-ai/glm-4.5-air:free"},
+        ],
+    )
+    server = _ServerThread(app, port)
+    server.start()
+    time.sleep(0.2)
+    try:
+        yield {"app": app, "url": f"http://127.0.0.1:{port}/v1"}
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def proxy_app(stub_server):
+    """Build a proxy whose upstream is the stub server."""
+    app = proxy_mod.create_app(
+        upstream_url=stub_server["url"],
+        cache_ttl=60,
+        api_key_provider=lambda: "sk-test",
+    )
+    app.config["TESTING"] = True
+    return app
+
+
+def test_injects_zdr_true(proxy_app, stub_server):
+    """Forwarded payload must carry provider.zdr=True and an allow-list."""
+    client = proxy_app.test_client()
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen/qwen3-coder:free",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert resp.status_code == 200, resp.data
+
+    last = stub_server["app"].config["LAST_PAYLOAD"]
+    assert last is not None, "stub did not record any upstream POST"
+    assert last["provider"]["zdr"] is True
+    assert "allow" in last["provider"]
+    assert "qwen/qwen3-coder:free" in last["provider"]["allow"]
+
+
+def test_rejects_non_zdr_model(proxy_app, stub_server):
+    """A model that is not in the cached ZDR allow-list must 403."""
+    client = proxy_app.test_client()
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openrouter/gpt-4o-32k",
+            "messages": [{"role": "user", "content": "x"}],
+        },
+    )
+    assert resp.status_code == 403, resp.data
+    body = resp.get_json()
+    assert body["error"]["type"] == "zdr_blocked"
+    # Stub must NOT have received any upstream POST for the rejected model.
+    assert stub_server["app"].config["LAST_PAYLOAD"] is None
+
+
+def test_healthz_fails_closed(monkeypatch):
+    """When upstream refresh fails AND cache is older than 2*ttl, fail closed."""
+    fake_now = {"t": 1_000_000.0}
+
+    def now():
+        return fake_now["t"]
+
+    monkeypatch.setattr(proxy_mod, "_TIME_FN", now)
+
+    fetch_calls: list[str] = []
+
+    def successful_fetcher(upstream, api_key):
+        fetch_calls.append("ok")
+        return {"qwen/qwen3-coder:free"}
+
+    def failing_fetcher(upstream, api_key):
+        fetch_calls.append("fail")
+        raise RuntimeError("upstream down")
+
+    # First, populate the cache with one successful fetch.
+    app = proxy_mod.create_app(
+        upstream_url="http://upstream.invalid/v1",
+        cache_ttl=60,
+        api_key_provider=lambda: "sk-test",
+        zdr_fetcher=successful_fetcher,
+    )
+    client = app.test_client()
+    assert client.get("/healthz").status_code == 200
+    assert fetch_calls == ["ok"]
+
+    # Now swap in a failing fetcher and advance time past 2 * cache_ttl
+    # (60s). Health must fail closed AND chat completions must 503.
+    app.config["ZDR_FETCHER"] = failing_fetcher
+    fake_now["t"] += 60 * 2 + 1  # > 2 * ttl since last success
+
+    health = client.get("/healthz")
+    assert health.status_code == 503, health.data
+
+    chat = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen/qwen3-coder:free",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert chat.status_code == 503, chat.data
+    body = chat.get_json()
+    assert "zdr allow-list unavailable" in body["error"]
+    # And confirm the failing fetcher was invoked at least once during the
+    # stale-cache refresh attempt.
+    assert "fail" in fetch_calls


### PR DESCRIPTION
## Summary

Migrate the OpenClaw agent on `sancta-claw` (Hetzner VPS) off broken Anthropic-via-Pro auth onto a free + ZDR-only OpenRouter model ladder, with ZDR strictly enforced at every request via a local Flask sidecar proxy.

## Why

Every ~2h health probe currently fails with `400 invalid_request_error: "Third-party apps now draw from your extra usage, not your plan limits"` — Anthropic no longer covers third-party apps via Claude.ai Pro/Max plans. Reverting to the previous Anthropic state has zero diagnostic value (it is itself the broken state), so this PR strips the `anthropic/*` and `claude-cli/*` model entries and the `anthropic:default` auth profile to leave a clean end state.

## Design decisions

- **ZDR enforcement: local Flask sidecar proxy** on `127.0.0.1:5780`. Reuses the line-169 injection from `modules/services/open-webui-functions/openrouter_zdr_pipe.py` (`payload["provider"] = {**body.get("provider", {}), "zdr": True}`) plus a fail-closed allow-list fetched from `https://openrouter.ai/api/v1/endpoints/zdr`. New module: `modules/services/openclaw-zdr-proxy.nix`.
- **Model ladder** (free + ZDR, picked from `/api/v1/endpoints/zdr`):
  1. `qwen/qwen3-coder:free` (Venice, 262K) — primary; coder-tuned, biggest free context.
  2. `z-ai/glm-4.5-air:free` (Z.AI, 131K) — secondary; different provider for outage isolation.
  3. `qwen/qwen3-next-80b-a3b-instruct:free` (Venice, 262K) — tertiary; large window general fallback.
- **ZDR allow-list refresh fails closed**: if the upstream `/endpoints/zdr` fetch fails AND the cache is older than `2 * cacheTtl`, the proxy returns 503, not pass-through.
- **Account-level "ZDR endpoints only" toggle** at `https://openrouter.ai/settings/preferences` is layered defense, not the primary mechanism.

## Verification

Five test layers cover this change end-to-end:

1. **Module-eval assertions** (`tests/module-eval.nix`): `services.openclaw-zdr-proxy.port == 5780`, systemd unit references the agenix path, rendered `openclawBrowserConfigScript` contains `qwen/qwen3-coder:free`, `z-ai/glm-4.5-air:free`, `qwen/qwen3-next-80b-a3b-instruct:free`, and `127.0.0.1:5780`, smoke-test body contains the four new check titles, watcher unit contains `.zdr-migration-announced` and `free+ZDR ladder` and `primary=$PRIMARY`.
2. **Pytest unit tests** (`tests/test_openclaw_zdr_proxy.py`): three cases — `test_injects_zdr_true`, `test_rejects_non_zdr_model`, `test_healthz_fails_closed` (asserts 503 after `2 * cacheTtl` of upstream failures).
3. **nixosTest integration** (`tests/openclaw-zdr-proxy.nix`): stands up the proxy + an OpenRouter stub on port 9999, asserts `/healthz` 200, asserts `provider.zdr == true` reaches the upstream payload, asserts a non-ZDR model returns 4xx. Wired into `flake.nix` as `checks.x86_64-linux.openclaw-zdr-proxy`.
4. **Live smoke test** (`/etc/sancta-claw/smoke-test.sh`): four new checks — `openclaw-zdr-proxy` is active, `model.primary` matches the free+ZDR vendor allowlist regex, `/healthz` 200, end-to-end completion to `qwen/qwen3-coder:free` returns content matching `OK`.
5. **Health-check + Telegram alerts** (`hosts/sancta-claw/openclaw-watchers.nix`): one-shot first-success message after migration (gated on `.zdr-migration-announced` sentinel), and regression-side message annotated with active primary model.

## Out of scope (separate issues)

- Broken nightly `Flake Update` workflow (pushes directly to `main`, blocked by branch ruleset).
- 64-day uptime / pending kernel reboot on sancta-claw (`allowReboot = false` is intentional).
- Disk at 80% (57G / 75G) — `nix-collect-garbage` is a separate task.
- Stale Tailscale machines: `sancta-claw-1`, `sancta-claw-e2e-test`, `sancta-gw-1`.
- Tailscale Serve config for `:18789` (mentioned as pending in CLAUDE.md).

## Test plan

- [ ] CI green: `Check Flake & Formatting` + `build-x86` + `evaluate-aarch64` + `python-tests`.
- [ ] After merge: `touch /var/lib/openclaw/rebuild-trigger` on sancta-claw → `nixos-rebuild-watcher.path` fires.
- [ ] Canary: 30 min after rebuild, `journalctl -u openclaw-health-check --since "30 min ago" | grep -c "Gateway healthy"` ≥ 5, zero `Gateway unhealthy`.
- [ ] `/etc/sancta-claw/smoke-test.sh` exits 0 with all PASS.
- [ ] Telegram first-success message arrives exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
