### PR TITLE
fix(sancta-claw): Telegram alerts read .botToken not .token

### DIFF
--- a/hosts/sancta-claw/openclaw-watchers.nix
+++ b/hosts/sancta-claw/openclaw-watchers.nix
@@ -20,7 +20,7 @@ let
       # one-shot announcement marker does not yet exist. Subsequent green
       # probes are silent. Marker is plain `touch` — survives reboots.
       if [ "$PREV_FAILURES" -gt 0 ] && [ ! -f "$ANNOUNCED_FILE" ]; then
-        TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
+        TOKEN=$(jq -r '.channels.telegram.botToken // empty' "$OC_CONFIG" 2>/dev/null || true)
         CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
         PRIMARY=$(jq -r '.agents.defaults.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
         # Only mark "announced" after a real send. If the Telegram token is
@@ -55,7 +55,7 @@ let
       RECENT_RESTARTS=$(find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN" 2>/dev/null | wc -l)
 
       NOW=$(date +%s)
-      TOKEN=$(jq -r '.channels.telegram.token // empty' "$OC_CONFIG" 2>/dev/null || true)
+      TOKEN=$(jq -r '.channels.telegram.botToken // empty' "$OC_CONFIG" 2>/dev/null || true)
       CHAT_ID=$(jq -r '.channels.telegram.chatId // "364749075"' "$OC_CONFIG" 2>/dev/null || echo 364749075)
       PRIMARY=$(jq -r '.agents.defaults.model.primary // "unknown"' "$OC_CONFIG" 2>/dev/null || echo unknown)
 


### PR DESCRIPTION
## Summary

Fourth bug surfaced: the Telegram alerts in `openclaw-watchers.nix` read the bot token from `.channels.telegram.token`, but OpenClaw 2026.4.x stores it at `.channels.telegram.botToken`. The `// empty` fallback masked the mismatch — `TOKEN` was always empty, the `if [ -n "$TOKEN" ]` guard short-circuited, no curl ran, no message ever sent.

The bug predates this migration (the failure-side crash-loop alert had it too) but only became visible because:
- the first-success announcement added in #420 was the first time anyone was looking for an outbound notification
- the post-#420 restart loop accumulated 16 health-check failures with zero alerts

## Verification

- [x] Bot itself confirmed alive: `bot/getMe → {ok: true, username: "kuzea_assistant_bot"}`
- [x] Direct `curl bot/sendMessage` with the same token from `openclaw.json` and chatId 364749075 delivered to the user (message_id 3326)
- [x] Both jq paths switched via `replace_all` (only two occurrences in the file, both identical)
- [ ] CI `Check Flake & Formatting` — green expected (one-line nix change)
- [ ] Post-merge: trigger rebuild, then `echo 1 > /var/lib/openclaw/.health-failures && rm -f /var/lib/openclaw/.zdr-migration-announced` to set up the broken→healthy transition; the next probe (≤60s later) should fire the announcement.

## Why this slipped past previous reviews

The round-2 review fixes in #421 (commit `e211805`) actually *touched* both of these `.token` lines (changed `.model.primary` references on the same lines) without spotting that `.token` is also wrong — the review focused on the model-path bug and missed the adjacent token-path bug.

## Related

- #420 — original migration (introduced the token-path bug in the new announcement code)
- #421 — fixed adjacent jq paths in same file but missed `.token`
- #422 — proxy `provider.allow` injection fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
