### PR TITLE
fix(hermes-claw): switch to llama-3.3-70b (free+ZDR+tools)

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -40,15 +40,15 @@
     # Declarative config — deep-merged into $HERMES_HOME/config.yaml
     settings = {
       model = {
-        default = "nousresearch/hermes-3-llama-3.1-405b:free";
+        default = "meta-llama/llama-3.3-70b-instruct:free";
         provider = "openrouter";
         base_url = "https://openrouter.ai/api/v1";
       };
       auxiliary = {
-        title_generation = { provider = "openrouter"; model = "nousresearch/hermes-3-llama-3.1-405b:free"; };
-        compression = { provider = "openrouter"; model = "nousresearch/hermes-3-llama-3.1-405b:free"; };
-        session_search = { provider = "openrouter"; model = "nousresearch/hermes-3-llama-3.1-405b:free"; };
-        web_extract = { provider = "openrouter"; model = "nousresearch/hermes-3-llama-3.1-405b:free"; };
+        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
+        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
+        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
+        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
       };
       toolsets = [ "all" ];
       memory = { enabled = true; };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -676,7 +676,7 @@ let
           containerBackend = ha.container.backend == "podman";
           containerImage = ha.container.image == "ubuntu:24.04";
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
-          modelPin = ha.settings.model.default == "nousresearch/hermes-3-llama-3.1-405b:free";
+          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct:free";
           modelProvider = ha.settings.model.provider == "openrouter";
           telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";


### PR DESCRIPTION
## Summary
- `hermes-3-llama-3.1-405b:free` doesn't support tool use → HTTP 404
- Switch to `meta-llama/llama-3.3-70b-instruct:free` (free, ZDR via Venice, tool calling, 65k context)

Already hotfixed on hermes-claw — this makes it survive rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)