### PR TITLE
fix(openclaw-zdr-proxy,sancta-claw): allow-list parser + provider.models[] schema

### DIFF
--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -175,29 +175,36 @@ let
         "noSandbox": True,
     }
 
+    # Free + ZDR ladder, single source of truth. Primary is rung 0; fallbacks
+    # are the rest. Used to populate three openclaw.json paths so a future PR
+    # adding/removing a rung touches only this list.
+    LADDER = [
+        ("qwen/qwen3-coder:free",                 "Qwen3 Coder (free, ZDR)"),
+        ("z-ai/glm-4.5-air:free",                 "GLM 4.5 Air (free, ZDR)"),
+        ("qwen/qwen3-next-80b-a3b-instruct:free", "Qwen3 Next 80B (free, ZDR)"),
+    ]
+
     # Provider-level override: route every openrouter/* model through the
     # local ZDR proxy on 127.0.0.1:5780. The proxy injects provider.zdr=true
-    # and rejects any model not on the OpenRouter ZDR allow-list. Auth is
-    # supplied by the openrouter:zdr-proxy entry in auth-profiles.json
-    # (separate ExecStartPre), not by an env-var marker here.
+    # and rejects any model not on the OpenRouter ZDR allow-list. Auth flows
+    # from auth-profiles.json keyed by `openrouter:*` (separate ExecStartPre).
+    # OpenClaw 2026.4.x zod schema (additionalProperties: false) requires
+    # `models: [{id, name}]` per provider — without it the gateway exits 1 on
+    # startup with "models.providers.openrouter.models: expected array".
     models_root = config.setdefault("models", {})
     providers = models_root.setdefault("providers", {})
     openrouter_provider = providers.setdefault("openrouter", {})
     openrouter_provider["baseUrl"] = "http://127.0.0.1:5780/v1"
+    openrouter_provider["models"] = [
+        {"id": rung_id, "name": rung_name} for rung_id, rung_name in LADDER
+    ]
 
-    # Free + ZDR ladder, all picked from /api/v1/endpoints/zdr.
-    # Primary: qwen3-coder (Venice, 262K, coder-tuned).
-    # Fallbacks isolate provider outages: glm-4.5-air (Z.AI, 131K)
-    # then qwen3-next-80b (Venice, 262K, general).
     agents = config.setdefault("agents", {})
     defaults = agents.setdefault("defaults", {})
     models = defaults.setdefault("models", {})
     model = defaults.setdefault("model", {})
-    model["primary"] = "qwen/qwen3-coder:free"
-    model["fallbacks"] = [
-        "z-ai/glm-4.5-air:free",
-        "qwen/qwen3-next-80b-a3b-instruct:free",
-    ]
+    model["primary"] = LADDER[0][0]
+    model["fallbacks"] = [rung_id for rung_id, _ in LADDER[1:]]
 
     # Drop legacy anthropic/* and claude-cli/* entries left behind by
     # pre-migration runs. The pre-migration Anthropic-via-Pro state is
@@ -208,14 +215,11 @@ let
         if key.startswith(("anthropic/", "claude-cli/")):
             models.pop(key, None)
 
-    # Register the three rungs as empty entries — baseUrl is provider-level
-    # above; auth flows from auth-profiles.json keyed by provider.
-    for rung in (
-        "qwen/qwen3-coder:free",
-        "z-ai/glm-4.5-air:free",
-        "qwen/qwen3-next-80b-a3b-instruct:free",
-    ):
-        models.setdefault(rung, {})
+    # Register each ladder rung as an empty entry under agents.defaults.models —
+    # this map is keyed by model id, separate from the provider.models[] array
+    # above; baseUrl is provider-level, auth flows from auth-profiles.json.
+    for rung_id, _ in LADDER:
+        models.setdefault(rung_id, {})
 
     # Compaction: preserve 8 recent turns so Kuzea keeps conversational
     # context after auto-compaction instead of losing the thread.

--- a/modules/services/openclaw-zdr-proxy/proxy.py
+++ b/modules/services/openclaw-zdr-proxy/proxy.py
@@ -94,20 +94,35 @@ def _parse_zdr_response(payload: dict[str, Any]) -> set[str]:
     if not isinstance(data, list):
         return set()
 
