### PR TITLE
fix(sancta-claw): make OpenClaw resolve free+ZDR model selectors

### DIFF
--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -176,35 +176,60 @@ let
     }
 
     # Free + ZDR ladder, single source of truth. Primary is rung 0; fallbacks
-    # are the rest. Used to populate three openclaw.json paths so a future PR
-    # adding/removing a rung touches only this list.
+    # are the rest. Used to populate two openclaw.json paths (provider.models[]
+    # and agents.defaults.model.{primary,fallbacks}) so a future PR adding or
+    # removing a rung touches one place.
     LADDER = [
-        ("qwen/qwen3-coder:free",                 "Qwen3 Coder (free, ZDR)"),
-        ("z-ai/glm-4.5-air:free",                 "GLM 4.5 Air (free, ZDR)"),
-        ("qwen/qwen3-next-80b-a3b-instruct:free", "Qwen3 Next 80B (free, ZDR)"),
+        {"id": "qwen/qwen3-coder:free",                 "name": "Qwen3 Coder (free, ZDR)",   "ctx": 262144},
+        {"id": "z-ai/glm-4.5-air:free",                 "name": "GLM 4.5 Air (free, ZDR)",   "ctx": 131072},
+        {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "name": "Qwen3 Next 80B (free, ZDR)","ctx": 262144},
     ]
+
+    def _make_model_entry(rung):
+        # OpenClaw 2026.4.x's runtime resolution requires every field below
+        # for a custom-provider model to be picked up — empty {id,name} entries
+        # parse fine but fail at runtime with `model_not_found`. Specifically:
+        #   `findInlineModelMatch` in dist/anthropic-vertex-stream-*.js returns
+        #   the matched entry, then `resolveExplicitModelWithRegistry` checks
+        #   `if (inlineMatch?.api)` — the api flag is read from the entry, not
+        #   propagated from provider-level. The other metadata (reasoning,
+        #   input, cost, contextWindow, maxTokens) mirrors the canonical built-in
+        #   `buildOpenrouterProvider()` shape in dist/provider-catalog-*.js.
+        return {
+            "id":            rung["id"],
+            "name":          rung["name"],
+            "api":           "openai-completions",
+            "reasoning":     False,
+            "input":         ["text"],
+            "cost":          {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": rung["ctx"],
+            "maxTokens":     8192,
+        }
 
     # Provider-level override: route every openrouter/* model through the
     # local ZDR proxy on 127.0.0.1:5780. The proxy injects provider.zdr=true
     # and rejects any model not on the OpenRouter ZDR allow-list. Auth flows
     # from auth-profiles.json keyed by `openrouter:*` (separate ExecStartPre).
-    # OpenClaw 2026.4.x zod schema (additionalProperties: false) requires
-    # `models: [{id, name}]` per provider — without it the gateway exits 1 on
-    # startup with "models.providers.openrouter.models: expected array".
     models_root = config.setdefault("models", {})
     providers = models_root.setdefault("providers", {})
     openrouter_provider = providers.setdefault("openrouter", {})
     openrouter_provider["baseUrl"] = "http://127.0.0.1:5780/v1"
-    openrouter_provider["models"] = [
-        {"id": rung_id, "name": rung_name} for rung_id, rung_name in LADDER
-    ]
+    openrouter_provider["api"] = "openai-completions"
+    openrouter_provider["models"] = [_make_model_entry(r) for r in LADDER]
 
+    # Selectors carry the literal `openrouter/` prefix because OpenClaw's
+    # `parseModelRef` (dist/model-selection-*.js) splits on the FIRST slash to
+    # derive (provider, modelId). Without the prefix, "qwen/qwen3-coder:free"
+    # parses as provider="qwen" — no such provider configured — and resolution
+    # fails before any HTTP call. With the prefix it parses as provider=
+    # "openrouter", modelId="qwen/qwen3-coder:free", which then matches the
+    # entry above by (provider, id).
     agents = config.setdefault("agents", {})
     defaults = agents.setdefault("defaults", {})
     models = defaults.setdefault("models", {})
     model = defaults.setdefault("model", {})
-    model["primary"] = LADDER[0][0]
-    model["fallbacks"] = [rung_id for rung_id, _ in LADDER[1:]]
+    model["primary"] = f"openrouter/{LADDER[0]['id']}"
+    model["fallbacks"] = [f"openrouter/{r['id']}" for r in LADDER[1:]]
 
     # Drop legacy anthropic/* and claude-cli/* entries left behind by
     # pre-migration runs. The pre-migration Anthropic-via-Pro state is
@@ -215,11 +240,10 @@ let
         if key.startswith(("anthropic/", "claude-cli/")):
             models.pop(key, None)
 
-    # Register each ladder rung as an empty entry under agents.defaults.models —
-    # this map is keyed by model id, separate from the provider.models[] array
-    # above; baseUrl is provider-level, auth flows from auth-profiles.json.
-    for rung_id, _ in LADDER:
-        models.setdefault(rung_id, {})
+    # NOTE: agents.defaults.models{} is NOT used for resolution — it's only
+    # consulted for display aliases. Resolution goes through models.providers
+    # only. Don't add ladder entries here; they'd just be dead weight and
+    # would have to be hand-removed when a rung gets retired.
 
     # Compaction: preserve 8 recent turns so Kuzea keeps conversational
     # context after auto-compaction instead of losing the thread.

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -563,14 +563,22 @@ let
           "z-ai/glm-4.5-air:free"
           "qwen/qwen3-next-80b-a3b-instruct:free"
           "127.0.0.1:5780"
-          # OpenClaw 2026.4.x zod schema requires `models: [{id, name}]`
-          # per provider — without this, the gateway exits 1 on startup
-          # with "models.providers.openrouter.models: expected array".
-          # Assert both the assignment site and a representative {id, name}
-          # entry rendered into the script.
-          ''openrouter_provider["models"]''
-          ''"id": rung_id''
+          # Provider config + ladder entries (OpenClaw 2026.4.x zod schema
+          # requires the rich model metadata for runtime resolution to
+          # succeed; empty {id,name} entries parse but fail at runtime with
+          # `model_not_found`).
+          ''openrouter_provider["models"] = [_make_model_entry(r) for r in LADDER]''
           "Qwen3 Coder (free, ZDR)"
+          # Selectors carry the literal `openrouter/` prefix; without it,
+          # OpenClaw's parseModelRef splits on the first `/` and tries to
+          # find a provider named "qwen" / "z-ai" instead of "openrouter".
+          ''f"openrouter/{LADDER[0]['id']}"''
+          # Per-model api + canonical-shape sentinels — without per-entry
+          # api, `resolveExplicitModelWithRegistry`'s `if (inlineMatch?.api)`
+          # check fails and resolution falls through to the registry, which
+          # doesn't know our custom IDs.
+          ''"api":           "openai-completions"''
+          ''"contextWindow": rung["ctx"]''
         ];
         missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
       in


