### PR TITLE
feat(n8n): typed allowBuiltinModules option (#156)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -202,13 +202,19 @@ in
     # Requires adminPasswordFile to authenticate with n8n
     communityPackages = [ "n8n-nodes-zip" ];
 
-    # Enable Node.js built-in modules in Code nodes:
+    # Node.js built-in modules in Code nodes:
     # - crypto: efficient SHA256 hashing (pure JS is slow on ARM)
     # - fs, path: file-based job status tracking for async workflow patterns
     # - child_process: NixFrame HEIC→JPEG conversion (removing from Code nodes doesn't
     #   help — n8n's Execute Command node allows the same; n8n user is systemd-sandboxed)
+    allowBuiltinModules = [
+      "fs"
+      "path"
+      "crypto"
+      "child_process"
+    ];
+
     extraEnvironment = {
-      NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto,child_process";
       # Enable n8n Public API for Claude Code MCP integration
       N8N_PUBLIC_API_DISABLED = "false";
       # Increase task runner heap for APKG assembly (reads all card files into one JSON blob)

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -300,6 +300,22 @@ in
       '';
     };
 
+    allowBuiltinModules = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''[ "fs" "path" "crypto" ]'';
+      description = ''
+        Node.js built-in modules usable inside n8n Code nodes (rendered as
+        NODE_FUNCTION_ALLOW_BUILTIN). Type-safe, mergeable alternative to
+        setting the raw variable via extraEnvironment.
+
+        SECURITY: every module listed widens what workflow authors can do.
+        "child_process" in particular allows arbitrary command execution as
+        the n8n user (equivalent to the built-in Execute Command node; the
+        n8n user is systemd-sandboxed). Keep this list minimal.
+      '';
+    };
+
     communityPackages = mkOption {
       type = types.listOf types.str;
       default = [ ];
@@ -354,6 +370,14 @@ in
           Without it, n8n credentials are stored unencrypted in the database.
           Generate a key: openssl rand -hex 32
           Set it to an agenix secret path: config.age.secrets.n8n-encryption-key.path
+        '';
+      }
+      {
+        assertion = !(cfg.allowBuiltinModules != [ ] && cfg.extraEnvironment ? NODE_FUNCTION_ALLOW_BUILTIN);
+        message = ''
+          services.n8n-tailscale: NODE_FUNCTION_ALLOW_BUILTIN is set both via
+          allowBuiltinModules and extraEnvironment — the duplicate env-file
+          lines would silently shadow one another. Use allowBuiltinModules only.
         '';
       }
     ];
@@ -478,6 +502,11 @@ in
 
                         # Concurrency limit
                         echo "N8N_CONCURRENCY_PRODUCTION_LIMIT=${toString cfg.concurrencyLimit}" >> "$ENV_FILE"
+
+                        # Node.js built-ins allowed in Code nodes (typed option)
+                        ${optionalString (cfg.allowBuiltinModules != [ ]) ''
+                          echo "NODE_FUNCTION_ALLOW_BUILTIN=${concatStringsSep "," cfg.allowBuiltinModules}" >> "$ENV_FILE"
+                        ''}
 
                         # Extra environment variables (values escaped to prevent shell injection)
                         ${concatStringsSep "\n" (mapAttrsToList (name: value: ''


### PR DESCRIPTION
## Summary
- New `services.n8n-tailscale.allowBuiltinModules` option (`listOf str`) rendered as `NODE_FUNCTION_ALLOW_BUILTIN` in the n8n env file — the typed, mergeable, self-documenting variant proposed in #156. The option description carries the security note (notably `child_process` ≈ arbitrary command execution as the sandboxed n8n user).
- Assertion rejects configuring the variable via both `allowBuiltinModules` and `extraEnvironment` simultaneously (duplicate env lines would shadow silently).
- rpi5-full migrated to the new option; `extraEnvironment` keeps its other two variables.

## Verification
Built the rendered `n8n.service` unit from the rpi5-full config and inspected the generated `n8n-setup-env` script:
```
echo "NODE_FUNCTION_ALLOW_BUILTIN=fs,path,crypto,child_process" >> "$ENV_FILE"
```
— byte-identical env-file line to the pre-migration `extraEnvironment` rendering.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)