### PR TITLE
fix(backup): repair backup-failure-alert unit (unloadable -> silent failures)

### DIFF
--- a/modules/services/backup-pull.nix
+++ b/modules/services/backup-pull.nix
@@ -243,12 +243,18 @@ in
                 ''
               else
                 "";
+            # A multi-line `bash -c '…'` with embedded "…" + the %i specifier can't be
+            # parsed by systemd's ExecStart quoting (unbalanced-quoting → the unit fails
+            # to load → backup-failure alerts silently never fired). Put the body in a
+            # script file and pass the instance via %i → $1; no inline quoting for
+            # systemd to misparse.
+            alertScript = pkgs.writeShellScript "backup-failure-alert" ''
+              msg="❌ BACKUP FAILURE: $1 failed at $(date -Iseconds) on $(hostname)"
+              echo "$msg" | ${pkgs.systemd}/bin/systemd-cat -t backup-alert -p err
+              ${telegramCmd}
+            '';
           in
-          "${pkgs.bash}/bin/bash -c ${lib.escapeShellArg ''
-            msg="❌ BACKUP FAILURE: %i failed at $(date -Iseconds) on $(hostname)"
-            echo "$msg" | ${pkgs.systemd}/bin/systemd-cat -t backup-alert -p err
-            ${telegramCmd}
-          ''}";
+          "${alertScript} %i";
         EnvironmentFile = lib.mkIf (cfg.telegramEnvFile != null) cfg.telegramEnvFile;
       };
     };


### PR DESCRIPTION
## fix(backup): repair `backup-failure-alert@` — it was unloadable, so failures were silent

`backup-failure-alert@.service` inlined a multi-line `bash -c '…'` with embedded `"…"` and the `%i` specifier. systemd's ExecStart quoting can't parse it:

```
backup-failure-alert@.service:9: Unbalanced quoting … → bad unit file setting → unit will not be started
```

So the `OnFailure=backup-failure-alert@…` hook **never fired**. With the (separate) backup failures, `restic-backups-46-225-168-24` has failed **6+ times with zero alerts** — doubly invisible.

**Fix:** move the alert body into a `pkgs.writeShellScript`; pass the instance via `%i → $1`. systemd runs a clean script path. Restores `systemd-cat` logging + Telegram (when `telegramEnvFile` set).

**Verified:** `nix eval … backup-failure-alert@.serviceConfig.ExecStart` → clean `/nix/store/…-backup-failure-alert %i`.

**Out of scope (separate, remote/infra):** the backup itself failing — `rsync` code 12, SSH auth to `46.225.168.24` (sancta-claw, likely rebuilt in DR → `backup-pull` access not restored). `knownHostsEntry` is unset (`accept-new`), so not a host-key pin. Needs prod access; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)