### PR TITLE
feat(sancta): heartbeat tick auth via CLAUDE_CODE_OAUTH_TOKEN (setup-token)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -68,10 +68,14 @@ in
 
   # Sancta sandboxed decoupled heartbeat — ~30-min cognitive tick that
   # survives session death/reboots. Dedicated sancta-tick user + full systemd
-  # sandbox; self-suppresses ("no-auth") until the one-time
-  #   sudo -u sancta-tick env CLAUDE_CONFIG_DIR=/var/lib/sancta-tick/config claude login
+  # sandbox; self-suppresses ("no-auth") until the OAuth token file below is
+  # placed by hand (off-git, off-store, chmod 600):
+  #   claude setup-token   # mint a long-lived token where already logged in
+  #   sudo install -m600 /dev/stdin /var/lib/sancta-tick/oauth-token  # paste, Ctrl-D
+  #   sudo nixos-rebuild switch --flake .#rpi5-full
   # See modules/services/sancta-heartbeat-tick.nix for the architecture.
   services.sancta-heartbeat-tick.enable = true;
+  services.sancta-heartbeat-tick.oauthTokenFile = "/var/lib/sancta-tick/oauth-token";
 
   # Fleet shared-memory commons — localhost-bound first deploy.
   # Cross-host access over Tailscale is a deliberate follow-up (bind the

--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -230,7 +230,19 @@ let
         export CLAUDE_CONFIG_DIR="$STATE/config"
         export HOME="$STATE"
         export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-        export CLAUDE_CODE_OAUTH_TOKEN="$(${cu}/cat "$OAUTH_TOKEN_CRED")"
+        # Read the token from the LoadCredential tmpfs into the env ONLY (never
+        # logged, never written to disk). The -s gate in §3 already proved the
+        # file is non-empty; guard the read anyway so a transient read failure or
+        # an all-whitespace file self-suppresses ("no-auth") cleanly instead of
+        # exporting an empty/garbage token and hitting a guaranteed auth error.
+        # $() strips the trailing newline `setup-token` / a stray Enter may add.
+        OAUTH_TOKEN_VALUE="$(${cu}/cat "$OAUTH_TOKEN_CRED" 2>/dev/null || true)"
+        if [ -z "''${OAUTH_TOKEN_VALUE//[[:space:]]/}" ]; then
+          echo "OAuth token credential unreadable/blank — self-suppressing (reason: no-auth)"
+          write_last_tick false "no-auth"
+          exit 0
+        fi
+        export CLAUDE_CODE_OAUTH_TOKEN="$OAUTH_TOKEN_VALUE"
 
         RAW="$STAGING/raw-output.json"
         RC=0
@@ -778,12 +790,28 @@ in
         # or the nix store. The tick reads it into CLAUDE_CODE_OAUTH_TOKEN.
         # When oauthTokenFile is null this key is absent → no credential → the
         # tick self-suppresses ("no-auth").
+        #
+        # LoadCredential= is enforced by systemd BEFORE ExecStart: a MISSING
+        # source file fails the unit outright (the in-script self-suppress never
+        # runs), so the "safe to rebuild before the token exists" property is
+        # instead upheld by ConditionPathExists= in unitConfig below — an absent
+        # file skips the unit as success, no onFailure alert storm.
         LoadCredential = "oauth-token:${cfg.oauthTokenFile}";
       } // lib.optionalAttrs cfg.egressPinning.enable {
         # Residual (b): IP-level egress bound. See egressPinning option docs
         # for the honest brittleness note.
         IPAddressDeny = "any";
         IPAddressAllow = cfg.egressPinning.allowedAddresses;
