### PR TITLE
fix(hermes-claw): bump container --tmpfs=/tmp size from 64m to 1g

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -97,7 +97,12 @@ in
       # boundary remains: namespace isolation + dropped caps + no-new-privs;
       # rootfs writes are ephemeral (vanish on container remove). Reintroduce
       # once the upstream crun/image interaction is understood.
-      "--tmpfs=/tmp:size=64m"
+      # tmpfs size MUST be >=1g for this image — crun fails at OCI spec prep
+      # with a misleading "No space left on device" if smaller (verified
+      # empirically: 64m/256m/512m all fail; 1g works). The container's actual
+      # /tmp usage at startup is modest, so 1g is comfortable headroom; the
+      # tmpfs counts against the container's --memory budget.
+      "--tmpfs=/tmp:size=1g"
       "--shm-size=256m"
       "--memory=2g"
       "--cpus=2.0"


### PR DESCRIPTION
fix(hermes-claw): bump container --tmpfs=/tmp size from 64m to 1g

Root cause finally isolated. The crun "No space left on device" error
that has been failing the container since first deploy is triggered
specifically by --tmpfs=/tmp:size=64m. Verified empirically on the
live host:

  --tmpfs=/tmp:size=64m   => crun: write: No space left on device
  --tmpfs=/tmp:size=256m  => crun: write: No space left on device
  --tmpfs=/tmp:size=512m  => crun: write: No space left on device
  --tmpfs=/tmp:size=1g    => container starts cleanly

This is a misleading crun error: the failure happens at OCI spec
prep time before the container entrypoint runs, and the message
points at "write" / "No space left on device" rather than the
actual sizing problem. Larger tmpfs unblocks startup.

The previous PR (#427) that removed --read-only was based on a
correct observation (the container fails) but a wrong diagnosis.
With the tmpfs bumped to 1g, --read-only is in fact compatible
again — but I'm leaving it removed for now because the container
still exits cleanly under --read-only with this image (a separate
issue: container startup writes outside /opt/data). Restoring
--read-only is a follow-up once the upstream image's actual write
paths are characterized.

The 1g tmpfs counts against the container's --memory=2g budget,
leaving ~1g working memory. Hermes Agent on OpenRouter (no local
model) should comfortably fit; if it doesn't, bump --memory to 3g.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
