### PR TITLE
fix: round-3 retrospective mechanical fixes (#457, #455, #459)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,9 @@ On memory-constrained hosts (RPi5, 4GB RAM), n8n loop iterations accumulate item
 
 1. **Write to disk early** — In Extract nodes, write raw bytes to `{jobDir}/` and return only the file path
 2. **Pass paths, not data** — Loop items carry `imageFile`/`audioFile` paths instead of base64 strings
-3. **Read back late** — In the final assembly node (e.g., Prepare APKG Input), read files from disk just before output
+3. **Stream output to disk, never re-materialize** — The final assembly node (e.g., Prepare APKG Input) must **stream** its output: open the target file once (`fs.openSync`), then for each item read its binary from disk, `fs.writeSync` it into the output, and immediately null the per-item base64 vars before the next iteration. Return only the output file path — never build one in-memory object that holds every item's bytes at once.
+
+⚠️ Do NOT "read all files back into memory just before output" — that re-materializes the entire payload and OOM'd the host again after PR #438. The streaming fix is `e098d06`; the task-runner heap bump in that commit was added headroom, not the mechanism — the real fix is never holding the full payload in memory.
 
 This prevents OOM when processing 40+ items with ~200KB each of image + audio data.
 

--- a/hosts/zero-kuzea/configuration.nix
+++ b/hosts/zero-kuzea/configuration.nix
@@ -22,6 +22,14 @@
   networking.hostName = "zero-kuzea";
   system.stateVersion = "25.05";
 
+  # Swap space (2GB for OOM headroom on 4GB CX22 — no disk swap otherwise)
+  swapDevices = [
+    {
+      device = "/swapfile";
+      size = 2048; # 2GB
+    }
+  ];
+
   # ── SSH authorized keys ─────────────────────────────────────────────
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPw5RFrFfZQUWlyfGSU1Q8BlEHnvIdBtcnCn+uYtEzal nixos-sancta-choir"

--- a/modules/services/backup-pull.nix
+++ b/modules/services/backup-pull.nix
@@ -198,6 +198,9 @@ in
         ExecStart = "${pkgs.restic}/bin/restic -r ${cfg.repository} --password-file ${cfg.resticPasswordFile} check";
         Nice = 19;
         IOSchedulingClass = "idle";
+        # A full repo check can far exceed the 90s host default; unbounded so it
+        # is not SIGTERM'd mid-check (which also fires a false backup-failure-alert).
+        TimeoutStartSec = 0;
       };
     };
 
@@ -217,6 +220,9 @@ in
         OnFailure = [ "backup-failure-alert@%N.service" ];
         RequiresMountsFor = [ cfg.stagingDir ];
       };
+      # A large backup run can exceed the 90s host default; give it generous
+      # headroom so it is not SIGTERM'd mid-run (which fires a false alert).
+      serviceConfig.TimeoutStartSec = "4h";
     };
 
 

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -854,6 +854,9 @@ in
         Type = "oneshot";
         RemainAfterExit = true;
         # Run as root to read password file and restart n8n
+        # ~180s of internal wait-loops (healthz + login retries); raise above
+        # the 90s host default so it is not SIGTERM'd mid-install.
+        TimeoutStartSec = 200;
       };
 
       path = [ pkgs.curl pkgs.jq ];

--- a/modules/services/open-webui-functions/openrouter_zdr_pipe.py
+++ b/modules/services/open-webui-functions/openrouter_zdr_pipe.py
@@ -89,15 +89,25 @@ class Pipe:
             zdr_models = []
 
             for item in zdr_data:
-                # Extract model ID from "Provider | model-id" format
-                # Use rsplit to handle edge cases where provider names might contain " | "
-                # Use .get() to avoid KeyError on malformed data
-                name = item.get("name", "")
-                if not name:
-                    continue  # Skip items without a name field
+                if not isinstance(item, dict):
+                    continue
 