+      };
+
+      # Keep the "safe to rebuild BEFORE the token file is placed" guarantee even
+      # with oauthTokenFile set: if the file is absent, ConditionPathExists=
+      # makes systemd SKIP the unit (recorded as a success — no onFailure, so no
+      # alert storm), rather than LoadCredential= failing the unit every tick.
+      # Once the file exists the condition passes and LoadCredential delivers it.
+      # (unitConfig → [Unit] section; conditions do NOT belong in serviceConfig.)
+      unitConfig = lib.mkIf (cfg.oauthTokenFile != null) {
+        ConditionPathExists = cfg.oauthTokenFile;
       };
     };
 

--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -37,10 +37,28 @@
 # helper units owned by the index owner (nixos) bridge the two worlds and
 # re-validate everything at the trust boundary.
 #
-# Post-merge, one-time (Alexandru's hand):
-#   sudo -u sancta-tick env CLAUDE_CONFIG_DIR=/var/lib/sancta-tick/config claude login
-# Until then the tick self-suppresses (last-tick reason "no-auth") — merging
-# and rebuilding BEFORE the login is safe.
+# Authentication — long-lived OAuth token (headless-correct):
+#   The tick authenticates via CLAUDE_CODE_OAUTH_TOKEN, the token minted by
+#   `claude setup-token` (a one-year OAuth token for a Claude subscription —
+#   https://code.claude.com/docs/en/authentication#generate-a-long-lived-token).
+#   This is the correct headless-service mechanism: it survives OAuth reauth
+#   better than an interactive-login .credentials.json and needs no browser.
+#
+#   The token is delivered to the unit via systemd LoadCredential=, which copies
+#   the file (services.sancta-heartbeat-tick.oauthTokenFile) into the unit's
+#   private $CREDENTIALS_DIRECTORY tmpfs — readable only by this service, never
+#   world-readable, and never in the nix store. The token FILE itself is placed
+#   by Alexandru's hand (chmod 600), NOT via git and NOT via chat; the module
+#   only ever references its PATH.
+#
+# Post-merge, one-time (Alexandru's hand) — replaces the old `claude login`:
+#   1. Mint a token (on any machine where he is logged in):  claude setup-token
+#   2. Place it on the host, owner-only, off-git, off-store:
+#        sudo install -m600 /dev/stdin /var/lib/sancta-tick/oauth-token
+#        <paste the token, then Ctrl-D>
+#   3. sudo nixos-rebuild switch --flake .#rpi5-full
+# Until the token file exists the tick self-suppresses (last-tick reason
+# "no-auth") — merging and rebuilding BEFORE the file is placed is safe.
 
 { config, pkgs, lib, claude-code ? null, ... }:
 
@@ -138,10 +156,10 @@ let
         # no owner to prune them, so on a long-lived deployment they grow
         # unbounded. Clear them at the START of every tick. This is bounded and
         # reversible: it deletes only these known cache/state dot-dirs and never
-        # touches the credentialed config dir, the inbox/staging/tripwire
-        # exchange dirs, the cap counters, or last-tick.json. CLAUDE_CONFIG_DIR
-        # points at "$STATE/config" (NOT "$STATE/.claude"), so credentials
-        # survive.
+        # touches the isolated config dir, the inbox/staging/tripwire exchange
+        # dirs, the cap counters, or last-tick.json. Auth is supplied via the
+        # CLAUDE_CODE_OAUTH_TOKEN env (from the LoadCredential tmpfs), so it is
+        # unaffected by clearing these caches.
         for d in "$STATE/.cache" "$STATE/.config" "$STATE/.claude" \
                  "$STATE/.npm" "$STATE/.local" "$STATE/.anthropic"; do
           ${cu}/rm -rf "$d"
@@ -179,10 +197,16 @@ let
           exit 0
         fi
 