### PR DESCRIPTION
## Summary

PR #420 deployed model selectors as bare IDs (`qwen/qwen3-coder:free`) with provider entries `{id, name}` only. OpenClaw 2026.4.x's zod schema accepts that, but the runtime resolution fails — every chat completion ends with `model_not_found` BEFORE any HTTP call to the proxy. The bot returned `⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.` for every Telegram message.

After reading the npm dist source, two specific bugs:

1. **`parseModelRef`** (`dist/model-selection-*.js`) splits the selector on the **first** `/`. `"qwen/qwen3-coder:free"` parses as `provider="qwen"`, `modelId="qwen3-coder:free"`. Our config only declares the `openrouter` provider — no `qwen` provider — so the inline lookup fails and the registry lookup doesn't know our custom IDs. Fix: prefix selectors literally with `openrouter/`. The split then gives `provider="openrouter"`, `modelId="qwen/qwen3-coder:free"`, which matches the provider's models[] entry by `(provider, id)`.

2. **`resolveExplicitModelWithRegistry`** (`dist/anthropic-vertex-stream-*.js`) gates on `if (inlineMatch?.api)` — checks for `api` on the matched **entry**, not propagated from provider-level. Empty `{id, name}` entries pass schema validation but fall through to the registry lookup at runtime. Fix: each entry now includes the canonical metadata block that `buildOpenrouterProvider` (`dist/provider-catalog-*.js`) uses for built-in OpenRouter models — `api`, `reasoning`, `input`, `cost`, `contextWindow`, `maxTokens`.

## Verification

- [x] **Live on sancta-claw** via runtime systemd drop-in (now superseded by this code change): with prefix + rich metadata, `openclaw agent --message "say OK"` shows `requested=openrouter/qwen/qwen3-coder:free` (selector parsed correctly) and `model=... provider=openrouter` (resolution succeeded; request reached OpenRouter via the proxy). Remaining errors in the journal were free-tier 429s — the failover ladder cycles through rungs as designed.
- [x] `nix flake check --all-systems --no-build` — green. `module-eval` checks now assert the canonical-shape sentinels (`openrouter/`-prefixed selector, `"contextWindow"`, per-model `"api"`).
- [ ] CI `Check Flake & Formatting`.
- [ ] Post-merge: trigger rebuild, send a real message via Telegram to `@kuzea_assistant_bot` — must get an LLM reply (or a free-tier rate-limit message), not the "Something went wrong" error.

## Refactor

- LADDER from tuples to dicts (`{id, name, ctx}`) with helper `_make_model_entry(rung)` returning the full entry shape. Single source of truth.
- Dropped the `agents.defaults.models{}` ladder-rung registration — that map is only used for display aliases per the dist source, not resolution.

## Related

- #420 — original migration (introduced the bugs)
- #421 — `provider.models[]` array required (cleared bug A)
- #422 — `provider.allow` injection rejected by OpenRouter (cleared bug B)
- #423 — Telegram `.botToken` jq key (independent, still pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
