### PR TITLE
chore(sancta-choir): bump codex 0.92.0 → 0.142.3 via scoped pkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -388,11 +388,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -1,5 +1,6 @@
 { config
 , pkgs
+, pkgs-unstable
 , lib
 , self
 , ...
@@ -60,8 +61,13 @@
   # herdr-server unit's PATH, not a login shell's) can find + launch them:
   # OpenAI Codex CLI (github.com/openai/codex) as a second coding agent
   # alongside Claude Code, plus git + curl that the agents and herdr need.
+  # Codex ships from `pkgs-unstable` (nixpkgs-unstable input), NOT the stable
+  # `pkgs` (nixos-25.11) — the 25.11 branch caps codex at 0.92.0, which is far
+  # behind upstream. Scoping codex alone to unstable (same idiom as
+  # dev-tools' github-copilot-cli and nullclaw's zig) keeps the fast-moving
+  # agent CLI current without dragging the whole host onto unstable nixpkgs.
   environment.systemPackages = [
-    pkgs.codex
+    pkgs-unstable.codex
     pkgs.git
     pkgs.curl
     # ralphex — multi-step Claude Code plan orchestrator (umputun/ralphex,


### PR DESCRIPTION
## What

Update the OpenAI Codex CLI on **sancta-choir** from **0.92.0 → 0.142.3**, the proper nixpkgs way — no overlay, no npm.

## Root cause

`hosts/sancta-choir/configuration.nix` had `pkgs.codex`, which resolves from the **stable `nixpkgs` (nixos-25.11)** input. The 25.11 branch caps codex at **0.92.0**. codex is a fast-moving agent CLI; nixos-unstable ships **0.142.3**.

(Note: the pinned `nixpkgs-unstable` input was at codex 0.118.0; the bump moves it to 0.142.3.)

## Fix

1. Source codex from **`pkgs-unstable`** (the existing `nixpkgs-unstable` input, already passed to every host via `specialArgs`) — same idiom as `dev-tools`' `github-copilot-cli` and `nullclaw`'s `zig`.
2. Bump the `nixpkgs-unstable` lock: `4bd9165` (2026-04-14) → `d407951` (2026-07-05).

### Why scoped source-swap (not the alternatives)
- **Bump stable `nixpkgs`**: can't reach 0.142.x on the 25.11 branch, and would rebuild *every* host. ✗
- **Dedicated codex-only flake input**: redundant — `nixpkgs-unstable` is already wired into every host's `specialArgs`. ✗
- **Scoped `pkgs-unstable.codex` + bump the shared unstable input**: moves codex to 0.142.3; blast radius verified small (below). ✓

## Blast-radius audit (nixpkgs-unstable is a shared input)

- codex 0.142.3 (x86_64, sancta-choir's arch) is **substitutable from cache.nixos.org** — no source build.
- `rpi5`, `rpi5-full`, `sancta-choir` toplevels all still **evaluate**.
- `rpi5-full` dry-build: **37 trivial config/wrapper builds** (activation scripts, systemd units, home-manager, `github-copilot-cli`, `nodejs`) + **258 MiB cached fetch**. No rust / llvm / python / boost from-source on the 4 GB aarch64 box.
- `open-webui` (the heavy unstable ML consumer) is commented out on `rpi5-full`, so its stack does **not** move.

## Verification (evidence)

```
codex @ old stable pin (pkgs.codex)      = 0.92.0
codex @ old nixpkgs-unstable pin         = 0.118.0
codex @ new nixpkgs-unstable pin (d407951) = 0.142.3   ✓ (matches nixos-unstable ref)
sancta-choir / rpi5 / rpi5-full toplevels: eval OK
codex-0.142.3 x86_64: present in cache.nixos.org (substitutable)
```

## Deploy (Alexandru's hand — not done here)

sancta-choir is a remote GRUB VPS; throttle + boot per repo policy:

```
nixos-rebuild build  --flake .#sancta-choir --max-jobs 1 --cores 1 && \
nixos-rebuild switch --flake .#sancta-choir --target-host root@sancta-choir --build-host root@sancta-choir
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)