### PR TITLE
fix(roborock): skip stale upstream MQTT test test_set_value (unblocks rpi5-full build)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -369,6 +369,13 @@ in
               'if country_code is None or country is None:' \
               'if True:  # nixos: force v1 code_login (v4 broken)'
         '';
+        # Skip the stale upstream MQTT-setup test. test_set_value asserts a hardcoded
+        # received-message count (==2), but python-roborock 3.8.0's
+        # connected_a01_mqtt_client fixture now emits 3 setup messages — the upstream
+        # test is out of sync with upstream's own MQTT setup. It is NOT our v1 web_api
+        # patch (a different subsystem) and NOT a runtime fault (vacuum.saros_10 + the
+        # roborock entities work end-to-end). The other 238 tests still run.
+        disabledTests = (old.disabledTests or [ ]) ++ [ "test_set_value" ];
       });
     };
   };


### PR DESCRIPTION
## fix(roborock): skip stale upstream MQTT test `test_set_value`

`python-roborock` 3.8.0's `tests/test_a01_api.py::test_set_value` asserts a hardcoded MQTT-setup message count (`received_requests.qsize() == 2`), but 3.8.0's `connected_a01_mqtt_client` fixture now emits **3** setup messages — the upstream test is out of sync with upstream's own MQTT setup.

- **Not** our v1 `web_api` login patch (different subsystem — that's login; this is the MQTT client).
- **Not** a runtime fault — `vacuum.saros_10` + 37 roborock entities work end-to-end on the deployed host.
- **Latent breakage:** CI only *evaluates* `rpi5-full` on aarch64 (never builds it), so this failing package test slipped past green CI. It surfaced when building the host to deploy the shared-memory commons (#508).

Surgically disables just `test_set_value` via the existing override; the other 238 tests still run.

⏳ Verifying locally with `nixos-rebuild build --flake .#rpi5-full` (CI can't build aarch64) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)