### PR TITLE
fix(home-assistant): patch python-roborock to use working v1 login (Roborock v4 1002 workaround)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -341,6 +341,31 @@ in
     extraComponents = [ "roborock" ];
   };
 
+  # python-roborock v4 login workaround. Roborock's v4 auth endpoint
+  # (/api/v4/auth/email/login/code) returns "parameter error" (code 1002) for
+  # some accounts/regions — confirmed for this account: every country/countryCode
+  # /majorVersion variant fails, while the legacy v1 endpoints
+  # (/api/v1/sendEmailCode + /api/v1/loginWithCode) succeed end-to-end. HA's
+  # roborock config flow hard-codes request_code_v4 / code_login_v4, so it can
+  # never finish setup (and would also break later on token-reauth). The library
+  # already delegates to its working v1 methods when country/country_code are
+  # unset, so we force that fallback branch unconditionally.
+  services.home-assistant.package = pkgs.home-assistant.override {
+    packageOverrides = _self: super: {
+      python-roborock = super.python-roborock.overridePythonAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace roborock/web_api.py \
+            --replace-fail \
+              'if await self.country_code is None or await self.country is None:' \
+              'if True:  # nixos: v4 endpoint 1002s for some regions; force v1 request_code' \
+            --replace-fail \
+              'if country_code is None or country is None:' \
+              'if True:  # nixos: force v1 code_login (v4 broken)'
+        '';
+      });
+    };
+  };
+
   # Explicit external/internal URLs so HA doesn't auto-detect behind the
   # Tailscale Serve reverse proxy — auto-detection sees http://127.0.0.1:8123
   # which breaks mobile app OAuth redirects (intermittent 400 on /auth/authorize).


### PR DESCRIPTION
## Problem

After #483 enabled the `roborock` integration, the config flow could **not** complete — it failed at the verification-code step. Investigation (driving the config-flow REST API + the `python-roborock` library directly) found:

- Roborock's **v4** auth endpoint `/api/v4/auth/email/login/code` returns **`1002 parameter error`** for this account/region — confirmed across *every* `country` / `countryCode` (str & int) / `majorVersion` (14 & 15) variant, even with a dummy code (so it rejects on a parameter, never reaching code validation).
- The legacy **v1** endpoints (`/api/v1/sendEmailCode` + `/api/v1/loginWithCode`) **work end-to-end** — verified with a real code (`V1_LOGIN_OK`, valid UserData returned).

HA's roborock config flow hard-codes `request_code_v4` / `code_login_v4`, so it can never finish setup — and would also break later on token **reauth**, which uses the same v4 calls.

## Fix

`python-roborock` already falls back to its v1 methods (`request_code` / `code_login`) when `country`/`country_code` are unset. This overrides the HA package's `python-roborock` (via `home-assistant.override { packageOverrides = … }`) to force that fallback branch unconditionally — two `substituteInPlace` one-liners on `web_api.py`. Fully documented inline in `hosts/rpi5-full/configuration.nix`.

## Verification

- [x] `rpi5-full` toplevel builds with the patch applied (no OOM)
- [x] Patch present in the built `python-roborock` closure (`web_api.py` lines 237 & 310 → `if True:`)
- [x] **Patched `code_login_v4("000000")` now raises `RoborockInvalidCode`** (reaches v1 validation) instead of the v4 `1002` error — proves a real code will succeed
- [ ] Post-deploy: complete HA config flow → `vacuum.*` entity appears (final closing check)

## Scope

Touches only `hosts/rpi5-full/configuration.nix`. No effect on x86_64 hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)