### PR TITLE
feat(sancta-choir): install ralphex (activate ralphex + brainstorming skills)

### DIFF
--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -64,6 +64,11 @@
     pkgs.codex
     pkgs.git
     pkgs.curl
+    # ralphex — multi-step Claude Code plan orchestrator (umputun/ralphex,
+    # packaged in pkgs/ralphex.nix). Activates the `ralphex` + `brainstorming`
+    # claude-shared skills on this host (the latter hands off to `ralphex`).
+    # Mirrors rpi5-full; sancta-choir is the always-on agent host.
+    self.packages.${pkgs.system}.ralphex
   ];
 
   # home-manager rewrites herdr's ~/.claude/settings.json on EVERY activation,


### PR DESCRIPTION
Adds `self.packages.${pkgs.system}.ralphex` to sancta-choir (mirroring rpi5-full). ralphex wasn't on the box, leaving the `ralphex` + `brainstorming` claude-shared skills dormant. Completes the agent toolchain (claude + codex + ralphex) on the always-on agent host. Verified: eval clean, toplevel instantiates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)