### PR TITLE
docs(flake): document intentional nixos-raspberrypi nixpkgs split (#182)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,15 @@
     # Uses nvmd/nixos-raspberrypi which has the same kernel as the pre-built SD image
     # Cache: nixos-raspberrypi.cachix.org
     # See: https://github.com/nvmd/nixos-raspberrypi
+    #
+    # INTENTIONALLY no `inputs.nixpkgs.follows = "nixpkgs"` (#182): the
+    # nixos-raspberrypi binary cache (kernel, firmware) is built against ITS
+    # pinned nixpkgs. Following our nixpkgs would change the kernel derivation
+    # hash and force multi-hour from-source kernel builds on the 4GB Pi.
+    # Consequence: rpi5/rpi5-full track nixos-raspberrypi's nixpkgs pin while
+    # the other hosts track the root `nixpkgs` input — both on the same
+    # nixos-25.11 branch since the 25.11 upgrade, but at slightly different
+    # revisions (days apart). Keep both fresh with `nix flake update`.
     nixos-raspberrypi = {
       url = "github:nvmd/nixos-raspberrypi";
     };


### PR DESCRIPTION
## Summary
Resolves #182 via its **Option B** (document the split):
- The impact described in the issue — a 25.05 vs 25.11 **release** split — no longer exists: root nixpkgs was bumped to `nixos-25.11` (for CVE-2025-68613), so all hosts are on the same release. Verified: `system.nixos.release` = 25.11 for both rpi5-full and sancta-choir.
- What remains is a small **revision** skew: rpi5/rpi5-full build from nixos-raspberrypi's own nixpkgs pin (`3e20095`, 2026-03-13) while other hosts use root nixpkgs (`fea3b36`, 2026-03-18).
- **Option A (`follows`) is deliberately rejected**, now documented at the input: the nixos-raspberrypi cachix cache builds the RPi kernel/firmware against *its* pin; `follows` would change the kernel drv hash and force multi-hour source kernel builds on the 4GB Pi — the exact reason the input has no `follows` today.

## Verification
- `nix flake metadata` parses the edited flake.
- `nix eval .#nixosConfigurations.{rpi5-full,sancta-choir}.config.system.nixos.release` → both `25.11`.
- Lock graph: root nixpkgs `fea3b36`, nixos-raspberrypi→nixpkgs `3e20095` (the documented skew).

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)