### PR TITLE
feat(sancta-choir): migrate to customModules.claudeShared

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,7 +134,7 @@
           system = "x86_64-linux";
           specialArgs = {
             pkgs-unstable = pkgs-unstable-x86;
-            inherit self claude-code owui-openrouter-stats;
+            inherit self claude-code claude-shared owui-openrouter-stats;
           };
           modules = [
             ./hosts/sancta-choir/configuration.nix

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -41,14 +41,17 @@
     ../../modules/system/networking.nix
     ../../modules/system/dev-tools.nix
     ../../modules/users/root.nix
-    ../../modules/services/claude.nix
+    ../../modules/services/claude-shared.nix
     ../../modules/services/tailscale.nix
     ../../modules/services/open-webui.nix
   ];
 
   # Enable development tools and Claude Code
   customModules.dev-tools.enable = true;
-  customModules.claude.enable = true;
+  customModules.claudeShared = {
+    enable = true;
+    users = [ "root" ];
+  };
 
   # Agenix secrets (defaults: owner=root, group=root, mode=0400)
   age.secrets =


### PR DESCRIPTION
## What

`sancta-choir` migrates from the legacy **`customModules.claude`** (package-only) to the full **`customModules.claudeShared`** for `root`. This installs `~/.claude/CLAUDE.md` (the shared feedback-loop working agreement) plus the shared `skills/`, `agents/`, `commands/`, and `settings`. `flake.lock` already pins `claude-shared` at `47b65c9` — **no lock change** is part of this PR.

The change is exactly three edits, all on choir:
- `flake.nix` — sancta-choir `specialArgs`: add `claude-shared` to the inherit list.
- `hosts/sancta-choir/configuration.nix` — imports: `claude.nix` -> `claude-shared.nix`.
- `hosts/sancta-choir/configuration.nix` — config: `customModules.claude.enable = true;` -> `customModules.claudeShared = { enable = true; users = [ "root" ]; };`.

## Why choir / why NOT claw

- **choir**: runs a `root` `openclaw-gateway` whose coding-agent shells out to `claude` and reads `/root/.claude/CLAUDE.md`. So migrating root reaches a **real agent** and the shared working agreement actually takes effect.
- **claw is intentionally left on legacy**: claw's OpenClaw runs **sandboxed as uid 995** (`ProtectHome=yes`), reading its own kuzea `CLAUDE.md`. Migrating claw's root would be **decorative** — the sandboxed agent never reads root's config — while paying the #252 cost (OOM / auto-pull / auto-approve) for **zero agent value**. claw's value should be routed via a separate kuzea-workspace change. claw's `specialArgs` are untouched here.

## Verification done

- `nix fmt` clean.
- `sancta-choir` & `sancta-claw` toplevels eval.
- root `home.file` gains `.claude/CLAUDE.md` (eval = `true`).
- `home-manager.users` == `["root"]`.
- `flake.lock` untouched.

## Deploy notes (USER runs deploy)

choir has **no autoUpgrade timer** and **no earlyoom**, so deploy attended and throttled:

```
nixos-rebuild switch --flake .#sancta-choir --max-jobs 1 --cores 1
```

Rollback armed: `nixos-rebuild switch --rollback`.

- **Pre-deploy**: baseline `systemctl --failed`. A **pre-existing, unrelated** failure `open-webui-memory-migration.service` exists — post-switch the failed set must be **exactly that, unchanged**.
- **Post-deploy**:
  - `head -3 /root/.claude/CLAUDE.md`
  - open-webui active
  - the root `openclaw-gateway` still active
  - `claude --version` resolves to `/root/.nix-profile/bin/claude`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
