### PR TITLE
fix(sancta-claw): rebuild OpenClaw ladder to all-ZDR-eligible rungs + paid anchor

### DIFF
--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -205,15 +205,21 @@ let
     # - Free-first: rungs 0-3 are all :free (zero cost), tried before any paid
     #   token is ever spent.
     # - 262K rungs first; the agent's working session can accumulate >131K
-    #   tokens, so smaller-context rungs hit "Context overflow" before they ever
-    #   serve a token and only add latency to the failover path.
+    #   tokens. Only two FREE ZDR-eligible rungs offer 262K context (rungs 0-1) —
+    #   no other free ZDR model on OpenRouter exceeds 131K — so rungs 2 (131K) and
+    #   3 (65K) are lower-context free options that a long session will
+    #   "Context overflow" past before they serve a token. That is intended: they
+    #   still catch SHORT sessions for free; long sessions fall straight through
+    #   to the 262K paid anchor.
     # - Coder-tuned primary because OpenClaw's main role is an "AI programming
     #   partner".
     # - Rung 4 is the PAID anchor: qwen/qwen3-coder-30b-a3b-instruct is the
     #   cheapest coder-tuned, tools-capable, 262K, ZDR-eligible model on
-    #   OpenRouter (~$0.07/M input, ~$0.27/M output). It exists so that when the
-    #   free tier is exhausted by 429 rate-limits the ladder still has a working
-    #   ZDR fallback instead of dead-ending. It reuses the same
+    #   OpenRouter (~$0.07/M input, ~$0.27/M output). It exists so the ladder
+    #   never dead-ends once the free tier is unavailable — whether from 429
+    #   rate-limits OR from a long session (>131K tokens) that context-overflows
+    #   every free rung. So it DOES fire on long sessions, not only on 429s;
+    #   cost is ~$0 only for short/light sessions. It reuses the same
     #   openrouter-api-key + ZDR proxy — no new provider/auth, ZDR preserved.
     LADDER = [
         {"id": "qwen/qwen3-coder:free",                 "name": "Qwen3 Coder (free, ZDR)",         "ctx": 262144},

--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -190,24 +190,37 @@ let
     # and agents.defaults.model.{primary,fallbacks}) so a future PR adding or
     # removing a rung touches one place.
     #
-    # Ordering rationale (observed empirically on sancta-claw — see #420 thread):
-    # - 262K rungs first; the agent's working session has accumulated >131K tokens,
-    #   so smaller-context rungs hit "Context overflow" before they ever serve a
-    #   token and only add latency to the failover path.
-    # - Providers are spread across Venice, SiliconFlow, Novita, Z.AI so an
-    #   outage on any single upstream doesn't drain the whole ladder. OpenRouter's
-    #   free tier caps each model at ~8 rpm, so 5 rungs ≈ 40 rpm of burst budget.
+    # ZDR CONSTRAINT — every rung MUST be present on the live OpenRouter ZDR
+    # allow-list (https://openrouter.ai/api/v1/endpoints/zdr, the same source
+    # the openclaw-zdr-proxy sidecar enforces). A rung that is NOT on that list
+    # is 403'd by the proxy ("zdr_blocked") and dead-ends the ladder. This list
+    # was rebuilt after 3 of the previous 5 rungs (tencent/hy3-preview:free,
+    # inclusionai/ling-2.6-1t:free, z-ai/glm-4.5-air:free) fell off the ZDR
+    # allow-list and 403'd, while the 2 survivors were left rate-limited (429)
+    # with no working fallback. To re-verify before editing:
+    #   curl -s https://openrouter.ai/api/v1/endpoints/zdr \
+    #     | jq -r '.data[].model_id' | sort -u | grep -F '<id>'
+    #
+    # Ordering rationale:
+    # - Free-first: rungs 0-3 are all :free (zero cost), tried before any paid
+    #   token is ever spent.
+    # - 262K rungs first; the agent's working session can accumulate >131K
+    #   tokens, so smaller-context rungs hit "Context overflow" before they ever
+    #   serve a token and only add latency to the failover path.
     # - Coder-tuned primary because OpenClaw's main role is an "AI programming
     #   partner".
-    # - GLM-Air is kept as the LAST rung (smaller 131K context) — only reachable
-    #   after every higher-context rung has been tried, so its context-overflow
-    #   failure mode is harmless on short sessions and never blocks a long one.
+    # - Rung 4 is the PAID anchor: qwen/qwen3-coder-30b-a3b-instruct is the
+    #   cheapest coder-tuned, tools-capable, 262K, ZDR-eligible model on
+    #   OpenRouter (~$0.07/M input, ~$0.27/M output). It exists so that when the
+    #   free tier is exhausted by 429 rate-limits the ladder still has a working
+    #   ZDR fallback instead of dead-ending. It reuses the same
+    #   openrouter-api-key + ZDR proxy — no new provider/auth, ZDR preserved.
     LADDER = [
-        {"id": "qwen/qwen3-coder:free",                 "name": "Qwen3 Coder (free, ZDR)",   "ctx": 262144},
-        {"id": "tencent/hy3-preview:free",              "name": "Hunyuan 3 Preview (free, ZDR)", "ctx": 262144},
-        {"id": "inclusionai/ling-2.6-1t:free",          "name": "Ling 2.6 1T (free, ZDR)",   "ctx": 262144},
-        {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "name": "Qwen3 Next 80B (free, ZDR)","ctx": 262144},
-        {"id": "z-ai/glm-4.5-air:free",                 "name": "GLM 4.5 Air (free, ZDR)",   "ctx": 131072},
+        {"id": "qwen/qwen3-coder:free",                 "name": "Qwen3 Coder (free, ZDR)",         "ctx": 262144},
+        {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "name": "Qwen3 Next 80B (free, ZDR)",       "ctx": 262144},
+        {"id": "nousresearch/hermes-3-llama-3.1-405b:free", "name": "Hermes 3 405B (free, ZDR)",   "ctx": 131072},
+        {"id": "meta-llama/llama-3.3-70b-instruct:free", "name": "Llama 3.3 70B (free, ZDR)",      "ctx": 65536},
+        {"id": "qwen/qwen3-coder-30b-a3b-instruct",     "name": "Qwen3 Coder 30B (paid anchor, ZDR)", "ctx": 262144},
     ]
 
     def _make_model_entry(rung):


### PR DESCRIPTION
## Diagnosis

OpenClaw on **sancta-claw** is alive-but-broken: its 5-model OpenRouter ladder dead-ends.

The ladder is declarative — generated by `openclawBrowserConfigBody` in `hosts/sancta-claw/openclaw-service.nix` (the `LADDER` list) and applied by an ExecStartPre. Every request is routed through the local **ZDR proxy** (`openclaw-zdr-proxy.service`, `127.0.0.1:5780`), which fetches the live OpenRouter ZDR allow-list from `https://openrouter.ai/api/v1/endpoints/zdr` and **403s ("zdr_blocked") any model not on it**.

Checking the previous 5 rungs against the live ZDR list (`curl … /endpoints/zdr | jq -r '.data[].model_id'`):

| Old rung | On live ZDR list? | Failure |
|---|---|---|
| `qwen/qwen3-coder:free` | ✅ ON | rate-limited (429) |
| `tencent/hy3-preview:free` | ❌ OFF | **403 zdr_blocked** |
| `inclusionai/ling-2.6-1t:free` | ❌ OFF | **403 zdr_blocked** |
| `qwen/qwen3-next-80b-a3b-instruct:free` | ✅ ON | rate-limited (429) |
| `z-ai/glm-4.5-air:free` | ❌ OFF | **403 zdr_blocked** |

**3 of 5 rungs are off the ZDR allow-list (403) and the 2 survivors are 429 rate-limited with no working fallback** → the ladder dead-ends. The outage is a ladder/allow-list mismatch, not "OpenRouter can't work."

## The new ladder — every rung ZDR-verified

Ordered free-first, 262K-context-first, coder-tuned primary, with one cheap **paid** ZDR anchor as the bottom rung.

| # | Model id | ctx | ZDR-eligibility evidence (live `/endpoints/zdr`) | Cost |
|---|---|---|---|---|
| 0 | `qwen/qwen3-coder:free` | 262K | ✅ `model_id` present (survivor) | free |
| 1 | `qwen/qwen3-next-80b-a3b-instruct:free` | 262K | ✅ `model_id` present (survivor) | free |
| 2 | `nousresearch/hermes-3-llama-3.1-405b:free` | 131K | ✅ `model_id` present | free |
| 3 | `meta-llama/llama-3.3-70b-instruct:free` | 65K | ✅ `model_id` present | free |
| 4 | `qwen/qwen3-coder-30b-a3b-instruct` | 262K | ✅ `model_id` present, 4 ZDR endpoints, `tools` supported | **paid anchor** |

**Anchor cost note:** rung 4 is the cheapest coder-tuned, tools-capable, 262K, ZDR-eligible model on OpenRouter — **~\$0.07/M input, ~\$0.27/M output**. It serves traffic whenever the free tier is unavailable — from 429 rate-limits **or** from a long session (>131K tokens) that context-overflows every free rung (only rungs 0-1 offer 262K; no other free ZDR model exceeds 131K). So the anchor **does** fire on long sessions, not only on 429s; cost is ~$0 only for short/light sessions. It reuses the **existing `openrouter-api-key` secret + the same ZDR proxy** — no new provider, no new auth, **ZDR preserved end-to-end**.

## Verification

- Config-injection body evaluates clean (module-eval path, IFD-free — `system.build.openclawBrowserConfigBody`); new ladder present, all 3 old offenders removed, proxy `baseUrl http://127.0.0.1:5780/v1` intact.
- `nix eval .#nixosConfigurations.sancta-claw.config.system.build.toplevel.drvPath` cannot complete **on the aarch64 rpi5** — it hits the `agent-browser` Rust `import-cargo-lock` IFD which requires an `x86_64-linux` builder (the known cross-arch constraint). This fails identically on unchanged `origin/main`, so it is not introduced by this change. **CI runs on x86_64 and does the full build.**

## Deploy step (for Alexandru's hand — do NOT auto-deploy)

Remote VPS deploys are non-atomic; throttle the build, then switch (per repo convention):

```bash
nixos-rebuild build  --flake .#sancta-claw --target-host root@sancta-claw --build-host root@sancta-claw --max-jobs 1 --cores 1 \
 && nixos-rebuild switch --flake .#sancta-claw --target-host root@sancta-claw --build-host root@sancta-claw
```

(Restarting `openclaw` re-runs the ExecStartPre and rewrites `openclaw.json` with the new ladder.)

## Honest one-liner

This keeps **ZDR** intact and costs **~$0 for short/light sessions** (four free rungs first); long sessions (>131K tokens) context-overflow the free rungs and fall through to the cheap paid anchor (~$0.07/M in), which is the intended safety net. The alternative "switch to codex" path would be **separately-billed OpenAI API tokens** (ChatGPT Pro does not cover the API) **and drops the ZDR guarantee** OpenClaw was built around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)