### PR TITLE
feat(secrets): migrate OpenRouter to two-tier sancta-port-openrouter (prd+dev)

### DIFF
--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -19,6 +19,14 @@
   };
 
   # ── Hermes Agent (upstream NixOS module, container mode) ─────────────
+  # OR virtual key for hermes (Sancta Port - dev tier, env-file format).
+  age.secrets.sancta-port-openrouter-dev = {
+    file = ../../secrets/sancta-port-openrouter-dev.age;
+    owner = "hermes";
+    group = "hermes";
+    mode = "0400";
+  };
+
   services.hermes-agent = {
     enable = true;
     addToSystemPackages = true;

--- a/hosts/hermes-claw/hermes-service.nix
+++ b/hosts/hermes-claw/hermes-service.nix
@@ -85,7 +85,10 @@
     };
 
     # Secrets via combined agenix env file
-    environmentFiles = [ config.age.secrets.hermes-env.path ];
+    environmentFiles = [
+      config.age.secrets.hermes-env.path # TELEGRAM_BOT_TOKEN (legacy file; OR_KEY here shadowed by dev file below)
+      config.age.secrets.sancta-port-openrouter-dev.path # OPENROUTER_API_KEY (env-file format)
+    ];
 
     # Non-secret environment
     environment = {

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -144,6 +144,7 @@ in
       # Open-WebUI (disabled)
       # open-webui-secret-key = secret "open-webui-secret-key";
       openrouter-api-key = secret "openrouter-api-key"; # also used by n8n
+      sancta-port-openrouter-prd = secret "sancta-port-openrouter-prd";
       # tavily-api-key = secret "tavily-api-key";
       openai-api-key = secret "openai-api-key"; # also used by n8n
       # e2e-test-api-key = secret "e2e-test-api-key";

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -224,7 +224,7 @@ in
 
     # OpenRouter API key - injected as OPENROUTER_API_KEY environment variable
     # Workflows can reference it using: Bearer {{ $env.OPENROUTER_API_KEY }}
-    openrouterApiKeyFile = secret "openrouter-api-key";
+    openrouterApiKeyFile = secret "sancta-port-openrouter-prd";
 
     # OpenAI API key - for TTS pronunciation audio in image-to-anki workflow
     # Workflows can reference it using: Bearer {{ $env.OPENAI_API_KEY }}

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -169,6 +169,7 @@
       # Open-WebUI secrets
       open-webui-secret-key = secret "open-webui-secret-key";
       openrouter-api-key = secret "openrouter-api-key";
+      sancta-port-openrouter-prd = secret "sancta-port-openrouter-prd";
       tavily-api-key = secret "tavily-api-key";
       e2e-test-api-key = secret "e2e-test-api-key";
       # SSH private key for the herdr user → hermes-claw (the `hermes-claw`

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -296,7 +296,7 @@
     secretKeyFile = config.age.secrets.open-webui-secret-key.path;
 
     # OpenRouter as LLM backend
-    openai.apiKeyFile = config.age.secrets.openrouter-api-key.path;
+    openai.apiKeyFile = config.age.secrets.sancta-port-openrouter-prd.path;
 
     # OIDC via Tailscale tsidp
     oidc.enable = true;

--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -72,6 +72,7 @@
       # OpenRouter API key — drives the ZDR proxy (sancta-claw only consumer
       # on this host); also used by n8n on rpi5 (raw key format, kept that way).
       openrouter-api-key = kuzeaSecret "openrouter-api-key";
+      sancta-port-openrouter-prd = kuzeaSecret "sancta-port-openrouter-prd";
     };
 
   # ── OpenClaw ZDR proxy (local OpenRouter sidecar) ──────────────────────

