### PR TITLE
chore(dev): make pre-commit secret hook resilient + self-updating

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,23 +14,54 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    # Install/refresh the trivy secret-scan pre-commit hook. This mirrors the
-    # canonical CI boundary (.github/workflows/trivy.yml) so local and CI agree
-    # on exactly what counts as a leak. Refreshes the old gitleaks hook if found.
+    # Install/refresh the Trivy secret-scan pre-commit hook. Mirrors the
+    # canonical CI boundary (.github/workflows/trivy.yml) so local and CI
+    # agree on exactly what counts as a leak. The generated hook carries a
+    # version marker on line 2: when you change the hook body, bump BOTH
+    # SECRET_HOOK_VERSION below AND the "# nixos-config secret-hook v<N>"
+    # line inside the heredoc (keep them equal) so every clone re-converges
+    # on the new body — including clones that already carry an older,
+    # marker-less Trivy hook (the previous "grep -q gitleaks" guard froze
+    # those forever). A legacy hook that actually runs gitleaks (pre-#442) is
+    # refreshed too, matched outside comments so a prose mention can't trip it.
     if [ -d .git ]; then
-      if [ ! -f .git/hooks/pre-commit ] || grep -q gitleaks .git/hooks/pre-commit 2>/dev/null; then
-        mkdir -p .git/hooks
-        cat > .git/hooks/pre-commit << 'HOOK'
-    #!/usr/bin/env bash
-    # Secret scan — mirrors the CI boundary (trivy.yml): same engine, same
-    # allowlist (trivy-secret.yaml). Scans the whole tree (not just staged
-    # files) so local results match CI exactly; fast enough on this config
-    # repo. Note: a secret-like pattern in an UNSTAGED file will also block
-    # the commit — if it is a known non-secret, add it to trivy-secret.yaml.
-    trivy fs --scanners secret --secret-config trivy-secret.yaml --exit-code 1 --no-progress --quiet .
-    HOOK
-        chmod +x .git/hooks/pre-commit
+      SECRET_HOOK_VERSION=2
+      _hook=.git/hooks/pre-commit
+      _marker="# nixos-config secret-hook v$SECRET_HOOK_VERSION"
+      _refresh=1
+      if [ -f "$_hook" ]; then
+        if grep -qxF "$_marker" "$_hook" 2>/dev/null; then _refresh=0; fi
+        if grep -qE '^[^#]*\bgitleaks\b' "$_hook" 2>/dev/null; then _refresh=1; fi
       fi
+      if [ "$_refresh" = 1 ]; then
+        mkdir -p .git/hooks
+        cat > "$_hook" << 'HOOK'
+    #!/usr/bin/env bash
+    # nixos-config secret-hook v2
+    # Secret scan — mirrors the CI boundary (.github/workflows/trivy.yml): same
+    # engine, same allowlist (trivy-secret.yaml). Scans the whole tree by
+    # absolute path ($PWD) so the scan and config resolve even while trivy is
+    # being realised on first use. trivy comes from PATH (present in the
+    # nix-shell, see shell.nix) and otherwise from an ephemeral
+    # `nix shell nixpkgs#trivy`, so a commit never fails with "command not
+    # found" outside the dev shell. Silent on a clean tree; prints Trivy's
+    # report only when it blocks a commit. To allowlist a known non-secret,
+    # add a rule to trivy-secret.yaml.
+    set -uo pipefail
+    args=(fs --scanners secret --secret-config "$PWD/trivy-secret.yaml" --exit-code 1 --no-progress "$PWD")
+    if command -v trivy >/dev/null 2>&1; then
+      out=$(trivy "''${args[@]}" 2>&1); rc=$?
+    else
+      out=$(nix shell nixpkgs#trivy -c trivy "''${args[@]}" 2>&1); rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+      printf '%s\n' "$out" >&2
+    fi
+    exit "$rc"
+    HOOK
+        chmod +x "$_hook"
+      fi
+      unset SECRET_HOOK_VERSION _hook _marker _refresh
     fi
   '';
 }


### PR DESCRIPTION
## What

Rewrites the `shellHook` in `shell.nix` that installs the Trivy secret-scan pre-commit hook. The hook lives in `.git/hooks/` (never tracked), so the only durable, shareable source is the `shellHook` that generates it — this makes that source produce a **resilient, self-updating** hook.

## Why

Two real bugs in the current generator, plus a divergence from the better hook some clones already run:

1. **Frozen clones.** The guard `[ ! -f hook ] || grep -q gitleaks hook` only refreshes when the hook is missing or mentions `gitleaks`. A clone that already has a non-gitleaks Trivy hook is **never updated** — future improvements to flags/allowlist/body never reach it.
2. **False-positive clobber.** `grep -q gitleaks` matches the word in a *comment*. A good hook whose comment says "Replaces the pre-#442 gitleaks hook" gets treated as legacy and **overwritten with the worse bare one-liner** on the next `nix-shell` entry.
3. **"command not found" outside the dev shell.** `trivy` is only in `shell.nix` `buildInputs`; committing outside the dev shell ran `trivy …` with nothing on PATH → exit 127, blocking the commit.

## Change

**Hook body**
- Resolve trivy from PATH (inside the dev shell) **else** an ephemeral `nix shell nixpkgs#trivy` — a commit never dies with "command not found".
- Scan by absolute `$PWD` (scan dir + `--secret-config`) so paths resolve even while trivy is realised on first use.
- **Silent on a clean tree**; prints Trivy's report only when it blocks (the old one-liner printed a summary box on *every* commit).
- Same engine/flags/allowlist as the CI boundary (`.github/workflows/trivy.yml` + `trivy-secret.yaml`).

**Refresh logic — version marker**
- The generated hook carries `# nixos-config secret-hook v2` on line 2.
- Refresh unless that exact marker line is present (`grep -qxF`); **always** refresh a hook that actually *runs* gitleaks (matched outside comments, `^[^#]*\bgitleaks\b`).
- Bump `SECRET_HOOK_VERSION` **and** the marker line together when the body changes → every clone re-converges.

## Verification (trivy 0.66.0; trivy off PATH, so the `nix shell` fallback was exercised)

- `nix fmt -- --check .` → exit 0 (CI format gate)
- `nix eval -f shell.nix shellHook` → clean (the `''${args[@]}` antiquotation evaluates)
- Generated hook: shebang at **byte 0** (`23 21`), marker on line 2
- Clone states **no-hook / legacy-gitleaks / frozen-marker-less-trivy** → all converge to v2; **idempotent** on re-run
- Good v2 hook + prose "gitleaks" comment → **not clobbered**
- Clean tree → exit 0 **and silent**; RSA private key in `prod-credentials.conf` → exit 1 + **real `git commit` blocked** (0 commits); identical key in `*.age` → **allowlisted**, exit 0

## Notes / known limitations
- The `[ -d .git ]` guard (unchanged) skips linked **worktrees** (where `.git` is a file) — pre-existing; CI still enforces the boundary. Could later use `git rev-parse --git-path hooks`.
- First commit on a fresh machine *outside* the dev shell fetches the trivy closure (~40 MiB) once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)