-                name_parts = name.rsplit(" | ", 1)
-                model_id = name_parts[1] if len(name_parts) > 1 else name
+                # The canonical model identifier on each `/endpoints/zdr` entry
+                # is `model_id` ("qwen/qwen3-coder:free") — the slug inbound
+                # requests actually send. `name` is human-readable
+                # ("Venice | Qwen3 Coder"); deriving the id from a
+                # `name.rsplit(" | ", 1)` tail leaks the display fragment
+                # ("Qwen3 Coder") for providers whose right half is the
+                # model_name, so the selector filled with ids no request could
+                # match. Read the canonical field first; keep `id` and the
+                # name-rsplit path only as last-resort fallbacks.
+                model_id = item.get("model_id") or item.get("id") or ""
+                if not model_id:
+                    name = item.get("name", "")
+                    if not name:
+                        continue  # Skip items without any identifiable field
+                    name_parts = name.rsplit(" | ", 1)
+                    model_id = name_parts[1] if len(name_parts) > 1 else name
 
                 # Skip if model_id is empty or already seen
                 if not model_id or model_id in seen_ids:

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -1155,6 +1155,9 @@ in
         # Run as open-webui user for database and state directory access
         User = "open-webui";
         Group = "open-webui";
+        # ~90s of sequential wait-loops; raise above the 90s host default so it
+        # is not SIGTERM'd mid-migration.
+        TimeoutStartSec = 300;
       };
 
       script = ''
@@ -1311,6 +1314,9 @@ in
         # Run as open-webui user for database access
         User = "open-webui";
         Group = "open-webui";
+        # ~90s of sequential wait-loops; raise above the 90s host default so it
+        # is not SIGTERM'd mid-provision.
+        TimeoutStartSec = 300;
       };
 
       script = ''
@@ -1482,6 +1488,9 @@ in
         RemainAfterExit = true;
         User = "open-webui";
         Group = "open-webui";
+        # ~90s of sequential wait-loops; raise above the 90s host default so it
+        # is not SIGTERM'd mid-provision.
+        TimeoutStartSec = 300;
       };
 
       script = ''

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -118,7 +118,7 @@ echo ""
 
 # Build configuration
 echo "Building configuration..."
-if nixos-rebuild build --flake "$FLAKE_REF"; then
+if nixos-rebuild build --flake "$FLAKE_REF" --max-jobs 1 --cores 1; then
     echo "Build successful!"
 else
     echo "Build failed!"
@@ -149,7 +149,7 @@ else
     echo "Applying configuration..."
 fi
 
-if $SUDO nixos-rebuild switch --flake "$FLAKE_REF"; then
+if $SUDO nixos-rebuild switch --flake "$FLAKE_REF" --max-jobs 1 --cores 1; then
     echo ""
     echo "Deployment complete!"
     echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ echo ""
 
 # First, try to build without applying
 echo "🔨 Testing build (dry-run)..."
-if $SUDO nixos-rebuild build --flake "$FLAKE_URL"; then
+if $SUDO nixos-rebuild build --flake "$FLAKE_URL" --max-jobs 1 --cores 1; then
     echo "✅ Build successful!"
     echo ""
 else
@@ -123,7 +123,7 @@ fi
 
 # Apply the configuration
 echo "🚀 Applying configuration..."
-if $SUDO nixos-rebuild switch --flake "$FLAKE_URL"; then
+if $SUDO nixos-rebuild switch --flake "$FLAKE_URL" --max-jobs 1 --cores 1; then
     echo ""
     echo "✅ Installation complete!"
     echo ""

--- a/tests/test_openrouter_zdr_pipe.py
+++ b/tests/test_openrouter_zdr_pipe.py
@@ -39,17 +39,23 @@ def mock_requests_get(monkeypatch):
     def _mock_get(url, headers=None, timeout=None):
         # Determine which endpoint is being called
         if url.endswith("/endpoints/zdr"):
