### PR TITLE
fix(cleanup): repoint dormant earlyoom --prefer to hass + stale rpi5 README docs (#453)

### DIFF
--- a/hosts/rpi5/README.md
+++ b/hosts/rpi5/README.md
@@ -161,17 +161,22 @@ raspberry-pi-nix.board = "bcm2712";
 |---------|-------|---------|
 | zram | 50% of RAM | Compressed swap in memory |
 | Swap file | 4GB | Disk swap for heavy workloads |
-| vm.swappiness | 60 | Balanced swap usage |
+| vm.swappiness | 80 | Prefer zram swap (4.5x compression) over cold pages in RAM |
 | vm.min_free_kbytes | 64MB | Reserve for system stability |
 
-### Open-WebUI Limits
+### Service Memory Limits (rpi5-full)
 
-| Limit | Value | Purpose |
-|-------|-------|---------|
-| MemoryMax | 2GB | Prevent runaway memory usage |
-| MemoryHigh | 1.5GB | Trigger memory pressure earlier |
-| CPUQuota | 300% | Max 3 cores |
-| Nice | 5 | Lower priority during builds |
+Enforced only with `cgroup_enable=memory` on the kernel cmdline (set in
+`configuration.nix`, needs a reboot after first deploy).
+
+| Service | MemoryMax | MemoryHigh |
+|---------|-----------|------------|
+| n8n | 1536M | 1280M |
+| home-assistant | 1G | 768M |
+| gatus | 256M | 192M |
+
+Open-WebUI is currently disabled on rpi5-full (#381); its old 2GB/1.5GB
+limits no longer apply.
 
 ### Nix Build Optimization
 

--- a/hosts/rpi5/configuration.nix
+++ b/hosts/rpi5/configuration.nix
@@ -228,8 +228,13 @@
     freeSwapThreshold = 10;
     enableNotifications = true;
     extraArgs = [
+      # earlyoom matches against the truncated, sometimes dot-prefixed
+      # /proc/PID/comm (Home Assistant's comm is ".hass-wrapped"), so the
+      # --prefer regex must stay UNANCHORED; the --avoid comms have no
+      # prefix, so anchoring them is correct. Was "(open-webui)" — dormant
+      # since open-webui was disabled on rpi5-full (#381/#453).
       "--prefer"
-      "(open-webui)"
+      "(hass)"
       "--avoid"
       "^(sshd|tailscaled|n8n)"
     ];


### PR DESCRIPTION
## Summary
- **P2:** `earlyoom --prefer "(open-webui)"` → `"(hass)"` in `hosts/rpi5/configuration.nix`. Open-WebUI has been disabled on rpi5-full since #381, so the preferred-victim regex matched nothing. Home Assistant is the heaviest running service; its live comm is `.hass-wrapped` (checked on-box: `cat /proc/$(systemctl show -p MainPID --value home-assistant)/comm`), so the regex stays **unanchored** per the comm-truncation gotcha documented in the issue. Added an in-tree comment explaining the anchored/unanchored asymmetry so it survives future edits.
- **P3:** `hosts/rpi5/README.md` — replaced the stale "Open-WebUI Limits" table with the actually-enforced per-service limits (n8n 1536M/1280M, home-assistant 1G/768M, gatus 256M/192M, values from the live module configs) and fixed `vm.swappiness` 60 → 80.
- **On-box checkbox:** `/proc/cmdline` on live rpi5 contains `cgroup_enable=memory` → the reboot after #202 happened; memory limits are actually enforced.

## Verification
- `nix eval .#nixosConfigurations.rpi5-full.config.services.earlyoom.extraArgs` → `["--prefer","(hass)","--avoid","^(sshd|tailscaled|n8n)"]`
- Live comm check on rpi5: home-assistant MainPID comm = `.hass-wrapped` (unanchored `(hass)` matches; an anchored `^(hass)` would not).

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)