+    # `/api/v1/endpoints/zdr` returns one entry per provider+model+quant combo;
+    # the canonical model identifier is `model_id` ("qwen/qwen3-coder:free"),
+    # which is what OpenClaw / OpenRouter clients send in the request body.
+    # The previous parser tried to derive the id from `name` (e.g. "Together
+    # | deepseek/...") via rsplit on " | ", which only works when the right
+    # half happens to be the model_id. For Venice, Z.AI and several others
+    # the right half is the human-readable `model_name` ("Qwen3 Coder"), so
+    # the cache silently filled with names that no inbound request would
+    # ever match — the proxy then 403'd every legitimate ZDR-allowed model.
+    # Fix: read `model_id` directly. Keep `id` (some shapes use it) and the
+    # `name`-rsplit path as last-resort fallbacks for forward compatibility.
     out: set[str] = set()
     for item in data:
         if not isinstance(item, dict):
             continue
-        name = item.get("name") or ""
-        if name:
-            parts = name.rsplit(" | ", 1)
-            model_id = parts[1] if len(parts) > 1 else name
-            if model_id:
-                out.add(model_id)
-        # Some shapes also carry a top-level `id`.
+        model_id = item.get("model_id")
+        if isinstance(model_id, str) and model_id:
+            out.add(model_id)
+            continue
         item_id = item.get("id")
         if isinstance(item_id, str) and item_id:
             out.add(item_id)
+            continue
+        name = item.get("name") or ""
+        if name:
+            parts = name.rsplit(" | ", 1)
+            fallback = parts[1] if len(parts) > 1 else name
+            if fallback:
+                out.add(fallback)
     return out
 
 

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -563,6 +563,14 @@ let
           "z-ai/glm-4.5-air:free"
           "qwen/qwen3-next-80b-a3b-instruct:free"
           "127.0.0.1:5780"
+          # OpenClaw 2026.4.x zod schema requires `models: [{id, name}]`
+          # per provider — without this, the gateway exits 1 on startup
+          # with "models.providers.openrouter.models: expected array".
+          # Assert both the assignment site and a representative {id, name}
+          # entry rendered into the script.
+          ''openrouter_provider["models"]''
+          ''"id": rung_id''
+          "Qwen3 Coder (free, ZDR)"
         ];
         missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
       in

--- a/tests/stubs/openrouter_stub.py
+++ b/tests/stubs/openrouter_stub.py
@@ -23,15 +23,38 @@ from typing import Any
 from flask import Flask, jsonify, request
 
 
+# Real OpenRouter `/api/v1/endpoints/zdr` items use a human-readable
+# `name` ("Venice | Qwen3 Coder") and a separate `model_id` carrying the
+# canonical "qwen/qwen3-coder:free" identifier. Older stub data put the
+# canonical id in the `name` rsplit-tail by accident, which let the
+# proxy's name-rsplit parser pass against happy-path stub data while
+# silently failing against real upstream. Stub now mirrors real shape.
 DEFAULT_ZDR_MODELS: list[dict[str, Any]] = [
-    {"name": "Venice | qwen/qwen3-coder:free", "model_name": "Qwen3 Coder (free)"},
-    {"name": "Z.AI | z-ai/glm-4.5-air:free", "model_name": "GLM 4.5 Air (free)"},
     {
-        "name": "Venice | qwen/qwen3-next-80b-a3b-instruct:free",
+        "name": "Venice | Qwen3 Coder",
+        "model_id": "qwen/qwen3-coder:free",
+        "model_name": "Qwen3 Coder (free)",
+    },
+    {
+        "name": "Z.AI | GLM 4.5 Air",
+        "model_id": "z-ai/glm-4.5-air:free",
+        "model_name": "GLM 4.5 Air (free)",
+    },
+    {
+        "name": "Venice | Qwen3 Next 80B",
+        "model_id": "qwen/qwen3-next-80b-a3b-instruct:free",
         "model_name": "Qwen3 Next 80B (free)",
     },
-    {"name": "OpenAI | openrouter/gpt-4o-mini", "model_name": "GPT-4o Mini"},
-    {"name": "OpenAI | openrouter/gpt-4o", "model_name": "GPT-4o"},
+    {
+        "name": "OpenAI | GPT-4o Mini",
+        "model_id": "openrouter/gpt-4o-mini",
+        "model_name": "GPT-4o Mini",
+    },
+    {
+        "name": "OpenAI | GPT-4o",
+        "model_id": "openrouter/gpt-4o",
+        "model_name": "GPT-4o",
+    },
 ]
 
 

--- a/tests/test_openclaw_zdr_proxy.py
+++ b/tests/test_openclaw_zdr_proxy.py
@@ -57,10 +57,13 @@ class _ServerThread(threading.Thread):
 @pytest.fixture
 def stub_server():
     port = _free_port()
