### PR TITLE
feat(rpi5-full): add ralphex package for orchestrating Claude Code agents

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -242,6 +242,10 @@
           # Default package (what runs with `nix run github:user/repo`)
           default = self.packages.${system}.install;
 
+          # Ralphex — orchestrates Claude Code agents through plan files.
+          # See pkgs/ralphex.nix; install via environment.systemPackages.
+          ralphex = pkgs.callPackage ./pkgs/ralphex.nix { };
+
           # Fresh system installation script
           install = pkgs.writeShellApplication {
             name = "nixos-install";

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -83,6 +83,12 @@ in
     })
   ];
 
+  # Locally-packaged tools available on this host. Ralphex orchestrates
+  # Claude Code agents through multi-step plan files; lives in pkgs/ralphex.nix.
+  environment.systemPackages = [
+    self.packages.${pkgs.system}.ralphex
+  ];
+
   # Agenix secrets for additional services
   age.secrets =
     let

--- a/pkgs/ralphex.nix
+++ b/pkgs/ralphex.nix
@@ -1,0 +1,48 @@
+# Ralphex — multi-step plan orchestrator for Claude Code agents.
+# Upstream: https://github.com/umputun/ralphex (MIT, Go binary).
+#
+# Installed from upstream's prebuilt Linux release tarball. The Go binary is
+# statically linked (verified via `file`), so no autoPatchelfHook is needed.
+# Both aarch64-linux and x86_64-linux are supported by upstream; pick by host.
+{ stdenv, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "ralphex";
+  version = "1.3.1";
+
+  src = fetchurl (
+    let
+      sources = {
+        "aarch64-linux" = {
+          url = "https://github.com/umputun/ralphex/releases/download/v${version}/ralphex_${version}_linux_arm64.tar.gz";
+          hash = "sha256-GIoFw8tzxflioBXF5Zz8AxwURcBSF8BpKYPEVj20lUc=";
+        };
+        "x86_64-linux" = {
+          url = "https://github.com/umputun/ralphex/releases/download/v${version}/ralphex_${version}_linux_amd64.tar.gz";
+          hash = "sha256-OJcT/r8zDFzIsn6Y44h8xomfs04EM2IUytM2J64vYIA=";
+        };
+      };
+      system = stdenv.hostPlatform.system;
+    in
+      sources.${system} or (throw "ralphex: unsupported system ${system}")
+  );
+
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ralphex $out/bin/ralphex
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Orchestrates AI coding agents to execute multi-step plans";
+    homepage = "https://github.com/umputun/ralphex";
+    license = licenses.mit;
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
+    mainProgram = "ralphex";
+  };
+}


### PR DESCRIPTION
## Summary
- New `pkgs/ralphex.nix`: multi-arch derivation pulling upstream's prebuilt static Go binary (v1.3.1) for aarch64-linux and x86_64-linux
- Wired into existing `flake.nix` `packages = forAllSystems (...)` block — no new top-level packages output, merged alongside existing default/install/deploy/bootstrap
- Installed on `rpi5-full` only via `environment.systemPackages`

## Why
Enables running multi-step plan files (e.g. the upcoming OpenRouter virtual-keys migration plan) through Claude Code agents directly from rpi5 instead of the operator's Mac.

## Test plan
- [x] `nix build .#packages.aarch64-linux.ralphex` succeeded; binary reports `ralphex v1.3.1-4da229a-20260522T171400`
- [x] `nix fmt -- --check .` clean (0/59 files would be reformatted)
- [x] `nixos-rebuild dry-build --flake .#rpi5-full` succeeded
- [ ] Post-merge: `sudo nixos-rebuild switch --flake github:alexandru-savinov/nixos-config#rpi5-full` then verify `ralphex --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)