### PR TITLE
fix(sancta): heartbeat tick — token charset gate + redacted stdout diagnostics

### DIFF
--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -267,6 +267,28 @@ let
           write_last_tick false "no-auth"
           exit 0
         fi
+        # Trim surrounding whitespace (stray spaces/newlines a hand-paste can add).
+        # Deliberately NOT stripping INTERIOR whitespace: that would "repair" a
+        # corrupt paste into a syntactically clean but wrong token — interior
+        # junk must fail the charset gate below instead.
+        OAUTH_TOKEN_VALUE="''${OAUTH_TOKEN_VALUE#"''${OAUTH_TOKEN_VALUE%%[![:space:]]*}"}"
+        OAUTH_TOKEN_VALUE="''${OAUTH_TOKEN_VALUE%"''${OAUTH_TOKEN_VALUE##*[![:space:]]}"}"
+        # Charset gate. A `claude setup-token` token (sk-ant-oat01-…) is plain
+        # ASCII from [A-Za-z0-9_-] only. A terminal paste of the token can
+        # capture TUI pane-border bytes (e.g. "│ │", U+2502 = e2 94 82)
+        # MID-token; the whitespace-only check above passes such a token, and
+        # the resulting corrupt Authorization header makes `claude -p` exit 1
+        # with an EMPTY stderr (with --output-format json the real error goes
+        # to stdout) — burning a daily-cap slot on a guaranteed failure every
+        # tick. Reject any byte outside the token alphabet BEFORE spending the
+        # invocation. LC_ALL=C keeps the bracket expression byte-safe (no
+        # locale-dependent ranges); the token value itself is never echoed.
+        if ${cu}/printf '%s' "$OAUTH_TOKEN_VALUE" \
+             | LC_ALL=C ${pkgs.gnugrep}/bin/grep -q '[^A-Za-z0-9_-]'; then
+          echo "OAuth token contains non-token characters — self-suppressing (reason: bad-token)"
+          write_last_tick false "bad-token"
+          exit 0
+        fi
         export CLAUDE_CODE_OAUTH_TOKEN="$OAUTH_TOKEN_VALUE"
 
         RAW="$STAGING/raw-output.json"
@@ -284,6 +306,21 @@ let
         if [ "$RC" -ne 0 ]; then
           echo "claude exited non-zero ($RC); stderr tail:" >&2
           ${cu}/tail -n 20 "$STAGING/stderr.log" >&2 || true
+          # With --output-format json the REAL error often lands on STDOUT
+          # inside the JSON envelope (.result / raw-output.json), leaving
+          # stderr EMPTY — the corrupt-token auth failure surfaced NOTHING in
+          # the journal this way. When stderr has nothing, also emit a
+          # REDACTED tail of the raw stdout: extract .result when the envelope
+          # parses (fall back to the raw bytes otherwise), scrub any
+          # token-shaped value FIRST so a token can never reach the journal,
+          # and byte-bound the tail. Makes the "error only on stdout" class
+          # visible on FIRST occurrence.
+          if [ ! -s "$STAGING/stderr.log" ] && [ -s "$RAW" ]; then
+            echo "stderr empty — redacted stdout tail:" >&2
+            { ${jqBin} -r '.result // .' "$RAW" 2>/dev/null || ${cu}/cat "$RAW"; } \
+              | ${gnused}/bin/sed 's/sk-ant-oat01-[A-Za-z0-9_-]*/sk-ant-oat01-<REDACTED>/g' \
+              | ${cu}/tail -c 2048 >&2 || true
+          fi
           write_last_tick false "claude-exit-$RC"
           # HANDLED failure — exit 0 (like the other handled-fail paths below:
           # output-too-large / bad-envelope / malformed-output). A non-zero


### PR DESCRIPTION
## Root cause (diagnosed, evidence in journal + staging on rpi5)

The operator-pasted token file `/var/lib/sancta-tick/oauth-token` contained **TUI pane-border bytes** (`│ │`, UTF-8 `e2 94 82`) mid-token, captured from a terminal paste. Three compounding gaps:

1. **Whitespace-only guard was insufficient** — the existing blank check happily passed a token with embedded non-token bytes.
2. **stderr-empty blindness** — with `--output-format json`, the real auth error goes to **stdout** (the JSON envelope / `staging/raw-output.json`); `claude -p` exits 1 with an *empty* stderr, so the journal's `stderr tail:` showed nothing and the failure class was invisible on first occurrence.
3. Each guaranteed-failure tick still **burned a daily-cap slot**.

## Changes (two, both inside the tick script)

1. **Token charset gate** — after the blank check: trim surrounding whitespace (interior whitespace is deliberately NOT stripped — that would "repair" a corrupt paste into a wrong-but-clean token), then reject any token containing bytes outside `[A-Za-z0-9_-]` (an `sk-ant-oat01` token is plain ASCII from that alphabet; `LC_ALL=C` keeps the match byte-safe). On rejection: journal line + `write_last_tick false "bad-token"` + `exit 0` — self-suppression *before* spending a cap slot, same pattern as `no-auth`/`capped`.

2. **Redacted stdout diagnostics on failure** — when claude exits non-zero *and* `stderr.log` is empty, also emit a REDACTED tail of the raw stdout: `.result` via jq (raw-bytes fallback if the envelope doesn't parse), scrubbed with `s/sk-ant-oat01-[A-Za-z0-9_-]*/sk-ant-oat01-<REDACTED>/g` *before* anything reaches the journal, byte-bounded to 2 KiB. The "error only on stdout" class is now visible the first time it happens.

No flag changes, no hardening changes, `--tools` whitelist untouched. The token value itself is never echoed on any path.

## Verification

- `nix fmt -- .` clean; `nix eval` of both `rpi5-full` and `rpi5` toplevel drvPaths succeeds.
- `bash -n` on the *built* generated script: OK.
- Gate simulated with the exact built gnugrep/gnused store paths: token with embedded `│` → REJECTED (bad-token); clean token-shaped string → PASSED; clean token with surrounding whitespace → PASSED after trim; token with interior space → REJECTED (not silently repaired). Redaction sed verified on a fake stdout error line, jq fallback verified on non-JSON stdout.

## Operational note — immediate unblock is independent of this PR

The live fix on rpi5 is simply **re-provisioning the token file by hand** (careful paste, e.g. `sudo install -m600 /dev/stdin /var/lib/sancta-tick/oauth-token` outside any TUI pane, then optionally `systemctl start sancta-heartbeat-tick` to verify). This PR only prevents the *next* corrupt paste from failing silently and burning cap slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)