### PR TITLE
fix(reliability): TimeoutStartSec on Tailscale Serve sidecars + start propagation (#449)

### DIFF
--- a/hosts/sancta-claw/openclaw-tailscale-serve.nix
+++ b/hosts/sancta-claw/openclaw-tailscale-serve.nix
@@ -68,4 +68,8 @@
       ${pkgs.tailscale}/bin/tailscale serve --https 18789 off || true
     '';
   };
+
+  # PartOf above only propagates stop/restart of openclaw, not a plain start —
+  # openclaw also `wants` this unit so HTTPS returns on every openclaw start.
+  systemd.services.openclaw.wants = [ "openclaw-tailscale-serve.service" ];
 }

--- a/modules/services/gatus.nix
+++ b/modules/services/gatus.nix
@@ -567,6 +567,11 @@ in
     # Ensure gatus waits for env setup
     systemd.services.gatus.after = mkIf (cfg.apiKeyFile != null) [ "gatus-env-setup.service" ];
 
+    # PartOf on the serve oneshot only propagates stop/restart, not a plain
+    # start — gatus also `wants` the serve unit so HTTPS is reconfigured on
+    # every gatus start (pattern from home-assistant.nix).
+    systemd.services.gatus.wants = mkIf cfg.tailscaleServe.enable [ "tailscale-serve-gatus.service" ];
+
     # Tailscale Serve configuration for HTTPS access
     systemd.services.tailscale-serve-gatus = mkIf cfg.tailscaleServe.enable {
       description = "Configure Tailscale Serve for Gatus HTTPS access";
@@ -588,6 +593,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # Wait loops below total up to 120s (60s tailscaled + 60s gatus); the
+        # rpi5 host default of 90s would SIGTERM the oneshot mid-loop.
+        TimeoutStartSec = 150;
       };
 
       script = ''

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -120,6 +120,10 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # The wait loops below total up to 240s (60s tailscaled + 180s HA);
+        # without this the host's DefaultTimeoutStartSec=90s SIGTERMs the
+        # oneshot mid-loop and HTTPS never comes up on cold boot.
+        TimeoutStartSec = 300;
       };
 
       script = ''

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -367,6 +367,10 @@ in
     # Configure systemd service with environment variables
     # Uses ExecStartPre with "+" prefix to run as root for secret file setup
     systemd.services.n8n = {
+      # PartOf on the serve oneshot only propagates stop/restart, not a plain
+      # start — n8n also `wants` the serve unit so HTTPS is reconfigured on
+      # every n8n start (pattern from home-assistant.nix).
+      wants = mkIf cfg.tailscaleServe.enable [ "tailscale-serve-n8n.service" ];
       serviceConfig = {
         # Use static n8n user instead of DynamicUser to ensure consistent file ownership
         # This prevents SQLite database lock conflicts with n8n-workflow-sync service
@@ -745,6 +749,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # Wait loops below total up to 120s (60s tailscaled + 60s n8n); the
+        # rpi5 host default of 90s would SIGTERM the oneshot mid-loop.
+        TimeoutStartSec = 150;
       };
 
       script = ''

--- a/modules/services/nullclaw.nix
+++ b/modules/services/nullclaw.nix
@@ -269,7 +269,12 @@ in
     systemd.services.nullclaw = {
       description = "NullClaw AI Assistant (Gateway)";
       after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
+      # The serve oneshot's PartOf only propagates stop/restart, not a plain
+      # start — also `wants` it so HTTPS returns on every nullclaw start.
+      wants = [
+        "network-online.target"
+      ]
+      ++ lib.optionals cfg.tailscaleServe.enable [ "nullclaw-tailscale-serve.service" ];
       wantedBy = [ "multi-user.target" ];
 
       # NullClaw's libcurl dynamically loads NSS modules for DNS resolution.

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -655,7 +655,13 @@ in
     systemd.services.open-webui = {
       # Ensure Qdrant is running before Open-WebUI starts when using Qdrant vector DB
       after = mkIf (cfg.vectorDb.type == "qdrant") [ "qdrant.service" ];
-      wants = mkIf (cfg.vectorDb.type == "qdrant") [ "qdrant.service" ];
+      wants = mkMerge [
+        (mkIf (cfg.vectorDb.type == "qdrant") [ "qdrant.service" ])
+        # PartOf on the serve oneshot only propagates stop/restart, not a plain
+        # start — open-webui also `wants` the serve unit so HTTPS is
+        # reconfigured on every start (pattern from home-assistant.nix).
+        (mkIf cfg.tailscaleServe.enable [ "tailscale-serve-open-webui.service" ])
+      ];
 
       serviceConfig = mkMerge [
         {
@@ -1092,6 +1098,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # Wait loops below total up to 120s (60s tailscaled + 60s open-webui);
+        # the rpi5 host default of 90s would SIGTERM the oneshot mid-loop.
+        TimeoutStartSec = 150;
       };
 
       script = ''

--- a/modules/services/qdrant.nix
+++ b/modules/services/qdrant.nix
@@ -139,6 +139,11 @@ in
       ];
     };
 
+    # PartOf on the serve oneshot only propagates stop/restart, not a plain
+    # start — qdrant also `wants` the serve unit so HTTPS is reconfigured on
+    # every qdrant start (pattern from home-assistant.nix).
+    systemd.services.qdrant.wants = mkIf cfg.tailscaleServe.enable [ "tailscale-serve-qdrant.service" ];
+
     # Tailscale Serve configuration for HTTPS access
     systemd.services.tailscale-serve-qdrant = mkIf cfg.tailscaleServe.enable {
       description = "Configure Tailscale Serve for Qdrant HTTPS access";
@@ -160,6 +165,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # Wait loops below total up to 120s (60s tailscaled + 60s qdrant); the
+        # rpi5 host default of 90s would SIGTERM the oneshot mid-loop.
+        TimeoutStartSec = 150;
       };
 
       script = ''

--- a/modules/services/unifi-mcp.nix
+++ b/modules/services/unifi-mcp.nix
@@ -482,7 +482,12 @@ in
         unifi-mcp = mkIf cfg.service.enable {
           description = "UniFi Network MCP Server (HTTP SSE mode)";
           after = [ "network-online.target" ] ++ lib.optionals cfg.useDocker [ "docker.service" ];
-          wants = [ "network-online.target" ];
+          # The serve oneshot's PartOf only propagates stop/restart, not a
+          # plain start — also `wants` it so HTTPS returns on every start.
+          wants = [
+            "network-online.target"
+          ]
+          ++ lib.optionals cfg.tailscaleServe.enable [ "tailscale-serve-unifi-mcp.service" ];
           requires = mkIf cfg.useDocker [ "docker.service" ];
           wantedBy = [ "multi-user.target" ];
 
@@ -550,6 +555,9 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
+            # Wait loops below total up to 120s (60s tailscaled + 60s MCP);
+            # the rpi5 host default of 90s would SIGTERM the oneshot mid-loop.
+            TimeoutStartSec = 150;
           };
 
           script = ''


### PR DESCRIPTION
## Summary
- Add explicit `TimeoutStartSec` to every Tailscale Serve oneshot whose wait loops exceed the 90s host default (`DefaultTimeoutStartSec` at `hosts/rpi5/configuration.nix:253`): home-assistant gets 300 (60s tailscaled + 180s HA port), n8n/gatus/qdrant/open-webui/unifi-mcp get 150 (dual 60s loops).
- Close the `partOf` start-propagation gap repo-wide: `PartOf=` propagates stop/restart but **not** a plain start, so a stop→start of the parent left HTTPS dark. Each parent service now also `wants` its serve sidecar, replicating the existing home-assistant pattern onto n8n, gatus, qdrant, open-webui, unifi-mcp, nullclaw, and sancta-claw's openclaw serve unit.

Fixes the live bug on rpi5-full where `tailscale-serve-home-assistant` (240s loop budget), `tailscale-serve-n8n` and `tailscale-serve-gatus` (120s) were SIGTERM'd at 90s on cold boot.

## Verification
`nix eval` of the rendered units:
- rpi5-full: `ha_timeout=300, n8n_timeout=150, gatus_timeout=150`, parents' `wants` include their serve sidecars
- sancta-claw: `openclaw.wants` includes `openclaw-tailscale-serve.service`
- zero-kuzea: `nullclaw.wants` includes `nullclaw-tailscale-serve.service`, serve timeout 150
- All-host toplevel eval: rpi5/rpi5-full/sancta-choir/zero-kuzea OK; sancta-claw/hermes-claw fail locally on a pre-existing cross-arch IFD limitation (same on main), covered by x86_64 CI.

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)