### PR TITLE
fix(reliability): crash-loop circuit breaker + operator alert for tailscale-dns-watchdog (#450)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -472,6 +472,10 @@ in
     telegramEnvFile = secret "backup-telegram-env";
   };
 
+  # Operator alert when the DNS-watchdog crash-loop breaker opens (#450).
+  # Reuses the backup alert credentials (TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID).
+  services.tailscale-dns-watchdog.telegramEnvFile = secret "backup-telegram-env";
+
   # Add n8n to nixframe group so it can write photos to nixframe's home dir
   users.users.n8n.extraGroups = [ "nixframe" ];
 

--- a/modules/services/tailscale.nix
+++ b/modules/services/tailscale.nix
@@ -1,65 +1,141 @@
-{ config, pkgs, ... }:
+{ config
+, lib
+, pkgs
+, ...
+}:
 
+let
+  cfg = config.services.tailscale-dns-watchdog;
+in
 {
-  # Tailscale - Zero-config VPN
-  services.tailscale = {
-    enable = true;
-    useRoutingFeatures = "client";
-    openFirewall = true;
-    authKeyFile = config.age.secrets.tailscale-auth-key.path;
-    extraUpFlags = [
-      "--ssh"
-      "--accept-routes"
-    ];
+  options.services.tailscale-dns-watchdog = {
+    telegramEnvFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Optional EnvironmentFile with TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID
+        (same format as services.backup-pull.telegramEnvFile). When set, the
+        watchdog alerts the operator once per outage when the crash-loop
+        breaker opens (restarts stopped, manual intervention needed).
+        When null, breaker events are journal-only.
+      '';
+    };
   };
 
-  # Trust the Tailscale interface
-  networking.firewall.trustedInterfaces = [ "tailscale0" ];
+  config = {
+    # Tailscale - Zero-config VPN
+    services.tailscale = {
+      enable = true;
+      useRoutingFeatures = "client";
+      openFirewall = true;
+      authKeyFile = config.age.secrets.tailscale-auth-key.path;
+      extraUpFlags = [
+        "--ssh"
+        "--accept-routes"
+      ];
+    };
 
-  systemd = {
-    # Watchdog: restart tailscaled if its DNS proxy stops forwarding.
-    # After an Ethernet link flap, Tailscale can lose its upstream resolver
-    # config (Routes:{.:[]}) and never recover, returning SERVFAIL for all
-    # non-Tailscale queries. This timer probes every 2 minutes and restarts
-    # tailscaled after 3 consecutive failures (~4-6 min of DNS failure).
-    services.tailscale-dns-watchdog = {
-      description = "Tailscale DNS forwarding watchdog";
-      after = [ "tailscaled.service" ];
-      path = [ pkgs.dig pkgs.gnugrep ];
-      serviceConfig = {
-        Type = "oneshot";
-        StateDirectory = "tailscale-dns-watchdog";
-      };
-      script = ''
-        set -euo pipefail
+    # Trust the Tailscale interface
+    networking.firewall.trustedInterfaces = [ "tailscale0" ];
 
-        FAIL_COUNT_FILE="/var/lib/tailscale-dns-watchdog/fail-count"
-        MAX_FAILURES=3
+    systemd = {
+      # Watchdog: restart tailscaled if its DNS proxy stops forwarding.
+      # After an Ethernet link flap, Tailscale can lose its upstream resolver
+      # config (Routes:{.:[]}) and never recover, returning SERVFAIL for all
+      # non-Tailscale queries. This timer probes every 2 minutes and restarts
+      # tailscaled after 3 consecutive failures (~4-6 min of DNS failure).
+      #
+      # Crash-loop circuit breaker (#450): a fixed retry interval is not a
+      # breaker — against a persistent failure the old logic restarted
+      # tailscaled every ~6 min forever. Mirrors the openclaw health-probe
+      # pattern (hosts/sancta-claw/openclaw-watchers.nix): restart markers in
+      # the StateDirectory, counted over a sliding window via `find -mmin`;
+      # after CRASH_LOOP_MAX restarts in the window it STOPS restarting,
+      # alerts the operator once, and only re-arms when markers age out
+      # (half-open) or a probe succeeds.
+      services.tailscale-dns-watchdog = {
+        description = "Tailscale DNS forwarding watchdog";
+        after = [ "tailscaled.service" ];
+        path = [
+          pkgs.dig
+          pkgs.gnugrep
+          pkgs.curl
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          StateDirectory = "tailscale-dns-watchdog";
+          EnvironmentFile = lib.mkIf (cfg.telegramEnvFile != null) cfg.telegramEnvFile;
+        };
+        script = ''
+          set -euo pipefail
 
-        # Skip if Tailscale DNS is not active (100.100.100.100 not in resolv.conf)
-        if ! grep -q '100.100.100.100' /etc/resolv.conf 2>/dev/null; then
-          rm -f "$FAIL_COUNT_FILE"
-          exit 0
-        fi
+          STATE_DIR="/var/lib/tailscale-dns-watchdog"
+          FAIL_COUNT_FILE="$STATE_DIR/fail-count"
+          RESTART_LOG_DIR="$STATE_DIR/restarts"
+          BREAKER_ALERTED_FILE="$STATE_DIR/breaker-alerted"
+          MAX_FAILURES=3
+          CRASH_LOOP_MAX=3
+          CRASH_LOOP_WINDOW_MIN=30
 
-        # Probe an external domain through Tailscale's DNS proxy (expect IPv4 A record)
-        dig_output=$(dig +short +timeout=5 +tries=1 @100.100.100.100 google.com A 2>&1) || true
-        if echo "$dig_output" | grep -q '^[0-9]'; then
-          rm -f "$FAIL_COUNT_FILE"
-          exit 0
-        fi
+          # Best-effort operator alert; journal-only when no Telegram env is
+          # configured (services.tailscale-dns-watchdog.telegramEnvFile).
+          alert() {
+            echo "$1" >&2
+            if [ -n "''${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "''${TELEGRAM_CHAT_ID:-}" ]; then
+              curl -sf -X POST \
+                "https://api.telegram.org/bot''${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                -d "chat_id=''${TELEGRAM_CHAT_ID}" \
+                -d "text=$1" \
+                --max-time 10 || true
+            fi
+          }
 
-        # DNS probe failed — read and validate counter
-        raw=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
-        if ! [[ "$raw" =~ ^[0-9]+$ ]]; then
-          echo "tailscale-dns-watchdog: corrupt fail-count ('$raw'), resetting" >&2
-          raw=0
-        fi
-        count=$((raw + 1))
-        echo "$count" > "$FAIL_COUNT_FILE"
+          # Skip if Tailscale DNS is not active (100.100.100.100 not in resolv.conf)
+          if ! grep -q '100.100.100.100' /etc/resolv.conf 2>/dev/null; then
+            rm -f "$FAIL_COUNT_FILE" "$BREAKER_ALERTED_FILE"
+            exit 0
+          fi
 
-        if [ "$count" -ge "$MAX_FAILURES" ]; then
-          echo "tailscale-dns-watchdog: $count consecutive DNS failures (dig output: '$dig_output'), restarting tailscaled"
+          # Probe an external domain through Tailscale's DNS proxy (expect IPv4 A record)
+          dig_output=$(dig +short +timeout=5 +tries=1 @100.100.100.100 google.com A 2>&1) || true
+          if echo "$dig_output" | grep -q '^[0-9]'; then
+            rm -f "$FAIL_COUNT_FILE" "$BREAKER_ALERTED_FILE"
+            exit 0
+          fi
+
+          # DNS probe failed — read and validate counter
+          raw=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
+          if ! [[ "$raw" =~ ^[0-9]+$ ]]; then
+            echo "tailscale-dns-watchdog: corrupt fail-count ('$raw'), resetting" >&2
+            raw=0
+          fi
+          count=$((raw + 1))
+          echo "$count" > "$FAIL_COUNT_FILE"
+
+          if [ "$count" -lt "$MAX_FAILURES" ]; then
+            echo "tailscale-dns-watchdog: DNS probe failed ($count/$MAX_FAILURES)"
+            exit 0
+          fi
+
+          # Eligible for restart — consult the windowed circuit breaker first.
+          mkdir -p "$RESTART_LOG_DIR"
+          find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "+$CRASH_LOOP_WINDOW_MIN" -delete 2>/dev/null || true
+          RECENT_RESTARTS=$(find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN" 2>/dev/null | wc -l)
+
+          if [ "$RECENT_RESTARTS" -ge "$CRASH_LOOP_MAX" ]; then
+            echo "tailscale-dns-watchdog: crash loop detected ($RECENT_RESTARTS tailscaled restarts in $CRASH_LOOP_WINDOW_MIN min without DNS recovery). NOT restarting." >&2
+            # Alert once per outage; marker clears on the next successful probe.
+            if [ ! -f "$BREAKER_ALERTED_FILE" ]; then
+              alert "🔴 [${config.networking.hostName}] tailscale-dns-watchdog: crash loop — $RECENT_RESTARTS tailscaled restarts in ''${CRASH_LOOP_WINDOW_MIN}min without DNS recovery. Auto-restart STOPPED. Manual intervention needed."
+              touch "$BREAKER_ALERTED_FILE"
+            fi
+            exit 1
+          fi
+
+          echo "tailscale-dns-watchdog: $count consecutive DNS failures (dig output: '$dig_output'), restarting tailscaled ($((RECENT_RESTARTS + 1))/$CRASH_LOOP_MAX in window before breaker opens)"
+          # %N: marker names must be unique even for restarts within the same
+          # second, or colliding names undercount the window (breaker never opens)
+          touch "$RESTART_LOG_DIR/$(date +%s%N)"
           if systemctl restart tailscaled.service; then
             echo "tailscale-dns-watchdog: tailscaled restarted successfully"
             rm -f "$FAIL_COUNT_FILE"
@@ -67,18 +143,16 @@
             echo "tailscale-dns-watchdog: ERROR - tailscaled restart failed" >&2
             exit 1
           fi
-        else
-          echo "tailscale-dns-watchdog: DNS probe failed ($count/$MAX_FAILURES)"
-        fi
-      '';
-    };
+        '';
+      };
 
-    timers.tailscale-dns-watchdog = {
-      description = "Run Tailscale DNS watchdog every 2 minutes";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnBootSec = "3min";
-        OnUnitActiveSec = "2min";
+      timers.tailscale-dns-watchdog = {
+        description = "Run Tailscale DNS watchdog every 2 minutes";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnBootSec = "3min";
+          OnUnitActiveSec = "2min";
+        };
       };
     };
   };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -697,6 +697,13 @@ let
           ".zdr-migration-announced"
           "free+ZDR ladder"
           "primary=$PRIMARY"
+          # Crash-loop circuit breaker (#403/#450): assert the windowed
+          # breaker can't be silently deleted — marker-file window count,
+          # give-up branch, and hard failure exit.
+          "CRASH_LOOP_MAX"
+          ''find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN"''
+          "NOT restarting"
+          "exit 1"
         ];
         missing = builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
       in
@@ -704,6 +711,42 @@ let
         true
       else
         builtins.throw "FAIL: openclawHealthProbeBody missing substrings: ${builtins.toJSON missing}";
+
+    # Verify the tailscale-dns-watchdog ships the same windowed crash-loop
+    # breaker + operator alert (#450) on every host that imports the shared
+    # tailscale module. Reads the rendered unit script — pure eval, no IFD.
+    tailscale-dns-watchdog-breaker =
+      let
+        hosts = [
+          "rpi5"
+          "rpi5-full"
+          "sancta-choir"
+          "sancta-claw"
+          "hermes-claw"
+          "zero-kuzea"
+        ];
+        required = [
+          "CRASH_LOOP_MAX"
+          ''find "$RESTART_LOG_DIR" -maxdepth 1 -type f -mmin "-$CRASH_LOOP_WINDOW_MIN"''
+          "NOT restarting"
+          "Manual intervention needed"
+          "exit 1"
+        ];
+        missingFor =
+          host:
+          let
+            body = self.nixosConfigurations.${host}.config.systemd.services.tailscale-dns-watchdog.script;
+          in
+          builtins.filter (s: !(nixpkgs.lib.hasInfix s body)) required;
+        failures = builtins.filter (h: missingFor h != [ ]) hosts;
+        # rpi5-full must additionally wire the Telegram alert credentials.
+        rpi5AlertWired =
+          self.nixosConfigurations.rpi5-full.config.services.tailscale-dns-watchdog.telegramEnvFile != null;
+      in
+      if failures == [ ] && rpi5AlertWired then
+        true
+      else
+        builtins.throw "FAIL: tailscale-dns-watchdog breaker — hosts missing sentinels: ${builtins.toJSON failures}; rpi5-full alert wired: ${builtins.toJSON rpi5AlertWired}";
 
     # Verify the hermes-claw host config uses the upstream hermes-agent
     # module in container mode with the correct model pin and settings.


### PR DESCRIPTION
## Summary
- Ports the windowed crash-loop breaker from `hosts/sancta-claw/openclaw-watchers.nix` to `modules/services/tailscale.nix` (all 6 hosts): marker files under the StateDirectory, counted with `find -mmin` over a 30-min sliding window; after 3 tailscaled restarts in the window the watchdog **stops restarting**, alerts the operator once per outage, and exits 1. Markers aging out of the window re-arm it (half-open); a successful DNS probe clears all breaker state.
- New `services.tailscale-dns-watchdog.telegramEnvFile` option (same `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` env-file format as `services.backup-pull`); **rpi5-full** wires the existing `backup-telegram-env` secret. Other hosts remain journal-only until wired.
- Marker filenames use `date +%s%N`: second-resolution names collide for restarts in the same second and silently undercount the window — found by the behavioral test below (latent in the openclaw original, masked by its 60s timer).
- **Test coverage (P2 from the issue):** `tests/module-eval.nix` gains a `tailscale-dns-watchdog-breaker` assertion (rendered script on all 6 hosts must contain the breaker sentinels; rpi5-full must have the alert wired), and the existing openclaw health-probe assertion now pins `CRASH_LOOP_MAX`, the `find -mmin` window count, `NOT restarting`, and `exit 1`.

## Verification
- Behavioral test of the rendered rpi5-full script (stubbed `dig`/`systemctl`/`curl`, state dir + resolv.conf redirected): 15 consecutive failing probes → restarts at probes 3/6/9, breaker opens at probe 12 with exactly one Telegram alert, probes 13–15 hold open (exit 1, no restart, no repeat alert); successful probe then exits 0 and clears `fail-count` + `breaker-alerted`.
- The same test run before the `%s%N` fix showed the breaker **never opening** (marker-name collision) — regression caught and fixed.
- `nix eval .#checks.x86_64-linux.module-eval.drvPath` passes with the new assertions.
- `nix eval` of rpi5-full: watchdog `serviceConfig.EnvironmentFile = /run/agenix/backup-telegram-env`.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)