### PR TITLE
feat(home-assistant): add cast for local Samsung soundbar (Chromecast)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -376,6 +376,12 @@ in
     "samsungtv"
     "wake_on_lan"
     "tplink"
+    # Google Cast — local media control of the Samsung S801B soundbar, which has
+    # Chromecast built-in (ports 8008/8009; DLNA is NOT available on this B-series
+    # soundbar). Gives a media_player for play/pause/volume/cast-audio/TTS over the
+    # LAN (hardware power/source/EQ still require SmartThings). Auto-discovers via
+    # zeroconf (default_config) — no credentials needed.
+    "cast"
   ];
 
   # al-one/hass-xiaomi-miot ("Xiaomi Miot Auto") for the Xiaomi humidifier (and


### PR DESCRIPTION
## What
Adds the core `cast` (Google Cast) integration. The Samsung S801B soundbar has **no DLNA** (UPnP/1900 closed, no description XML) but **has Chromecast built-in** (ports 8008/8009, confirmed via `eureka_info`). `cast` controls it **locally** — play/pause, volume, cast audio/streams/TTS — no cloud, no credentials (zeroconf auto-discovery via `default_config`).

Hardware power/source/EQ still require SmartThings; this covers the media-renderer role DLNA would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)