### PR TITLE
feat(home-assistant): enable Roborock integration for Saros 10 vacuum

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -335,6 +335,10 @@ in
     enable = true;
     timeZone = "Europe/Bucharest";
     tailscaleServe.enable = true;
+    # Roborock Saros 10 vacuum — bundles python-roborock so the cloud-light
+    # integration (Roborock account login once, then local LAN control) can be
+    # configured via the Add Integration UI / config flow.
+    extraComponents = [ "roborock" ];
   };
 
   # Explicit external/internal URLs so HA doesn't auto-detect behind the

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -33,6 +33,22 @@ in
       '';
     };
 
+    extraComponents = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "roborock" ];
+      description = ''
+        Home Assistant integration components to bundle into the package,
+        together with their Python dependencies. Empty by default so the HA
+        package stays a binary-cache hit. Each entry pulls that integration's
+        requirements into the HA Python environment and forces a local
+        aarch64 rebuild (slow + memory-hungry on the 4GB Pi), so only add a
+        component when a real device needs it (e.g. "roborock" for a Roborock
+        vacuum). Once built, the integration becomes available in the
+        config-flow / Add Integration UI for setup.
+      '';
+    };
+
     tailscaleServe = {
       enable = mkEnableOption "Tailscale Serve HTTPS front for Home Assistant";
 
@@ -45,13 +61,16 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Native Home Assistant module. We deliberately do NOT set
-    # extraComponents / extraPackages / package / customComponents here:
-    # keeping them at the module default guarantees a binary-cache hit and
-    # avoids a large local aarch64 Python rebuild that can OOM the 4GB Pi.
-    # Only `config` is set, which is a cheap YAML render.
+    # Native Home Assistant module. extraComponents defaults to [] (see the
+    # option below): with an empty list the HA package keeps its upstream hash
+    # and stays a binary-cache hit. Set extraComponents per-host only when a
+    # device needs an integration — a non-empty list bundles that integration's
+    # Python deps and forces a local aarch64 rebuild, slow and memory-hungry on
+    # the 4GB Pi, so keep the list minimal. extraPackages / package /
+    # customComponents are intentionally left at their defaults.
     services.home-assistant = {
       enable = true;
+      inherit (cfg) extraComponents;
       # Pin explicitly (defense-in-depth): never open 8123 to the network — access
       # is exclusively via the Tailscale Serve HTTPS proxy. Don't rely on the
       # upstream module default in case it ever changes.


### PR DESCRIPTION
## What

Adds the official **Roborock** integration to Home Assistant on `rpi5-full` for a newly-added **Roborock Saros 10** robot vacuum.

- New module option `services.home-assistant-tailscale.extraComponents` (default `[]`) — wires `services.home-assistant.extraComponents`. Empty default preserves the binary-cache hit for any host that doesn't set it.
- `hosts/rpi5-full/configuration.nix` sets `extraComponents = [ "roborock" ]`.

## Why

The roborock config flow currently fails with `No module named 'roborock'` — the NixOS HA package only bundles Python deps for explicitly-enabled components. Enabling the component bundles `python-roborock` + deps so the integration appears in **Add Integration** / the config flow.

Setup is **cloud-light**: a one-time Roborock account login (email + emailed code), after which HA controls the vacuum **locally over the LAN**. (Fully cloud-free isn't possible for the Saros 10 — Valetudo doesn't support this model.)

## Cost / risk

`nix build --dry-run` for rpi5-full: **28 derivations built, 60 fetched (6 MiB)**. All lightweight — `python-roborock`, `vacuum-map-parser-roborock`, `aiomqtt`, `paho-mqtt`, a couple small C extensions. **No ML/torch-scale packages**, so this is not the OOM class the module comment guards against. Build throttled with `--max-jobs 1 --cores 1`.

## Verification

- [x] `nix eval` confirms `roborock` threads through to `services.home-assistant.extraComponents` on rpi5-full
- [x] `nix fmt` clean
- [ ] Local `nixos-rebuild build --flake .#rpi5-full` (in progress on the Pi — the real aarch64 check, since CI only *evaluates* aarch64)
- [ ] Post-deploy: `roborock` config flow no longer 500s; `vacuum.*` entity appears and reports state after account login

🤖 Generated with [Claude Code](https://claude.com/claude-code)