-            # Return a list of ZDR-compliant models (format: "Provider | model-id")
+            # Mirror the REAL upstream shape: `name` is human-readable
+            # ("<Provider> | <human-readable>") and the canonical slug lives in
+            # a separate `model_id` field. If the parser fell back to
+            # rsplit-on-name it would leak "GPT-4o Mini" into the id, which the
+            # canonical-field assertions below would catch.
             return mock.Mock(
                 status_code=200,
                 json=lambda: {
                     "data": [
                         {
-                            "name": "OpenAI | openrouter/gpt-4o-mini",
+                            "name": "OpenAI | GPT-4o Mini",
+                            "model_id": "openrouter/gpt-4o-mini",
                             "model_name": "GPT-4o Mini",
                         },
                         {
-                            "name": "OpenAI | openrouter/gpt-4o",
+                            "name": "OpenAI | GPT-4o",
+                            "model_id": "openrouter/gpt-4o",
                             "model_name": "GPT-4o",
                         },
                     ]
@@ -106,6 +112,24 @@ def test_pipes_returns_only_zdr_models(pipe, mock_requests_get):
     # Names should be prefixed
     for m in models:
         assert m["name"].startswith("ZDR/")
+
+
+def test_pipes_id_is_canonical_model_id_not_display_name(pipe, mock_requests_get):
+    """Regression for #457: produced ids must equal the canonical model_id,
+    never a human-readable display fragment leaked from `name.rsplit`."""
+    pipe.valves.OPENROUTER_API_KEY = "dummy-key"
+
+    models = pipe.pipes()
+
+    # The canonical model_id values from the stub upstream response.
+    expected_ids = {"openrouter/gpt-4o-mini", "openrouter/gpt-4o"}
+    produced_ids = {m["id"] for m in models}
+    assert produced_ids == expected_ids
+
+    # No display fragment (the human-readable right half of `name`) should ever
+    # appear as a model id.
+    display_fragments = {"GPT-4o Mini", "GPT-4o"}
+    assert produced_ids.isdisjoint(display_fragments)
 
 
 def test_pipes_handles_missing_api_key(pipe):


### PR DESCRIPTION
## Round-3 retrospective mechanical fixes

Four small, independently-verified fixes surfaced by the commit-history retrospective (epic #454, round 3). Each is one commit, scoped to one issue.

| Commit | Issue | What |
|--------|-------|------|
| `fix(zdr)` | **#457** | Open-WebUI ZDR pipe reads canonical `model_id`/`id` first (rsplit only as last-resort fallback) — it was deriving the model id from `name.rsplit(" \| ")`, leaking display fragments like `Qwen3 Coder` instead of `qwen/qwen3-coder:free`. Same bug the proxy fixed in #421, never propagated to the pipe. Stub updated to the real upstream shape + regression test added. |
| `fix(reliability)` | **#455** | Add `TimeoutStartSec` to non-serve oneshots with wait-loops so they aren't SIGTERM'd at the 90s host default: `restic-check` (`0`/unbounded — a killed check also fires a false `backup-failure-alert`), `restic-backups` (`4h`), `n8n-community-packages` (`200`), and the three Open-WebUI DB-migration oneshots (`300`). |
| `fix(reliability)` | partially **#451** | zero-kuzea (4GB CX22 GRUB) gets a 2GB swapfile; `--max-jobs 1 --cores 1` throttle added to `install.sh` + `deploy.sh` build/switch so a small-RAM VPS build can't OOM. |
| `fix(docs)` | **#459** | Correct the CLAUDE.md Disk-Offload section: the assembly node must **stream** output to disk (not read everything back into memory, which OOM'd after #438). Cites `e098d06`. |

## Validation

Run on a darwin host (no aarch64 builder), so validated by evaluation:
- `pytest tests/test_openrouter_zdr_pipe.py` — **7/7 pass** (incl. the new #457 regression test).
- `nix eval …rpi5-full…toplevel.drvPath` and `…zero-kuzea…toplevel.drvPath` — both evaluate cleanly; `TimeoutStartSec` merges confirmed (`"4h"`, `200`).
- `nixpkgs-fmt --check` — clean on all changed nix files.

CI's Trivy secret scan + aarch64 eval are the canonical gates. Based on top of #461.

## Notes
- **Closes #457, #455, #459.**
- **#451** is only partially addressed here (zero-kuzea swap + build throttle); its other items (sancta-claw `autoUpgrade operation = "boot"`, the CLAUDE.md deploy-table note, the 6.6 kernel-pin audit) remain open in #451.
- #456 (nullclaw acceptance gate) and #458 (security-fix-ancestry guard) were intentionally not included — they need judgment on an external CLI's capabilities / CI-process design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
