### PR TITLE
fix(sancta-claw): vendor agent-browser-cli via importCargoLock (crates.io 403s python-requests UA)

### DIFF
--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -106,14 +106,24 @@ let
           cp -r node_modules $out/
         '';
       };
-      # Rust CLI: fast command dispatcher, spawns Node.js daemon on demand
+      # Rust CLI: fast command dispatcher, spawns Node.js daemon on demand.
+      # Vendor crates via cargoLock (importCargoLock) instead of cargoHash:
+      # importCargoLock fetches each crate with Nix's libcurl fetchurl, whereas
+      # rustPlatform.fetchCargoVendor (driven by cargoHash) uses Python requests,
+      # whose "python-requests/*" User-Agent crates.io now HTTP 403-blocks. The
+      # upstream fix (set a descriptive UA) is NixOS/nixpkgs#512735, backported
+      # to release-25.11 on 2026-04-26 but not yet in this flake's nixpkgs pin
+      # (2026-03-18) — revert to cargoHash once the pin carries it. The CLI
+      # lockfile has only crates.io-registry deps (no git sources), so no
+      # cargoLock.outputHashes are needed; crate hashes come from the lockfile's
+      # own checksums (one fewer hash to maintain than cargoHash).
       rustCli = pkgs.rustPlatform.buildRustPackage {
         pname = "agent-browser-cli";
         version = "0.14.0";
         inherit src;
         cargoRoot = "cli";
         buildAndTestSubdir = "cli";
-        cargoHash = "sha256-94w9V+NZiWeQ3WbQnsKxVxlvsCaOJR0Wm6XVc85Lo88=";
+        cargoLock.lockFile = src + "/cli/Cargo.lock";
       };
     in
     # AGENT_BROWSER_EXECUTABLE_PATH bypasses playwright-core's revision check,


### PR DESCRIPTION
## Problem

The **NixOS Configuration Check → Build x86_64 Configs → Build sancta-claw** job has been red on `main` for every push since the `agent-browser-cli` 0.14.0 vendor FOD fell out of the binary cache:

```
Exception: Failed to fetch file from https://crates.io/api/v1/crates/memchr/2.7.6/download. Status code: 403
error: 1 dependencies of derivation '...agent-browser-cli-0.14.0-vendor.drv' failed to build
```

### Root cause (verified empirically)

`rustPlatform.fetchCargoVendor` (triggered by `cargoHash`) vendors crates with a Python `requests`-based fetcher (`fetch-cargo-vendor-util.py`) that sets **no `User-Agent`**, so it sends `python-requests/*`. crates.io's crawler policy now **403-blocks** that UA. Confirmed from a clean host:

| User-Agent | Result |
|---|---|
| `python-requests/2.32.3` | **403** |
| `curl/8.x` | **403** |
| descriptive / empty UA | 302 ✅ |
| Nix's libcurl `fetchurl` (`nix store prefetch-file`) | ✅ (not blocked) |

This is the upstream issue [rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482). The nixpkgs fix is [NixOS/nixpkgs#512735](https://github.com/NixOS/nixpkgs/pull/512735) (set a descriptive UA), merged 2026-04-26 and **backported to `release-25.11`** — but this flake's `nixpkgs` pin is `2026-03-18`, before the backport.

## Fix

Switch the single `agent-browser-cli` `buildRustPackage` call from `cargoHash` to **`cargoLock` (`importCargoLock`)**, which fetches each crate via Nix's libcurl `fetchurl` — structurally immune to the crates.io UA policy. `cli/Cargo.lock` (v4) has only crates.io-registry deps and **zero git sources**, so no `cargoLock.outputHashes` are needed; crate hashes come from the lockfile's own checksums (one fewer hash to maintain than `cargoHash`).

- **Blast radius: minimal** — 2-line change to one package; no overlay, no nixpkgs bump, no new files. Only `sancta-claw` is touched.
- Revert to `cargoHash` once the nixpkgs pin carries the #512735 backport.

### Alternatives considered (via a multi-agent design + judge workflow)
- **Overlay-patching `fetchCargoVendor`'s UA** (mirrors #512735) — fixes all Rust builds repo-wide, but `rustPlatform.overrideScope` rewrites the vendor builder on every host, and hardcodes the UA string crates.io *currently* accepts. Runner-up.
- **Bumping the `nixpkgs` input** — ~3656 commits / ~2.3 months of churn rebuilding every host to unblock one CI job. Rejected as primary; fine as later routine maintenance.

## Verification (local, aarch64-darwin)
- ✅ `nixpkgs-fmt --check` clean
- ✅ `nix eval .#nixosConfigurations.sancta-claw...toplevel.drvPath` → valid drv (IFD reading `cli/Cargo.lock` works)
- ✅ `importCargoLock` vendor dir **builds end-to-end** — all 43 crates fetched via libcurl, **zero 403** (`/nix/store/...-cargo-vendor-dir`)
- ✅ `rpi5-full` still evaluates (unaffected)
- The x86_64-linux compile/link is CI-only — exercised by the previously-failing **Build sancta-claw** job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)