### PR TITLE
chore: bump claude-shared (ship shared user-level CLAUDE.md)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779818513,
-        "narHash": "sha256-bhf7iV8gSFRx/TpOAAUBf3aR12P/kOxgAB5dOUg8QTk=",
+        "lastModified": 1780759303,
+        "narHash": "sha256-khJNRrEmHk3l+qO0vluZ5aUr9ZKCpOClMClc+4h0OHQ=",
         "owner": "alexandru-savinov",
         "repo": "claude-shared",
-        "rev": "54f84c03315695661beb368f4d7feabd3d6d6bb8",
+        "rev": "47b65c9370060627f9c72b49ac951204ca8f23f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bumps the `claude-shared` flake input `54f84c0` → `47b65c9`.

That release adds a shared user-level `CLAUDE.md` (a task-agnostic "establish a closing feedback loop before you start" working agreement) and defaults `userClaudeMd` to the bundled `content/CLAUDE.md`, so every consumer installs `~/.claude/CLAUDE.md` automatically.

## Effect on this repo

`rpi5` / `rpi5-full` already import claude-shared via `customModules.claudeShared`, so after merge they install the user-level `CLAUDE.md`. It **appends** to this repo's own `CLAUDE.md` (does not replace it).

No NixOS module changes here — lock bump only.

## Verification

- `nix flake update claude-shared` — only `flake.lock` changed
- `nix eval .#nixosConfigurations.rpi5-full.config.system.build.toplevel.drvPath` — ✅ evaluates
- Already built + switched on rpi5 locally; `~/.claude/CLAUDE.md` confirmed present

🤖 Generated with [Claude Code](https://claude.com/claude-code)