--- a/hosts/sancta-claw/configuration.nix
+++ b/hosts/sancta-claw/configuration.nix
@@ -78,7 +78,7 @@
   # ── OpenClaw ZDR proxy (local OpenRouter sidecar) ──────────────────────
   services.openclaw-zdr-proxy = {
     enable = true;
-    apiKeyFile = config.age.secrets.openrouter-api-key.path;
+    apiKeyFile = config.age.secrets.sancta-port-openrouter-prd.path;
   };
 
   # ── Home Manager (scaffolding — required by root.nix, no user configs yet) ──

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -459,7 +459,8 @@ in
           set -euo pipefail
           AUTH_FILE="$HOME/.openclaw/agents/main/agent/auth-profiles.json"
           KEY="$(cat ${config.age.secrets.sancta-port-openrouter-prd.path})"
-          # Idempotent: register openrouter:zdr-proxy and strip the broken
+          # Idempotent (jq `=` assignment replaces, not appends): register
+          # openrouter:zdr-proxy and strip the broken
           # anthropic:default profile (third-party Pro auth, the cause of
           # this migration). lastGood.anthropic is also cleared so OpenClaw
           # does not retry the dead profile.

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -458,7 +458,7 @@ in
         (pkgs.writeShellScript "openclaw-inject-openrouter-auth" ''
           set -euo pipefail
           AUTH_FILE="$HOME/.openclaw/agents/main/agent/auth-profiles.json"
-          KEY="$(cat ${config.age.secrets.openrouter-api-key.path})"
+          KEY="$(cat ${config.age.secrets.sancta-port-openrouter-prd.path})"
           # Idempotent: register openrouter:zdr-proxy and strip the broken
           # anthropic:default profile (third-party Pro auth, the cause of
           # this migration). lastGood.anthropic is also cleared so OpenClaw

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -852,6 +852,9 @@ in
         cursor.execute("SELECT id FROM function WHERE id = ?", (function_id,))
         exists = cursor.fetchone()
 
+        # UPDATE path (not INSERT) upserts valves.openrouter_api_key on every
+        # service restart — agenix key rotation propagates without manual
+        # SQLite intervention. Verified during the OR vkey migration.
         if exists:
             cursor.execute("""
                 UPDATE function

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -71,6 +71,13 @@ in
   # Open-WebUI secrets - shared across sancta-choir and rpi5
   "open-webui-secret-key.age".publicKeys = allKeys;
   "openrouter-api-key.age".publicKeys = allPlusBoth;
+
+  # OpenRouter virtual keys (Sancta Port). Two-tier prd/dev staging.
+  # prd: raw key format (owui, openclaw+zdr-proxy, n8n).
+  # dev: env-file format (hermes, OPENROUTER_API_KEY=...).
+  # Coexists with openrouter-api-key.age until cleanup task.
+  "sancta-port-openrouter-prd.age".publicKeys = users ++ [ sancta-choir sancta-claw rpi5 ];
+  "sancta-port-openrouter-dev.age".publicKeys = users ++ [ hermes-claw ];
   "tavily-api-key.age".publicKeys = allKeys;
 
   # Tavily API key for Kuzea web search (separate from open-webui)

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -611,7 +611,7 @@ let
         {
           services.openclaw-zdr-proxy = {
             enable = true;
-            apiKeyFile = "/run/agenix/openrouter-api-key";
+            apiKeyFile = "/run/agenix/sancta-port-openrouter-prd";
           };
           # The proxy unit runs as user `openclaw`, normally created by
           # the host-level openclaw service. Declare it here so the
@@ -641,12 +641,12 @@ let
         proxy = self.nixosConfigurations.sancta-claw.config.services.openclaw-zdr-proxy;
         agenixPath = toString proxy.apiKeyFile;
         portOk = proxy.port == 5780;
-        pathOk = agenixPath == "/run/agenix/openrouter-api-key";
+        pathOk = agenixPath == "/run/agenix/sancta-port-openrouter-prd";
       in
       if portOk && pathOk then
         true
       else
-        builtins.throw "FAIL: sancta-claw openclaw-zdr-proxy wiring — port=${toString proxy.port} (expected 5780), apiKeyFile=${agenixPath} (expected /run/agenix/openrouter-api-key)";
+        builtins.throw "FAIL: sancta-claw openclaw-zdr-proxy wiring — port=${toString proxy.port} (expected 5780), apiKeyFile=${agenixPath} (expected /run/agenix/sancta-port-openrouter-prd)";
 
     # Verify the rendered openclaw browser-config script registers the
     # free+ZDR ladder and routes through the local proxy. Reads the body


### PR DESCRIPTION
## Summary
Migrates from one shared `openrouter-api-key.age` to two scoped virtual keys (`sancta-port-openrouter-prd`, `sancta-port-openrouter-dev`) per the Sancta Naming Guide and IaC Pledge. Option C two-tier staging (prd: owui+openclaw+n8n raw key format; dev: hermes env-file format). Coexists with the legacy key file during this PR; the legacy retires in a follow-up PR after deploy + soak.

## Why now
Plaintext OR keys created in OR dashboard sit in operator notepad (Charter §5 Porch tier). Encrypting them into agenix (`sancta-port-openrouter-prd.age` + `sancta-port-openrouter-dev.age`) moves them to Vault tier and enables per-tier blast-radius control.

## Affected rooms (Charter §5)
- **Vault**: OR API keys.

## Scope of impact
- 4 hosts read scoped keys instead of shared: sancta-choir (owui), sancta-claw (openclaw+zdr-proxy), rpi5-full (n8n), hermes-claw (hermes-agent).
- hermes-agent now reads `OPENROUTER_API_KEY` from `sancta-port-openrouter-dev.age` (env-file), shadowing the legacy `hermes-env.age` OR line via systemd EnvironmentFile last-wins.
- Test fixtures updated for new path assertion.
- No new services. No new outbound destinations. Idempotency invariants for openclaw jq inject and OWUI cost-tracker filter install verified (no logic change — comments added).

## Monitoring / verification
- After merge + deploy on each host, verify in OR dashboard that the new key labels receive traffic.
- 24-48h soak before revoking legacy `openrouter-api-key` in OR dashboard (follow-up PR).

## Rollback plan
- Revert any one commit; its specific consumer flips back to legacy `openrouter-api-key.age`.
- Revert entire PR: all consumers return to shared legacy key. Legacy key remains valid in OR until follow-up Task 7 revocation.
- If the agenix encryption gate is wrong (key paste error), `agenix -e <file>.age` again with corrected value; redeploy affected hosts.

## Exception block — Pledge §Hard Lines 4 ("no shared accounts")
**Reason**: Option C two-tier staging — `prd` key shared across owui+openclaw+n8n; `dev` key sole-consumer (hermes).
**Mitigations**: 90-day rotation; planned Option B (per-consumer) follow-up.
**Expiry**: Until Option B PR lands or 180 days from merge, whichever sooner.
**Owner**: @alexandru-savinov

## Exception block — Pledge §Hard Lines 2 ("access expires ≤90d")
**Reason**: OpenRouter provisioning API does not expose `expires_at`.
**Mitigations**: operator-side calendar reminder + manual rotation procedure.
**Expiry**: Revisit when OR API supports `expires_at`.
**Owner**: @alexandru-savinov

## Test plan
- [x] All 7 commits authored from a worktree off origin/main; gitleaks clean per commit.
- [x] `nix fmt -- --check .` clean.
- [ ] CI expected to fail until operator encrypts `secrets/sancta-port-openrouter-prd.age` (raw key format) and `secrets/sancta-port-openrouter-dev.age` (env-file format with `OPENROUTER_API_KEY=...` prefix).
- [ ] After encryption + push: CI green.
- [ ] Post-merge deploy order: sancta-claw → hermes-claw → rpi5-full → sancta-choir, each with service restart + OR dashboard verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)