### PR TITLE
feat(sancta-choir): Claude Code stack for herdr user + codex CLI

### DIFF
--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -50,8 +50,16 @@
   customModules.dev-tools.enable = true;
   customModules.claudeShared = {
     enable = true;
-    users = [ "root" ];
+    # `herdr` is included so the dedicated herdr user (which runs the herdr
+    # server + agent panes) gets the full Claude Code stack — claude CLI, skills,
+    # agents, commands — under /var/lib/herdr/.claude, not just root.
+    users = [ "root" "herdr" ];
   };
+
+  # OpenAI Codex CLI (github.com/openai/codex) — a second terminal coding agent
+  # alongside Claude Code, available to all users (incl. herdr panes) on this
+  # agent-runtime host.
+  environment.systemPackages = [ pkgs.codex ];
 
   # herdr — always-on terminal workspace server for AI coding agents. The server
   # lives here so long-running sessions survive the Mac sleeping; it runs as a

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -56,10 +56,15 @@
     users = [ "root" "herdr" ];
   };
 
-  # OpenAI Codex CLI (github.com/openai/codex) — a second terminal coding agent
-  # alongside Claude Code, available to all users (incl. herdr panes) on this
-  # agent-runtime host.
-  environment.systemPackages = [ pkgs.codex ];
+  # Agent tooling on the system PATH so herdr panes (which inherit the
+  # herdr-server unit's PATH, not a login shell's) can find + launch them:
+  # OpenAI Codex CLI (github.com/openai/codex) as a second coding agent
+  # alongside Claude Code, plus git + curl that the agents and herdr need.
+  environment.systemPackages = [
+    pkgs.codex
+    pkgs.git
+    pkgs.curl
+  ];
 
   # herdr — always-on terminal workspace server for AI coding agents. The server
   # lives here so long-running sessions survive the Mac sleeping; it runs as a

--- a/modules/services/herdr.nix
+++ b/modules/services/herdr.nix
@@ -174,7 +174,15 @@ in
       # that an interface has a routable IP / DNS. Match every other networked
       # service in this repo (qdrant, n8n, openclaw, gatus, ...) that waits on
       # network-online.target; otherwise those boot-time fetches race the network.
-      after = [ "network-online.target" ];
+      # Also order after the herdr user's home-manager activation: it writes
+      # ~/.claude/settings.json, and the ExecStartPost below wires the claude
+      # agent-state hook INTO that file — if the server (and its ExecStartPost)
+      # started before HM finished, HM clobbers the hook (the deploy-time race we
+      # hit). Ordering after HM makes ExecStartPost the last writer, every time.
+      after = [
+        "network-online.target"
+        "home-manager-herdr.service"
+      ];
       wants = [ "network-online.target" ];
       # herdr panes + integration hooks/launching inherit THIS unit's environment
       # (they are children of the long-lived server, NOT login shells), so the

--- a/modules/services/herdr.nix
+++ b/modules/services/herdr.nix
@@ -176,10 +176,19 @@ in
       # network-online.target; otherwise those boot-time fetches race the network.
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      # curl must be on the unit's PATH or the manifest refresh / update check
-      # fail at startup; agent detection is herdr's headline feature on this host.
-      path = [ pkgs.curl ];
-      environment.HOME = "/var/lib/herdr";
+      # herdr panes + integration hooks/launching inherit THIS unit's environment
+      # (they are children of the long-lived server, NOT login shells), so the
+      # agent binaries must be on this PATH or `herdr` finds no integrations and
+      # can't launch them — and curl must be here for the agent-state manifest
+      # refresh. Set explicitly (not via `path = [...]`) because claude lives in
+      # the per-user profile dir, not a single package output:
+      #   /etc/profiles/per-user/herdr/bin : claude (+ skills/agents, claudeShared)
+      #   /run/current-system/sw/bin        : codex, git, curl, coreutils, ...
+      #   /run/wrappers/bin                 : sudo (for herdr-deploy)
+      environment = {
+        HOME = "/var/lib/herdr";
+        PATH = lib.mkForce "/etc/profiles/per-user/herdr/bin:/run/current-system/sw/bin:/run/wrappers/bin";
+      };
       # Latch to `failed` after 5 crashes in 60s rather than looping forever at
       # RestartSec=5 (which, against systemd's default 10s window, would never
       # trip the burst cap) — a persistent crash becomes observable, not silent.
@@ -191,6 +200,15 @@ in
         Group = "herdr";
         WorkingDirectory = "/var/lib/herdr";
         ExecStart = "${lib.getExe herdr} server";
+        # Register the claude + codex integrations: writes agent-state hooks into
+        # ~/.claude and ~/.codex so herdr detects/launches them. Idempotent and
+        # re-run on every start, so it self-heals if a home-manager activation
+        # rewrites ~/.claude. Without this, an attached herdr shows NO integrations
+        # even though the agents are installed.
+        ExecStartPost = "${pkgs.writeShellScript "herdr-install-integrations" ''
+          ${lib.getExe herdr} integration install claude || true
+          ${lib.getExe herdr} integration install codex || true
+        ''}";
         Restart = "on-failure";
         RestartSec = 5;
       };


### PR DESCRIPTION
## Summary

Completes the herdr agent-host setup surfaced after the security redesign (#499/#503):

1. **Claude Code for the `herdr` user** — herdr-server runs agent panes as the dedicated unprivileged `herdr` user, but `claudeShared` was wired for `root` only, so `/var/lib/herdr/.claude` didn't exist and panes lacked the claude CLI + skills/agents/commands. Add `herdr` to `customModules.claudeShared.users = [ "root" "herdr" ]`.
2. **OpenAI Codex CLI** — install `pkgs.codex` (github.com/openai/codex) system-wide as a second terminal coding agent available in herdr panes.

## Verification
Eval-tier: `claudeShared.users = [root herdr]`; `codex` in `systemPackages`; sancta-choir toplevel instantiates (HM-for-herdr valid); `nixpkgs-fmt --check` clean. Runtime verify (claude + codex available to `runuser -u herdr`) on deploy.

Context: the box was just recovered from a (mis-diagnosed, transient) tailscale-reconnect scare on the first reboot after ~2 months uptime — it's healthy on current config now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)