-        # ── 3. Not-logged-in self-suppression: safe to merge+rebuild BEFORE the
-        # one-time `claude login` into this config dir has happened.
-        if [ ! -s "$STATE/config/.credentials.json" ]; then
-          echo "no credentials in $STATE/config — self-suppressing (reason: no-auth)"
+        # ── 3. No-auth self-suppression: safe to merge+rebuild BEFORE the
+        # one-time OAuth token file (services.sancta-heartbeat-tick.oauthTokenFile)
+        # has been placed by hand. systemd delivers that file via LoadCredential=
+        # into $CREDENTIALS_DIRECTORY/oauth-token (a private per-unit tmpfs). If
+        # oauthTokenFile is unset the credential is absent; if the file is empty
+        # the credential is empty — either way we self-suppress. The token value
+        # is NEVER echoed.
+        OAUTH_TOKEN_CRED="''${CREDENTIALS_DIRECTORY:-}/oauth-token"
+        if [ ! -s "$OAUTH_TOKEN_CRED" ]; then
+          echo "no OAuth token credential present — self-suppressing (reason: no-auth)"
           write_last_tick false "no-auth"
           exit 0
         fi
@@ -190,8 +214,15 @@ let
         echo $((COUNT + 1)) > "$CAPFILE"
 
         # ── 4. The claude call. Verified seam (design doc §3, RESOLVED):
-        #   * CLAUDE_CONFIG_DIR fully relocates config AND credentials — the real
-        #     ~/.claude is never consulted (ProtectHome=true stays ON).
+        #   * Auth comes from CLAUDE_CODE_OAUTH_TOKEN (the `claude setup-token`
+        #     long-lived token), read from the LoadCredential tmpfs into the env
+        #     ONLY — it is never logged or written to disk by this script. This
+        #     is the headless-correct mechanism (survives OAuth reauth; no
+        #     interactive login). NOTE: --bare would ignore this token; the tick
+        #     deliberately does NOT use --bare.
+        #   * CLAUDE_CONFIG_DIR still relocates config (isolated dot-dir + MCP
+        #     strip) — the real ~/.claude is never consulted (ProtectHome stays
+        #     ON). Auth no longer depends on a .credentials.json in that dir.
         #   * --strict-mcp-config strips ALL MCP tools, including account-level
         #     claude.ai connectors riding the OAuth account.
         #   * --disallowedTools cuts every write/exec/network built-in; the tick
@@ -199,6 +230,7 @@ let
         export CLAUDE_CONFIG_DIR="$STATE/config"
         export HOME="$STATE"
         export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+        export CLAUDE_CODE_OAUTH_TOKEN="$(${cu}/cat "$OAUTH_TOKEN_CRED")"
 
         RAW="$STAGING/raw-output.json"
         RC=0
@@ -486,6 +518,26 @@ in
       '';
     };
 
+    oauthTokenFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/var/lib/sancta-tick/oauth-token";
+      description = ''
+        Path to a chmod-600 file containing ONLY the long-lived OAuth token
+        string minted by `claude setup-token` (no trailing structure — just the
+        token). Placed by hand, owner-only, NOT in git and NOT in the nix store.
+
+        When set, the file is delivered to the tick unit via systemd
+        {option}`LoadCredential` (copied into the unit's private
+        `$CREDENTIALS_DIRECTORY` tmpfs, readable only by the service) and
+        exported as `CLAUDE_CODE_OAUTH_TOKEN` for the headless `claude -p` call.
+
+        When null (the default), no credential is loaded and the tick
+        self-suppresses every run with last-tick reason "no-auth" — so merging
+        and rebuilding BEFORE the token file exists is safe.
+      '';
+    };
+
     interval = lib.mkOption {
       type = lib.types.str;
       default = "*:00/30";
@@ -615,11 +667,11 @@ in
       group = "sancta-tick";
       home = stateDir;
       description = "Sancta sandboxed heartbeat tick";
-      # nologin: this user is never meant to have an interactive session. The
-      # one-time `claude login` runs the binary DIRECTLY under sudo -u (`sudo -u
-      # sancta-tick env CLAUDE_CONFIG_DIR=… claude login`), which does not spawn
-      # the target user's login shell — so nologin does not break setup while
-      # removing an interactive login path if the account ever gained a key.
+      # nologin: this user is never meant to have an interactive session. With
+      # OAuth-token auth there is no `claude login` step at all — auth arrives as
+      # a file placed by hand + delivered via LoadCredential — so nothing ever
+      # needs to run under this account interactively. nologin closes the
+      # interactive-login path if the account ever gained a key.
       shell = "${pkgs.shadow}/bin/nologin";
     };
     users.groups.sancta-tick = { };
