### PR TITLE
fix(home-assistant): set external_url for mobile app auth

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -331,6 +331,14 @@ in
     tailscaleServe.enable = true;
   };
 
+  # Explicit external/internal URLs so HA doesn't auto-detect behind the
+  # Tailscale Serve reverse proxy — auto-detection sees http://127.0.0.1:8123
+  # which breaks mobile app OAuth redirects (intermittent 400 on /auth/authorize).
+  services.home-assistant.config.homeassistant = {
+    external_url = "https://rpi5.tail4249a9.ts.net:8123";
+    internal_url = "http://127.0.0.1:8123";
+  };
+
   # Bluetooth: the RPi5 has an integrated BT adapter (hci0, UART serial0). Enable
   # the BlueZ stack so Home Assistant's bluetooth integration (pulled in by
   # default_config) can manage the adapter over D-Bus and move from setup_retry


### PR DESCRIPTION
## Summary

- Set `external_url` to `https://rpi5.tail4249a9.ts.net:8123` and `internal_url` to `http://127.0.0.1:8123` in the HA config
- Fixes intermittent 400 errors on `/auth/authorize` when connecting from the HA mobile app
- Root cause: with `external_url: null`, HA auto-detects its URL behind Tailscale Serve as `http://127.0.0.1:8123`, which breaks OAuth redirect validation

## Test plan

- [x] `nix eval` confirms `external_url` and `internal_url` merge correctly with existing `time_zone`
- [x] Deployed via `nixos-rebuild switch` — HA reloaded successfully
- [ ] Connect from HA mobile app and verify login works without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)