### PR TITLE
feat(hermes-claw): switch to qwen3-coder:free

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -40,15 +40,15 @@
     # Declarative config — deep-merged into $HERMES_HOME/config.yaml
     settings = {
       model = {
-        default = "meta-llama/llama-3.3-70b-instruct";
+        default = "qwen/qwen3-coder:free";
         provider = "openrouter";
         base_url = "https://openrouter.ai/api/v1";
       };
       auxiliary = {
-        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
-        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
-        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
-        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        title_generation = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
+        compression = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
+        session_search = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
+        web_extract = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
       };
       toolsets = [ "all" ];
       memory = { enabled = true; };

--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -40,15 +40,15 @@
     # Declarative config — deep-merged into $HERMES_HOME/config.yaml
     settings = {
       model = {
-        default = "meta-llama/llama-3.3-70b-instruct:free";
+        default = "meta-llama/llama-3.3-70b-instruct";
         provider = "openrouter";
         base_url = "https://openrouter.ai/api/v1";
       };
       auxiliary = {
-        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
-        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct:free"; };
+        title_generation = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        compression = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        session_search = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
+        web_extract = { provider = "openrouter"; model = "meta-llama/llama-3.3-70b-instruct"; };
       };
       toolsets = [ "all" ];
       memory = { enabled = true; };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -676,7 +676,7 @@ let
           containerBackend = ha.container.backend == "podman";
           containerImage = ha.container.image == "ubuntu:24.04";
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
-          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct";
+          modelPin = ha.settings.model.default == "qwen/qwen3-coder:free";
           modelProvider = ha.settings.model.provider == "openrouter";
           telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -676,7 +676,7 @@ let
           containerBackend = ha.container.backend == "podman";
           containerImage = ha.container.image == "ubuntu:24.04";
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
-          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct:free";
+          modelPin = ha.settings.model.default == "meta-llama/llama-3.3-70b-instruct";
           modelProvider = ha.settings.model.provider == "openrouter";
           telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";


### PR DESCRIPTION
## Summary
- Replace `meta-llama/llama-3.3-70b-instruct` with `qwen/qwen3-coder:free` (Qwen3 Coder 480B A35B MoE)
- 4x context window: 65k → 262k tokens
- Free, ZDR (zero data retention), tool support confirmed
- Updated model pin in module-eval test

## Test plan
- [x] `nix flake check` passes
- [ ] Deploy to hermes-claw and verify agent responds
- [ ] Confirm tool use works via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)