### PR TITLE
fix(hermes-claw): grant minimal caps for entrypoint init

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -89,7 +89,19 @@ in
     environmentFiles = [ "/run/hermes-agent/env" ];
     extraOptions = [
       "--security-opt=no-new-privileges"
+      # Drop everything, then add back the bare minimum the upstream image's
+      # entrypoint needs to do its init: chown /opt/data to its internal
+      # hermes user (UID 10000) and setuid to that UID. After the setuid,
+      # the process is unprivileged AND --security-opt=no-new-privileges
+      # prevents re-escalation, so these caps are only briefly held by PID 1.
+      # Without them, the entrypoint hits "operation not permitted" on the
+      # setuid call and the container exits status=1 in <100ms.
       "--cap-drop=ALL"
+      "--cap-add=CHOWN"
+      "--cap-add=SETUID"
+      "--cap-add=SETGID"
+      "--cap-add=FOWNER"
+      "--cap-add=DAC_OVERRIDE"
       # `--read-only` removed: triggers `crun: write: No space left on device`
       # at OCI spec prep time on this image (verified empirically — even an
       # empty bind-mount + tmpfs /tmp config fails before the entrypoint runs,


### PR DESCRIPTION
fix(hermes-claw): grant minimal caps for entrypoint init (chown + setuid)

After the tmpfs sizing fix in #428, the container made it past OCI
spec prep but exited <100ms with:

  Fixing ownership of /opt/data to hermes (10000)
  Warning: chown failed (rootless container?) — continuing anyway
  Dropping root privileges
  error: failed switching to 'hermes': operation not permitted

The upstream entrypoint runs as root in the container, chown's
/opt/data to its built-in non-root `hermes` user (UID 10000), then
setuid's to that UID. With --cap-drop=ALL the chown silently failed
(the warning) and the setuid hit EPERM (no CAP_SETUID).

Add the minimal caps the entrypoint needs:
  CHOWN, SETUID, SETGID, FOWNER, DAC_OVERRIDE

These are held only by PID 1 in the container, briefly, before the
setuid happens. After the setuid the process is UID 10000 and
no-new-privileges prevents re-escalation, so the caps are
effectively dead the instant the setuid completes.

Verified live on hermes-claw: with this cap-add, the container
starts cleanly, the gateway logs "Hermes Gateway Starting...", and
the bundled-skills sync runs as expected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
