### PR TITLE
fix(hermes-claw): switch to nemotron-3-super-120b

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -40,15 +40,15 @@
     # Declarative config — deep-merged into $HERMES_HOME/config.yaml
     settings = {
       model = {
-        default = "qwen/qwen3-coder:free";
+        default = "nvidia/nemotron-3-super-120b-a12b:free";
         provider = "openrouter";
         base_url = "https://openrouter.ai/api/v1";
       };
       auxiliary = {
-        title_generation = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
-        compression = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
-        session_search = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
-        web_extract = { provider = "openrouter"; model = "qwen/qwen3-coder:free"; };
+        title_generation = { provider = "openrouter"; model = "nvidia/nemotron-3-super-120b-a12b:free"; };
+        compression = { provider = "openrouter"; model = "nvidia/nemotron-3-super-120b-a12b:free"; };
+        session_search = { provider = "openrouter"; model = "nvidia/nemotron-3-super-120b-a12b:free"; };
+        web_extract = { provider = "openrouter"; model = "nvidia/nemotron-3-super-120b-a12b:free"; };
       };
       toolsets = [ "all" ];
       memory = { enabled = true; };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -676,7 +676,7 @@ let
           containerBackend = ha.container.backend == "podman";
           containerImage = ha.container.image == "ubuntu:24.04";
           securityOpt = builtins.elem "--security-opt=no-new-privileges" ha.container.extraOptions;
-          modelPin = ha.settings.model.default == "qwen/qwen3-coder:free";
+          modelPin = ha.settings.model.default == "nvidia/nemotron-3-super-120b-a12b:free";
           modelProvider = ha.settings.model.provider == "openrouter";
           telegramAllowed = ha.environment.TELEGRAM_ALLOWED_USERS == "364749075,7957556729";
           dashboardOff = ha.environment.HERMES_DASHBOARD == "0";


### PR DESCRIPTION
## Summary
- `qwen/qwen3-coder:free` hits HTTP 429 rate limits on OpenRouter
- Switch to `nvidia/nemotron-3-super-120b-a12b:free` (120B MoE, 262k context, tools, ZDR)
- Less popular model = fewer rate limit issues

## Test plan
- [x] `nix flake check` passes
- [ ] Deploy and verify no 429 errors
- [ ] Telegram bot responds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)