### PR TITLE
fix(hermes-claw): drop --read-only flag — incompatible with hermes-agent image

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -90,7 +90,13 @@ in
     extraOptions = [
       "--security-opt=no-new-privileges"
       "--cap-drop=ALL"
-      "--read-only"
+      # `--read-only` removed: triggers `crun: write: No space left on device`
+      # at OCI spec prep time on this image (verified empirically — even an
+      # empty bind-mount + tmpfs /tmp config fails before the entrypoint runs,
+      # so it's not an upstream Python bytecode write). Container security
+      # boundary remains: namespace isolation + dropped caps + no-new-privs;
+      # rootfs writes are ephemeral (vanish on container remove). Reintroduce
+      # once the upstream crun/image interaction is understood.
       "--tmpfs=/tmp:size=64m"
       "--shm-size=256m"
       "--memory=2g"
@@ -106,7 +112,7 @@ in
   # storage, container state to /run/containers, and manages cgroups. Applying
   # ProtectSystem=strict / ProtectControlGroups / PrivateDevices to *this*
   # unit would block podman from doing its job. Workload hardening lives on
-  # the container itself via `extraOptions` (--cap-drop=ALL, --read-only,
+  # the container itself via `extraOptions` (--cap-drop=ALL,
   # --security-opt=no-new-privileges, tmpfs, memory/cpu caps), which the
   # kernel actually applies inside the container's namespace.
   systemd.services.podman-hermes-agent = {


### PR DESCRIPTION
fix(hermes-claw): drop --read-only flag — incompatible with this image

Empirical: podman run --read-only against
nousresearch/hermes-agent@sha256:900e1f8076... fails at OCI spec prep
time with "crun: write: No space left on device" BEFORE the container
entrypoint runs. Reproduced on hermes-claw post-deploy with a
hello-world control showing all our other flags are fine.

Tried fixing with PYTHONDONTWRITEBYTECODE=1 (in case Python bytecode
writes were the cause) — no change, confirming the failure is at
crun/runtime layer, not in the image startup.

Container security posture is unchanged otherwise:
  - --security-opt=no-new-privileges (kernel-enforced)
  - --cap-drop=ALL (no Linux capabilities)
  - --tmpfs=/tmp:size=64m + --shm-size=256m (size-bounded)
  - --memory=2g --cpus=2.0 (resource caps)
  - User namespace isolation, default podman bridge net
  - Loopback-only port binding (127.0.0.1:8642)
  - Bind mount /opt/data to /var/lib/hermes/data (only writable host path)

Without --read-only, rootfs writes are still ephemeral (vanish on
podman rm) and confined to the container overlay layer. The
defense-in-depth value of --read-only was real but small here;
getting the agent functional matters more for the initial deploy.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
