### PR TITLE
chore: bump claude-code and claude-shared flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781026565,
-        "narHash": "sha256-sL9ZxUqeNFK2TXg0o0swSeJz0KlgkpLiyPSOq+Durug=",
+        "lastModified": 1782844284,
+        "narHash": "sha256-4UsRYeG9s2lsXz3Ggg0++dcd+6mF+U6mBW8gKfP0Xf0=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "4b0229ec9e37c594156b492653eada8413446f09",
+        "rev": "a9611e3182acc6e06a35d00e51d8f3a20fa1ffc5",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781469882,
-        "narHash": "sha256-uLdfmsAYDIlsOTjjUo8qaOdTbiHvj+m0Sls3uJi/ZdA=",
+        "lastModified": 1782080166,
+        "narHash": "sha256-1ilas1xF22+GqHYsUSxl9BQjBtEf99yLJE+h+i8ScR0=",
         "owner": "alexandru-savinov",
         "repo": "claude-shared",
-        "rev": "c15b9bccc47969a5647de832c57c7ff19a288fbd",
+        "rev": "a517f4ebca606edd9da6268ed96f54c3a9064f6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bundles two backlog items judged safe to bundle (same host = rpi5, both low/med risk, both a pure flake-input bump):

- `claude-code-nix-upgrade`: bump `claude-code` input (github:sadjow/claude-code-nix)
  - `4b0229ec9e37c594156b492653eada8413446f09` -> `a9611e3182acc6e06a35d00e51d8f3a20fa1ffc5`
  - installed CLI 2.1.170 -> latest upstream ~2.1.197
- `yourself-activation`: bump `claude-shared` input
  - `c15b9bccc47969a5647de832c57c7ff19a288fbd` -> `a517f4ebca606edd9da6268ed96f54c3a9064f6e`
  - picks up the already-merged `/yourself` skill (claude-shared PR #2, on `main`)

## Verification
- `nix eval .#nixosConfigurations --apply builtins.attrNames` -> `[ "hermes-claw" "rpi5" "rpi5-full" "sancta-choir" "sancta-claw" "zero-kuzea" ]`
- `nix eval .#nixosConfigurations.rpi5.config.system.build.toplevel.drvPath` evaluated successfully (only a source copy, no build)
- `flake.lock` confirmed valid JSON, only 6 lines changed for each of the two inputs

## Deliberately NOT done here
No `nixos-rebuild switch/boot/test` was run. That rebuild on rpi5 is Alexandru's action to run later, after review.

## Test plan
- [ ] Alexandru reviews the two rev bumps
- [ ] Alexandru runs `nixos-rebuild switch --flake .#rpi5` (or the relevant rpi5 host) when ready
- [ ] Confirm claude-code CLI version bumped and `/yourself` skill is active