### PR TITLE
fix(open-webui): memory-migration INSERT omits NOT NULL version column (#470)

### DIFF
--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -1022,16 +1022,18 @@ in
             """, (user_id, user_email, pw_hash))
             print("Created auth entry for E2E test user")
 
-        # Enable API keys in config if not already enabled
-        cursor.execute("SELECT data FROM config LIMIT 1")
+        # Enable API keys in config if not already enabled. Open-WebUI treats
+        # the highest-id row as the active config — read and update only that
+        # row (an unscoped UPDATE would clobber every row with the one read).
+        cursor.execute("SELECT id, data FROM config ORDER BY id DESC LIMIT 1")
         config_row = cursor.fetchone()
         if config_row:
-            config = json.loads(config_row[0])
+            config = json.loads(config_row[1])
             if "features" not in config:
                 config["features"] = {}
             if not config["features"].get("enable_api_keys"):
                 config["features"]["enable_api_keys"] = True
-                cursor.execute("UPDATE config SET data=?", (json.dumps(config),))
+                cursor.execute("UPDATE config SET data=? WHERE id=?", (json.dumps(config), config_row[0]))
                 print("Enabled API keys in config")
 
         conn.commit()
@@ -1221,9 +1223,10 @@ in
         try:
             cursor = conn.cursor()
 
-            # Get current config
+            # Get current config — Open-WebUI treats the highest-id row as
+            # the active config, so target that (not rowid 1).
             try:
-                cursor.execute("SELECT data FROM config LIMIT 1")
+                cursor.execute("SELECT id, data FROM config ORDER BY id DESC LIMIT 1")
             except sqlite3.OperationalError as e:
                 print(f"ERROR: Failed to query config table: {e}")
                 conn.close()
@@ -1233,7 +1236,7 @@ in
 
             if row:
                 try:
-                    config = json.loads(row[0])
+                    config = json.loads(row[1])
                 except json.JSONDecodeError as e:
                     print(f"ERROR: Config data in database is not valid JSON: {e}")
                     conn.close()
@@ -1271,15 +1274,24 @@ in
 
             if changed:
                 try:
-                    cursor.execute("UPDATE config SET data = ? WHERE rowid = 1", (json.dumps(config),))
-                    if cursor.rowcount == 0:
+                    if row:
+                        cursor.execute(
+                            "UPDATE config SET data = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                            (json.dumps(config), row[0]),
+                        )
+                    else:
+                        # version is NOT NULL with no default; created_at and
+                        # updated_at have CURRENT_TIMESTAMP defaults.
                         print("WARNING: No config row found to update, inserting new row")
-                        cursor.execute("INSERT INTO config (data) VALUES (?)", (json.dumps(config),))
+                        cursor.execute(
+                            "INSERT INTO config (data, version) VALUES (?, 0)",
+                            (json.dumps(config),),
+                        )
                     conn.commit()
                     print(f"Memory feature migration complete (updated {cursor.rowcount} row(s))")
-                except sqlite3.OperationalError as e:
+                except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
                     print(f"ERROR: Failed to update config in database: {e}")
-                    print("HINT: Database may be locked, disk may be full, or filesystem may be read-only")
+                    print("HINT: Database may be locked, disk full, read-only, or the config table schema may not match the expected Open-WebUI schema (id, data, version, created_at, updated_at)")
                     conn.close()
                     sys.exit(1)
             else:


### PR DESCRIPTION
## Summary
- `open-webui-memory-migration` INSERT branch now supplies `version = 0` — the `config` table declares `version INTEGER NOT NULL` with no default, which is exactly what crashed the unit on sancta-choir (`created_at`/`updated_at` have `CURRENT_TIMESTAMP` defaults, verified against a live `webui.db`).
- SELECT/UPDATE now target the **highest-id** config row (Open-WebUI's active config) instead of `rowid = 1`, and `updated_at` is bumped on update.
- `except` broadened to catch `sqlite3.IntegrityError` with a clear schema-mismatch hint instead of a raw traceback.
- Same wrong-row pattern fixed in the e2e-test-user provisioning script: it read the first config row and ran an **unscoped** `UPDATE config SET data=?` that would clobber every row with the first row's data; now scoped to the highest-id row.

## Verification
Extracted the rendered script via `nix eval .#nixosConfigurations.sancta-choir.config.systemd.services.open-webui-memory-migration.script` and ran it against test DBs using the exact live schema:

- **Empty config table (choir's failure):** old script reproduces `sqlite3.IntegrityError: NOT NULL constraint failed: config.version` (same line 70 as the issue's journal); new script exits 0, inserts one row with `version=0`, all three memory flags set, timestamps populated.
- **Multi-row table (id=3, id=7):** new script updates only id=7; id=3's data untouched.

## Post-merge
Acceptance ("`systemctl --failed` empty on choir after a rebuild") needs a sancta-choir deploy — will do a throttled `nixos-rebuild build && switch` after merge and confirm the unit succeeds.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)