### PR TITLE
fix(hermes-claw): Telegram allowed users + skills permissions

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -1,4 +1,5 @@
 { config
+, lib
 , pkgs
 , ...
 }:
@@ -62,7 +63,7 @@
 
     # Non-secret environment
     environment = {
-      TELEGRAM_ALLOWED_USERS = "364749075";
+      TELEGRAM_ALLOWED_USERS = "364749075,7957556729";
       HERMES_DASHBOARD = "0";
     };
 
@@ -74,4 +75,15 @@
       curl
     ];
   };
+
+  # ── Fix skills directory permissions ────────────────────────────────
+  # Default skills are copied from the Nix store (read-only, 444/555).
+  # The upstream entrypoint chown's HERMES_HOME but doesn't chmod u+w,
+  # so the hermes user owns the files but can't write to them.
+  # Run after the upstream activation script to ensure skills are writable.
+  system.activationScripts."hermes-skills-permissions" = lib.stringAfter [ "hermes-agent-setup" ] ''
+    if [ -d /var/lib/hermes/.hermes/skills ]; then
+      find /var/lib/hermes/.hermes/skills -not -perm -u+w -exec chmod u+w {} +
+    fi
+  '';
 }

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -678,7 +678,7 @@ let
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
           modelPin = ha.settings.model.default == "tencent/hy3-preview:free";
           modelProvider = ha.settings.model.provider == "openrouter";
-          telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075";
+          telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";
           hasEnvFiles = builtins.any (f: builtins.match ".*/hermes-env" f != null) ha.environmentFiles;
         };


### PR DESCRIPTION
## Summary
- Add Kuzea bot ID (`7957556729`) to `TELEGRAM_ALLOWED_USERS` — was rejected as "Unauthorized user" in the shared "Bots" group
- Add activation script to `chmod u+w` the skills directory — default skills copied from Nix store retain read-only permissions, causing `PermissionError` on `skill_manage` tool calls

## Root cause
1. **Unauthorized user**: hermes-claw runs in a Telegram group with the Kuzea bot; only user `364749075` was allowed
2. **Skills permissions**: upstream entrypoint does `chown -R` on `$HERMES_HOME` but not `chmod u+w`, so files copied from the Nix store (`r--r--r--`) stay read-only even after ownership change

## Test plan
- [ ] CI passes (`nix flake check` + hermes-claw build)
- [ ] Deploy to hermes-claw, verify no `PermissionError` in logs after skill_manage calls
- [ ] Verify Kuzea bot messages in "Bots" group no longer trigger "Unauthorized user" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)