@@ -630,7 +682,8 @@ in
 
     systemd.tmpfiles.rules = [
       "d ${stateDir} 0750 sancta-tick sancta-tick -"
-      # OAuth credentials live here after the one-time login — owner-only.
+      # Isolated CLAUDE_CONFIG_DIR (config + MCP strip) — owner-only. Auth no
+      # longer lives here; it arrives via LoadCredential (CLAUDE_CODE_OAUTH_TOKEN).
       "d ${stateDir}/config 0700 sancta-tick sancta-tick -"
       # Exchange dirs: setgid so files stay group sancta-tick; group-writable
       # so the indexOwner helpers can write mirrors / clean up staging.
@@ -708,6 +761,14 @@ in
         MemoryMax = cfg.memoryMax;
         CPUQuota = cfg.cpuQuota;
         Nice = 10;
+      } // lib.optionalAttrs (cfg.oauthTokenFile != null) {
+        # Deliver the OAuth token securely: systemd copies the file into the
+        # unit's private $CREDENTIALS_DIRECTORY tmpfs (readable only by this
+        # service), never exposing the path contents to the sandbox filesystem
+        # or the nix store. The tick reads it into CLAUDE_CODE_OAUTH_TOKEN.
+        # When oauthTokenFile is null this key is absent → no credential → the
+        # tick self-suppresses ("no-auth").
+        LoadCredential = "oauth-token:${cfg.oauthTokenFile}";
       } // lib.optionalAttrs cfg.egressPinning.enable {
         # Residual (b): IP-level egress bound. See egressPinning option docs
         # for the honest brittleness note.

--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -519,7 +519,12 @@ in
     };
 
     oauthTokenFile = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
+      # str, NOT path: this is a RUNTIME path to a hand-placed file, so it must
+      # stay a plain string. lib.types.path would coerce a Nix path literal
+      # (e.g. ./token) into a world-readable /nix/store copy of the secret —
+      # exactly what we must avoid. String means the path is referenced, never
+      # the contents.
+      type = lib.types.nullOr lib.types.str;
       default = null;
       example = "/var/lib/sancta-tick/oauth-token";
       description = ''
@@ -531,6 +536,11 @@ in
         {option}`LoadCredential` (copied into the unit's private
         `$CREDENTIALS_DIRECTORY` tmpfs, readable only by the service) and
         exported as `CLAUDE_CODE_OAUTH_TOKEN` for the headless `claude -p` call.
+        Residual exposure: once exported, the token is in the tick process
+        environment (`/proc/<pid>/environ`, root-readable) for the lifetime of
+        that `claude -p` call — inherent to the CLI's documented env-var auth
+        (no fd-based alternative). The sandbox and the never-log/never-persist
+        handling keep this to the minimum.
 
         When null (the default), no credential is loaded and the tick
         self-suppresses every run with last-tick reason "no-auth" — so merging


### PR DESCRIPTION
## What

Switch `services.sancta-heartbeat-tick` from interactive-login
`.credentials.json` auth to a **long-lived OAuth token** minted by
`claude setup-token`, delivered to the unit via systemd `LoadCredential=`.

This is the design Alexandru chose: `setup-token` is the correct
headless-service auth mechanism (survives OAuth reauth better than an
interactive login, no browser), and it is what he already minted.

## Verified fact (env var name)

