### PR TITLE
fix(hermes-claw): use paid llama-3.3-70b (drop :free)

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -40,15 +40,15 @@
     # Declarative config — deep-merged into $HERMES_HOME/config.yaml
     settings = {
       model = {
-        default = "meta-llama/llama-3.3-70b-instruct:free";
+        default = "meta-llama/llama-3.3-70b-instruct";
         provider = "openrouter";
         base_url = "https://openrouter.ai/api/v1";
       };
       auxiliary = {
-        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
+        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
       };
       toolsets = [ "all" ];
       memory = { enabled = true; };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -676,7 +676,7 @@ let
           containerBackend = ha.container.backend == "podman";
           containerImage = ha.container.image == "ubuntu:24.04";
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
-          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct:free";
+          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct";
           modelProvider = ha.settings.model.provider == "openrouter";
           telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";


### PR DESCRIPTION
## Summary
- Drop `:free` suffix from `meta-llama/llama-3.3-70b-instruct`
- Free tier hits 429 rate limits → exhausts credential pool → bot goes silent
- Paid version: $0.10/M input, $0.32/M output — trivial cost within $20/day budget
- Also gets 131k context (vs 65k on free tier)

Already hotfixed on hermes-claw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)