### PR TITLE
fix: retrospective follow-ups — nullclaw injection gate (#456) + verify-fix-shipped guard (#458)

### DIFF
--- a/.claude/skills/sweep-bugs/SKILL.md
+++ b/.claude/skills/sweep-bugs/SKILL.md
@@ -163,6 +163,13 @@ git pull origin main   # sync merged changes before next bug
 
 #### Step 3e: Close issue (if not auto-closed by PR merge)
 
+For `security` / `priority:critical` issues, FIRST prove the fix shipped (guards the
+claude-yolo false-closure, #458) — do NOT close on a NOT-SHIPPED verdict:
+
+```bash
+scripts/verify-fix-shipped.sh <fix-commit>   # exit 0 = ancestor of origin/main
+```
+
 ```bash
 gh issue close <number> --comment "Fixed in PR #<pr-number>"
 ```
@@ -180,6 +187,13 @@ Status: FIXED (PR #<pr>) | DEFERRED (reason) | FAILED (reason)
 ## Phase 4: Close CLOSE Bugs
 
 For each bug triaged as CLOSE:
+
+If the bug is `security` / `priority:critical` and the close reason is "already fixed",
+prove the fix actually shipped before closing (guards #458 — do NOT close on NOT-SHIPPED):
+```bash
+scripts/verify-fix-shipped.sh <fix-commit>   # exit 0 = ancestor of origin/main
+```
+
 ```bash
 gh issue close <number> --comment "Closing: <reason>."
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,22 @@ git worktree remove ../nixos-config-<branch-name>
 - `docs/<name>` - Documentation changes
 - `refactor/<name>` - Code refactoring
 
+### Security-Fix Closure Guard
+
+**Before closing any `security` / `priority:critical` issue, prove the fix shipped — not merely that a PR or branch existed.** A fix on an unmerged branch (PR closed, `mergedAt = null`) leaves the vuln deployed and the issue falsely "handled" (the claude-yolo double-removal, #458: `84fb666` was never an ancestor of `main`, so the weak-password user stayed live until `75cba9c`/#368). This guard matters most for **manual closes** and issues triaged CLOSE without a merge — the auto-fix path already guarantees ancestry via merge + `git pull`.
+
+Require the fix commit to be an ancestor of the deployed branch:
+
+```bash
+# Verdict + correct exit code; refuses to pass on unknown/unmerged commits.
+scripts/verify-fix-shipped.sh <fix-commit>          # defaults to origin/main
+# raw equivalent:
+git fetch origin main
+git merge-base --is-ancestor <fix-commit> origin/main && echo SHIPPED || echo NOT-SHIPPED
+```
+
+Close the issue only when this prints `SHIPPED` (exit 0). For auto-deploy hosts, also confirm the running generation includes it (`nixos-rebuild list-generations` / the deployed flake rev) before declaring it resolved.
+
 ## Claude Code
 
 User-level CC config (skills, agents, slash commands, settings.json) comes

--- a/modules/services/nullclaw.nix
+++ b/modules/services/nullclaw.nix
@@ -113,6 +113,13 @@ let
   };
 
   configTemplate = pkgs.writeText "nullclaw-config-template.json" configJson;
+
+  # jq SET expression that injects secrets into the rendered config.
+  # Shared verbatim by the ExecStartPre filter AND the eval-time contract
+  # string (system.build.nullclawConfigInjection) so the two cannot drift.
+  jqSetExpr =
+    ".models.providers.${cfg.provider}.api_key = $key"
+    + optionalString cfg.telegram.enable " | .channels.telegram.accounts.main.bot_token = $token";
 in
 {
   options.services.nullclaw = {
@@ -222,6 +229,27 @@ in
       }
     ];
 
+    # ── Config-injection acceptance contract (eval-time guard) ───────
+    # Exposes the exact JSON key paths this module injects secrets into,
+    # plus the canonical upstream schema paths the pinned nullclaw
+    # (rev e94ffb0 / v2026.2.26) actually parses. The module-eval test
+    # pins these substrings so a future rev bump or template refactor that
+    # moves/renames a key fails CI LOUDLY instead of silently dropping a
+    # secret at runtime — nullclaw parses with ignore_unknown_fields=true
+    # and skips unparseable accounts, and its validate() does NOT check
+    # telegram, so a stale key would otherwise yield an unauthenticated
+    # Telegram bot. Pure string via system.build — no IFD, no build.
+    # MAINTAINER: when bumping `rev`, re-confirm these paths against the
+    # new config.example.json and update this string in the SAME commit.
+    system.build.nullclawConfigInjection = ''
+      schema-rev: e94ffb0
+      provider-api-key-path: models.providers.${cfg.provider}.api_key
+      primary-model-path: agents.defaults.model.primary
+      telegram-enabled: ${if cfg.telegram.enable then "yes" else "no"}
+      telegram-bot-token-path: channels.telegram.accounts.main.bot_token
+      jq-set: ${jqSetExpr}
+    '';
+
     # ── User and Group ───────────────────────────────────────────────
     users.users.nullclaw = {
       isSystemUser = true;
@@ -289,7 +317,7 @@ in
               ${pkgs.jq}/bin/jq \
                 --arg key "$PROVIDER_KEY" \
                 ${optionalString cfg.telegram.enable ''--arg token "$BOT_TOKEN"''} \
-                '.models.providers.${cfg.provider}.api_key = $key${optionalString cfg.telegram.enable " | .channels.telegram.accounts.main.bot_token = $token"}' \
+                '${jqSetExpr}' \
                 ${configTemplate} > /run/nullclaw/.nullclaw/config.json
 
               ${pkgs.coreutils}/bin/chmod 600 /run/nullclaw/.nullclaw/config.json

--- a/scripts/verify-fix-shipped.sh
+++ b/scripts/verify-fix-shipped.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-fix-shipped.sh — assert a security fix actually shipped before
+# closing the issue. Guards against the claude-yolo failure mode (#458):
+# a "fix" that lived on an unmerged branch (PR closed, mergedAt=null) so the
+# vuln stayed deployed until it was removed a second time.
+#
+# Usage:
+#   scripts/verify-fix-shipped.sh <fix-commit> [deployed-branch]
+#
+#   <fix-commit>       commit (or ref) claimed to fix the issue
+#   [deployed-branch]  branch the hosts deploy from (default: origin/main)
+#
+# Exit 0 = fix IS an ancestor of the deployed branch (safe to close).
+# Exit 1 = fix is NOT shipped, or the ref is unknown (DO NOT close).
+
+print_usage() {
+  echo "Usage: $0 <fix-commit> [deployed-branch]   (default branch: origin/main)"
+  exit "${1:-0}"
+}
+
+case "${1:-}" in
+  -h | --help) print_usage 0 ;;
+  "") print_usage 1 ;;
+esac
+
+FIX="$1"
+BRANCH="${2:-origin/main}"
+
+# Refresh the deployed branch only when it is a remote ref (non-fatal).
+if [[ "$BRANCH" == origin/* ]]; then
+  git fetch --quiet origin "${BRANCH#origin/}" 2>/dev/null || true
+fi
+
+if ! git rev-parse --verify --quiet "${FIX}^{commit}" >/dev/null; then
+  echo "ERROR: unknown commit '$FIX' (fetch it or check the SHA)." >&2
+  exit 1
+fi
+if ! git rev-parse --verify --quiet "${BRANCH}^{commit}" >/dev/null; then
+  echo "ERROR: unknown branch '$BRANCH'." >&2
+  exit 1
+fi
+
+SHORT=$(git rev-parse --short "$FIX")
+if git merge-base --is-ancestor "$FIX" "$BRANCH"; then
+  echo "SHIPPED: $SHORT is an ancestor of $BRANCH — safe to close."
+  exit 0
+else
+  echo "NOT SHIPPED: $SHORT is NOT an ancestor of $BRANCH." >&2
+  echo "  The fix is not on the deployed branch (unmerged branch / closed PR?)." >&2
+  echo "  DO NOT close the security issue until the fix is merged to $BRANCH." >&2
+  exit 1
+fi

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -520,6 +520,48 @@ let
       };
     };
 
+    # Pin the nullclaw secret-injection contract against the upstream
+    # schema the PINNED binary (rev e94ffb0) actually parses. nullclaw
+    # parses with ignore_unknown_fields=true and silently skips accounts
+    # whose required fields (e.g. telegram bot_token, which has no default)
+    # are absent — so a rev bump renaming a key would drop the secret at
+    # runtime with NO error (validate() does not check telegram; /ready is
+    # presence-based and returns ready on an empty registry). This
+    # eval-time guard forces that drift to fail CI. Pure eval, no IFD.
+    nullclaw-injection-key-paths =
+      let
+        body = self.nixosConfigurations.zero-kuzea.config.system.build.nullclawConfigInjection;
+        required = [
+          "models.providers.anthropic.api_key"
+          "agents.defaults.model.primary"
+          "channels.telegram.accounts.main.bot_token"
+          "telegram-enabled: yes"
+          # The exact jq SET expression the ExecStartPre runs (shared `let`
+          # binding in nullclaw.nix); drift in the template/jq breaks this.
+          ''jq-set: .models.providers.anthropic.api_key = $key | .channels.telegram.accounts.main.bot_token = $token''
+        ];
+        missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
+      in
+      if missing == [ ] then
+        true
+      else
+        builtins.throw "FAIL: nullclaw injection contract drifted — missing/renamed key paths: ${builtins.toJSON missing}. Re-confirm modules/services/nullclaw.nix injection against nullclaw config.example.json at the pinned rev.";
+
+    # Negative control: prove the guard actually throws when a required key
+    # path is absent (simulates a silent-drop drift). tryEval must catch it.
+    nullclaw-injection-guard-fires =
+      let
+        body = self.nixosConfigurations.zero-kuzea.config.system.build.nullclawConfigInjection;
+        bogus = [ "channels.telegram.accounts.main.NONEXISTENT_FIELD" ];
+        missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) bogus;
+        guarded = if missing == [ ] then true else builtins.throw "expected-throw";
+        result = builtins.tryEval guarded;
+      in
+      if !result.success then
+        true
+      else
+        builtins.throw "FAIL: nullclaw-injection-guard-fires — guard did NOT throw on a missing key path; the pin is not actually guarding.";
+
     # ── UniFi MCP ─────────────────────────────────────────────────
     unifi-mcp-minimal = shouldEval "unifi-mcp: minimal config" {
       modules = [


### PR DESCRIPTION
## Retrospective follow-ups: #456 + #458

The last two actionable items from the commit-history retrospective (epic #454). Designed via an investigate→adversarially-verify workflow that read the pinned nullclaw source end-to-end and pressure-tested both approaches.

### #456 — nullclaw config-injection acceptance gate (eval-time only)
`nullclaw` parses config with `ignore_unknown_fields=true` and its `validate()` **doesn't check telegram at all**, so a future pinned-rev bump that renames a key would **silently drop `bot_token` → unauthenticated Telegram bot**, with no startup error.

- Expose `system.build.nullclawConfigInjection` (the injected key paths + the exact jq SET expression, hoisted to a shared `jqSetExpr` `let`-binding so the injector and the contract **cannot drift**).
- Pin it in `tests/module-eval.nix` (`nullclaw-injection-key-paths`) + a **negative control** (`nullclaw-injection-guard-fires`) proving the guard throws on a missing path. Drift now fails CI loudly.
- **Deliberately no runtime ExecStartPost probe.** The investigation proved it would be both ineffective and unsafe: no `--validate` flag exists; `doctor` always exits 0 and needs a running daemon; readiness is presence-based (empty registry ⇒ ready, so a dropped channel looks healthy); and a `daemon_state.json` probe would race the async heartbeat into `Restart=on-failure` — the exact F3 crash-loop (#450). The issue's runtime-gate checkbox is WONTFIX with that rationale.

### #458 — verify a security fix shipped before closing
Guards the claude-yolo double-removal (a "fix" on an unmerged branch left the vuln deployed).

- New `scripts/verify-fix-shipped.sh` — wraps `git merge-base --is-ancestor <fix> origin/main` with ref validation + fetch, printing `SHIPPED` (exit 0) / `NOT SHIPPED` (exit 1) / `ERROR: unknown commit`.
- CLAUDE.md gains a **Security-Fix Closure Guard** subsection; the `sweep-bugs` skill gets the guard at both close paths (Step 3e + Phase 4 — the manual/no-merge closes that are the real risk).
- A **CI gate was rejected as infeasible** — issue-close has no PR/diff/event a workflow can hook; the durable guard lives at the decision points.

### Validation (darwin host — eval/script only)
- `nix eval …zero-kuzea…nullclawConfigInjection` renders correctly (anthropic, telegram yes, exact jq-set).
- Full `module-eval` set incl. both new assertions + negative control → `all-eval-tests-passed`.
- `verify-fix-shipped.sh`: SHIPPED (`75cba9c`), NOT SHIPPED (`84fb666`), ERROR (bad ref), usage (no-arg) — all correct exit codes.
- `nixpkgs-fmt --check` clean on the 2 changed nix files (script/docs aren't nix-formatted).

**Closes #456. Closes #458.** These complete the epic #454 actionable backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