Per the official Claude Code auth docs
(<https://code.claude.com/docs/en/authentication#generate-a-long-lived-token>):

> The command walks you through OAuth authorization and prints a token to
> the terminal. It does not save the token anywhere; copy it and set it as
> the `CLAUDE_CODE_OAUTH_TOKEN` environment variable wherever you want to
> authenticate: `export CLAUDE_CODE_OAUTH_TOKEN=your-token`. This token
> authenticates with your Claude subscription and requires a Pro, Max,
> Team, or Enterprise plan.

And in the auth precedence list: "5. `CLAUDE_CODE_OAUTH_TOKEN` environment
variable. A long-lived OAuth token generated by `claude setup-token`."

The var is **`CLAUDE_CODE_OAUTH_TOKEN`**. Caveat noted in the docs and in
code: `--bare` mode ignores this token — the tick deliberately does **not**
use `--bare`, so it is unaffected.

## Changes

- **New option** `services.sancta-heartbeat-tick.oauthTokenFile`
  (`path | null`, default `null`): path to a chmod-600 file containing
  ONLY the token string, placed by hand — NOT in git, NOT in the store.
- **Secure delivery**: when set, added as
  `LoadCredential=oauth-token:${cfg.oauthTokenFile}` so systemd copies the
  file into the unit's private `$CREDENTIALS_DIRECTORY` tmpfs (readable
  only by the service). Omitted entirely when `oauthTokenFile == null`.
- **Auth gate rewritten**: read `$CREDENTIALS_DIRECTORY/oauth-token`; if
  absent/empty → `write_last_tick false "no-auth"` + `exit 0` (the
  safe-to-merge-and-rebuild-before-the-token-exists property is preserved
  exactly). If present → `export CLAUDE_CODE_OAUTH_TOKEN="$(cat …)"` before
  the `claude -p … --strict-mcp-config …` call. The token is never echoed
  or written to disk by the script.
- `CLAUDE_CONFIG_DIR` still points at `$STATE/config` (isolated config +
  MCP strip); auth no longer depends on a credentials file there.
- **All hardening unchanged**: sandbox, dedup, daily cap, staging/promote,
  tripwire, `--strict-mcp-config`, `--disallowedTools`.
- `hosts/rpi5-full`: `oauthTokenFile = "/var/lib/sancta-tick/oauth-token"`.

## Alexandru's one-time setup (replaces the old `claude login`)

```bash
# 1. mint a long-lived token where already logged in
claude setup-token
# 2. place it on the host: owner-only, off-git, off-store
sudo install -m600 /dev/stdin /var/lib/sancta-tick/oauth-token   # paste token, Ctrl-D
# 3. rebuild
sudo nixos-rebuild switch --flake .#rpi5-full
```

Until the file exists the tick self-suppresses ("no-auth") — merging and
rebuilding first is safe.

## Alternative considered (agenix)

The token could ride the existing agenix pattern
(`age.secrets.sancta-tick-oauth-token` → `LoadCredential=…:config.age.secrets.….path`).
Defaulted to the plain his-hand-file approach instead: it keeps the token
**entirely off-git** (agenix would commit the encrypted blob) and needs no
re-encrypt/recipient dance for a single per-host secret placed by hand.

## Verification

- `nix fmt -- .`: clean (0/63 reformatted).
- `nix eval .#nixosConfigurations.rpi5-full…toplevel.drvPath` and `.#rpi5`:
  both succeed.
- Rendered unit contains `LoadCredential=oauth-token:/var/lib/sancta-tick/oauth-token`.
- Generated tick script: `bash -n` OK; contains the
  `$CREDENTIALS_DIRECTORY/oauth-token` gate, the `no-auth` self-suppress,
  the `CLAUDE_CODE_OAUTH_TOKEN` export from the cred file, and
  `--strict-mcp-config`. The old `.credentials.json` check is gone.
- **Token-never-in-store proof**: `CLAUDE_CODE_OAUTH_TOKEN` appears in the
  built store output only in two comments + the single export line that
  `cat`s the credential path — there is no literal token value anywhere
  (the module only ever references a file PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)