### PR TITLE
fix(openclaw-zdr-proxy): stop injecting provider.allow — OpenRouter rejects unknown keys

### DIFF
--- a/modules/services/openclaw-zdr-proxy/proxy.py
+++ b/modules/services/openclaw-zdr-proxy/proxy.py
@@ -6,9 +6,10 @@ A Flask sidecar that sits between OpenClaw and OpenRouter. Every request:
 1. Has its `model` field validated against a fail-closed allow-list fetched
    from `${UPSTREAM}/endpoints/zdr` (cached, lazy refresh).
 2. Has `provider.zdr = true` injected (matches the open-webui pipe pattern).
-3. Has `provider.allow = [<cached_allow_list>]` injected so OpenRouter only
-   routes to ZDR endpoints even if a future upstream change made the global
-   ZDR flag insufficient.
+   This is the only field needed for upstream ZDR enforcement; OpenRouter's
+   request schema rejects unknown keys, so the proxy does NOT inject
+   `provider.allow` — the model allow-list is enforced client-side via the
+   403 path above, not by stuffing it into the upstream payload.
 
 Fail-closed semantics: if the upstream allow-list refresh fails AND the
 existing cache is older than `2 * cacheTtl` seconds, the proxy returns 503
@@ -261,7 +262,14 @@ def create_app(
         # client explicitly sends `"provider": null`. `{**None}` raises
         # TypeError, so coalesce explicitly.
         provider_in = body.get("provider") or {}
-        provider = {**provider_in, "zdr": True, "allow": sorted(allow)}
+        # ZDR enforcement on the upstream side is a single boolean: `zdr: true`
+        # tells OpenRouter to route only to ZDR endpoints. The defense-in-depth
+        # layer is the proxy's own client-side rejection above (the `model not
+        # in allow_list -> 403` branch). Earlier versions also stuffed the full
+        # allow-list into `provider.allow`, but OpenRouter's request schema
+        # rejects unknown keys with HTTP 400 (`Unrecognized key: "allow"`),
+        # which broke every chat completion. Keep the injection minimal.
+        provider = {**provider_in, "zdr": True}
         payload = {**body, "provider": provider}
 
         headers = {

--- a/tests/test_openclaw_zdr_proxy.py
+++ b/tests/test_openclaw_zdr_proxy.py
@@ -117,7 +117,15 @@ def proxy_app(stub_server):
 
 
 def test_injects_zdr_true(proxy_app, stub_server):
-    """Forwarded payload must carry provider.zdr=True and an allow-list."""
+    """Forwarded payload must carry provider.zdr=True and nothing extra.
+
+    Earlier versions also injected `provider.allow = [...]` (the cached
+    ZDR allow-list) as defense-in-depth. OpenRouter's request schema
+    rejects unknown keys, so that injection broke every real chat
+    completion with HTTP 400 (`Unrecognized key: "allow"`). The proxy
+    enforces the allow-list client-side via the 403 branch instead;
+    upstream injection is the boolean `zdr` flag only.
+    """
     client = proxy_app.test_client()
 
     resp = client.post(
@@ -131,9 +139,9 @@ def test_injects_zdr_true(proxy_app, stub_server):
 
     last = stub_server["app"].config["LAST_PAYLOAD"]
     assert last is not None, "stub did not record any upstream POST"
-    assert last["provider"]["zdr"] is True
-    assert "allow" in last["provider"]
-    assert "qwen/qwen3-coder:free" in last["provider"]["allow"]
+    assert last["provider"] == {"zdr": True}, (
+        f"upstream provider must be exactly {{'zdr': True}}, got {last['provider']!r}"
+    )
 
 
 def test_rejects_non_zdr_model(proxy_app, stub_server):


### PR DESCRIPTION
## Summary

Third bug surfaced after deploying #421: OpenRouter rejects the proxy's request with HTTP 400 `provider: Unrecognized key: "allow"`. The proxy injected the cached ZDR allow-list as `provider.allow = […]` on top of `provider.zdr = true`. OpenRouter's request schema rejects unknown keys in the `provider` block, so this broke every chat completion.

The allow-list still serves its purpose — the proxy enforces it client-side via the 403 branch (rejecting non-ZDR model IDs before they reach upstream). Only the upstream injection of the list is being removed.

## Why this wasn't caught earlier

The auto-review on #420 flagged it as MEDIUM 2 ("payload inflation, consider removing"). I dismissed it as belt-and-suspenders and merged. Live deploy proved the auto-review correct.

The pytest stub didn't catch it because the stub accepted any keys in the request body and echoed them back; only the real OpenRouter API rejects unknown `provider.*` keys.

## Verification

- [x] `pytest tests/test_openclaw_zdr_proxy.py -v` — 4/4 pass; updated `test_injects_zdr_true` asserts `provider == {"zdr": True}` exactly so future "let's add X for safety" patches have to confront the upstream-schema reality.
- [ ] CI `Check Flake & Formatting` — should be green (no Nix changes).
- [ ] Post-merge: trigger rebuild on sancta-claw, run `/etc/sancta-claw/smoke-test.sh` — `openclaw: end-to-end completion` should finally PASS.

## Related

- #420 — original migration (introduced the bug)
- #421 — fixed parser + provider schema; the allow-injection bug was hiding behind those two

🤖 Generated with [Claude Code](https://claude.com/claude-code)