+    # Real OpenRouter `name` is "<provider> | <human-readable-model-name>";
+    # the canonical id lives in `model_id`. Tests must mirror real shape so
+    # the parser is exercised against the field it has to read in production.
     app = create_stub_openrouter(
         zdr_models=[
-            {"name": "Venice | qwen/qwen3-coder:free"},
-            {"name": "Z.AI | z-ai/glm-4.5-air:free"},
+            {"name": "Venice | Qwen3 Coder", "model_id": "qwen/qwen3-coder:free"},
+            {"name": "Z.AI | GLM 4.5 Air", "model_id": "z-ai/glm-4.5-air:free"},
         ],
     )
     server = _ServerThread(app, port)
@@ -70,6 +73,35 @@ def stub_server():
         yield {"app": app, "url": f"http://127.0.0.1:{port}/v1"}
     finally:
         server.shutdown()
+
+
+def test_parses_model_id_field():
+    """Regression: the parser must read `model_id`, not derive it from `name`.
+
+    Real OpenRouter `name` is "Venice | Qwen3 Coder" (provider | display
+    name), so the older rsplit-on-' | ' parser cached the human-readable
+    name and rejected every legitimate model. Production hit this on
+    sancta-claw post-deploy: every chat completion 403'd with
+    'model 'qwen/qwen3-coder:free' is not in the ZDR allow-list'.
+    """
+    payload = {
+        "data": [
+            {"name": "Venice | Qwen3 Coder", "model_id": "qwen/qwen3-coder:free"},
+            {"name": "Z.AI | GLM 4.5 Air", "model_id": "z-ai/glm-4.5-air:free"},
+            # Missing model_id, falls back to `id` (some shapes use this).
+            {"name": "Other | Something", "id": "openrouter/something:free"},
+            # Last-resort: only `name` available; rsplit on " | ".
+            {"name": "Inline | inline/legacy:free"},
+        ]
+    }
+    parsed = proxy_mod._parse_zdr_response(payload)
+    assert "qwen/qwen3-coder:free" in parsed
+    assert "z-ai/glm-4.5-air:free" in parsed
+    assert "openrouter/something:free" in parsed
+    assert "inline/legacy:free" in parsed
+    # Human-readable display names must NOT leak into the allow-list.
+    assert "Qwen3 Coder" not in parsed
+    assert "GLM 4.5 Air" not in parsed
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Hotfix on top of #420. After deploying that PR to sancta-claw, two real bugs surfaced that prevented any successful LLM call on the new free+ZDR ladder:

- **Allow-list parser bug** in `modules/services/openclaw-zdr-proxy/proxy.py`. The cache was filled with human-readable names instead of canonical model IDs, so every legitimate request was rejected with `model '...' is not in the ZDR allow-list`. The fix reads `model_id` directly. Stub test data was happy-path-biased and let the bug through pytest; stub is now aligned with real upstream shape and a regression test pins it.
- **`openclaw.json` provider schema** in `hosts/sancta-claw/openclaw-service.nix`. OpenClaw 2026.4.x's zod schema requires `models.providers.<name>.models: Array<{id, name}>` and rejects unknown keys (`additionalProperties: false`). The original migration only set `baseUrl`, so the gateway crashed on every restart. Refactored to a single `LADDER` source of truth used by `model.primary`, `model.fallbacks`, and `provider.models[]`.

Both bugs are live on sancta-claw right now; this PR is the source-of-truth fix that will be deployed by the existing `nixos-rebuild-watcher` once merged.

## Verification

- [x] `pytest tests/test_openclaw_zdr_proxy.py -v` — 4/4 pass, including new `test_parses_model_id_field` regression
- [x] `nix flake check --all-systems` locally — green (module-eval extended to assert the new `openrouter_provider["models"]` rendering)
- [x] Tactical jq patch on the live host with the same schema shape — `openclaw.service` came up `active` and bound :18789, confirming the schema fix is correct
- [ ] CI `Check Flake & Formatting` — green (will appear after push)
- [ ] Post-merge: trigger rebuild, confirm `openclaw-zdr-proxy.service` cache contains real `model_id`s, confirm end-to-end smoke check passes

## Out of scope

- Stale-orphan cleanup pattern (kill any leftover `openclaw-gateway` on unit stop) — Task B2 in the migration plan; can fold into this PR if reviewer wants, otherwise follow-up.
- The orphaned March-24 `openclaw-gateway` PID 947122 holding :18789 was killed manually as part of the tactical fix; without B2 it could happen again on the next migration-class rebuild.

## Related

Migration PR: #420 (merged 2026-05-02 06:39 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
