### PR TITLE
fix(heartbeat): tolerate fractional-second timestamps in membrane reflection (#519)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -378,6 +378,12 @@
           # `id` used to fail only at runtime during ExecStartPost import.
           n8n-workflows-valid = import ./tests/n8n-workflows-valid.nix { inherit pkgs; };
 
+          # Heartbeat membrane-reflection guard (#519): runs the shared
+          # trusted-context jq against fractional-second (…NNN Z) fixtures —
+          # the real new Date().toISOString() form — and asserts the parsed
+          # counts. Locks the fix so the module and this check can never drift.
+          heartbeat-trusted-context = import ./tests/heartbeat-trusted-context.nix { inherit pkgs; };
+
           # NOTE: the declarative n8n VM test (#42) deliberately lives under
           # packages.<system>.n8n-declarative-test, NOT here. `nix flake
           # check` builds every check inside the resource-constrained
@@ -386,6 +392,20 @@
           # the runner with a shutdown signal. CI runs the test as an
           # explicit step in the "Build x86_64 Configs" job instead, which
           # frees ~30GB disk first and runs nothing concurrently.
+        };
+
+      # aarch64-linux checks: only the architecture-independent, cheap
+      # pure-jq/bash guards that are also meaningful on the actual deploy
+      # host. `heartbeat-trusted-context` is re-exposed here (same fixture,
+      # same shared .jq — no drift) so the guard for the tick, which runs
+      # on rpi5-full (aarch64), can be built NATIVELY on the Pi without
+      # x86_64 emulation. CI still exercises it on the x86_64 runner.
+      checks.aarch64-linux =
+        let
+          pkgs = nixpkgsFor.aarch64-linux;
+        in
+        {
+          heartbeat-trusted-context = import ./tests/heartbeat-trusted-context.nix { inherit pkgs; };
         };
 
       # Apps - makes packages runnable with `nix run`

--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -83,6 +83,7 @@ let
   jqBin = "${jq}/bin/jq";
 
   promptFile = ./sancta-heartbeat-tick-prompt.md;
+  trustedContextJq = ./sancta-heartbeat-trusted-context.jq;
 
   # ── Shared hardening for the indexOwner helper units (sync/promote/alert/
   # tripwire). These are pure local-file operations — no network, no new privs,
@@ -329,33 +330,8 @@ let
                 TRUSTED_CONTEXT="$(
                   ${jqBin} -n \
                     --slurpfile inbox <(${jqBin} -R 'fromjson? // empty' "$INBOX_FILE") \
-                    --slurpfile replies <(${jqBin} -R 'fromjson? // empty' "$REPLIES_FILE") '
-                    # epoch of an ISO-8601 ts, or null if absent/unparseable
-                    def epoch: (.ts // "") as $t
-                      | try ($t | fromdateiso8601) catch null;
-                    ($replies | map(epoch) | map(select(. != null))) as $rep_epochs
-                    | ($inbox
-                        | map(. + {e: epoch})
-                        | map(.e as $me
-                              | . + {answered:
-                                  ($me != null and ($rep_epochs | any(. > $me)))})
-                      ) as $msgs
-                    | ($msgs | map(select(.answered)) | length) as $answered
-                    | ($msgs | length) as $n
-                    | ($msgs
-                        | map(select(.answered | not))
-                        | map(select(.e != null))
-                        | sort_by(.e)
-                        | last) as $newest_open
-                    | {
-                        inbox_count: $n,
-                        replies_count: ($replies | length),
-                        answered: $answered,
-                        open: ($n - $answered),
-                        newest_open_message:
-                          ( ($newest_open.message // null)
-                            | if type == "string" then .[0:600] else null end )
-                      }'
+                    --slurpfile replies <(${jqBin} -R 'fromjson? // empty' "$REPLIES_FILE") \
+                    -f ${trustedContextJq}
                 )" || TRUSTED_CONTEXT='{"inbox_count":0,"replies_count":0,"answered":0,"open":0,"newest_open_message":null}'
                 # Non-secret, bounded — safe to log for the Witness closing check.
                 echo "trusted-context: $TRUSTED_CONTEXT"

--- a/modules/services/sancta-heartbeat-trusted-context.jq
+++ b/modules/services/sancta-heartbeat-trusted-context.jq
@@ -1,0 +1,43 @@
+# Mechanical trusted-context for the Sancta heartbeat tick (membrane reflection, #519).
+#
+# Computed OUTSIDE the model from the mirrored JSONL, so a crafted inbox line
+# cannot fake the counts or claim it is already answered — the model is told to
+# trust ONLY this block. Consumed by sancta-heartbeat-tick.nix via `jq -f`, and
+# exercised directly by the flake check `heartbeat-trusted-context` so the two
+# can never drift.
+#
+# Inputs (via --slurpfile): $inbox, $replies  (arrays of parsed JSONL objects).
+#
+# epoch: seconds for an ISO-8601 ts, or null if absent/unparseable. jq's
+# fromdateiso8601 accepts ONLY %Y-%m-%dT%H:%M:%SZ and REJECTS the fractional
+# form (…20.784Z) that new Date().toISOString() actually emits — every real
+# membrane line carries .NNN. Left unhandled it made every message unparseable
+# → answered=0, open=inbox_count, newest_open_message=null → the reflection
+# could never fire (bare-ACK forever). Strip the ".NNN" before the trailing Z;
+# non-fractional / already-Z inputs pass through unchanged.
+def epoch: (.ts // "")
+  | sub("\\.[0-9]+Z$"; "Z")
+  | (try fromdateiso8601 catch null);
+
+($replies | map(epoch) | map(select(. != null))) as $rep_epochs
+| ($inbox
+    | map(. + {e: epoch})
+    | map(.e as $me
+          | . + {answered: ($me != null and ($rep_epochs | any(. > $me)))})
+  ) as $msgs
+| ($msgs | map(select(.answered)) | length) as $answered
+| ($msgs | length) as $n
+| ($msgs
+    | map(select(.answered | not))
+    | map(select(.e != null))
+    | sort_by(.e)
+    | last) as $newest_open
+| {
+    inbox_count: $n,
+    replies_count: ($replies | length),
+    answered: $answered,
+    open: ($n - $answered),
+    newest_open_message:
+      ( ($newest_open.message // null)
+        | if type == "string" then .[0:600] else null end )
+  }

--- a/tests/heartbeat-trusted-context.nix
+++ b/tests/heartbeat-trusted-context.nix
@@ -1,0 +1,55 @@
+# Regression guard for the Sancta heartbeat membrane reflection (#519).
+#
+# Runs the SAME committed jq program the tick uses
+# (modules/services/sancta-heartbeat-trusted-context.jq) against
+# REAL-format fixtures — inbox/reply timestamps with fractional seconds
+# (…NNN Z), exactly what new Date().toISOString() emits. Before the fix,
+# jq's fromdateiso8601 rejected the fractional form, so every message was
+# unparseable → answered=0, open=inbox_count, newest_open_message=null and
+# the Tier-1 reflection could never fire. This asserts the parsed result so
+# the module and the guard can never drift (both read the one .jq file).
+{ pkgs }:
+pkgs.runCommand "heartbeat-trusted-context"
+{
+  nativeBuildInputs = [ pkgs.jq pkgs.bash ];
+  trustedContextJq = ../modules/services/sancta-heartbeat-trusted-context.jq;
+}
+  ''
+    export SHELL=${pkgs.bash}/bin/bash
+    ${pkgs.bash}/bin/bash -euo pipefail <<'EOF'
+    cat > inbox.jsonl <<'JSON'
+    {"ts":"2026-07-07T10:00:00.123Z","message":"old, answered"}
+    {"ts":"2026-07-07T12:30:45.784Z","message":"FRESH OPEN, no reply"}
+    JSON
+    cat > replies.jsonl <<'JSON'
+    {"ts":"2026-07-07T11:00:00.500Z","from":"sancta","text":"reply to first"}
+    JSON
+
+    OUT="$(
+      jq -n \
+        --slurpfile inbox <(jq -R 'fromjson? // empty' inbox.jsonl) \
+        --slurpfile replies <(jq -R 'fromjson? // empty' replies.jsonl) \
+        -f "$trustedContextJq"
+    )"
+    echo "trusted-context output:"
+    echo "$OUT"
+
+    check() {
+      local expr="$1" want="$2"
+      local got
+      got="$(printf '%s' "$OUT" | jq -r "$expr")"
+      if [ "$got" != "$want" ]; then
+        echo "ASSERTION FAILED: $expr => '$got' (expected '$want')" >&2
+        exit 1
+      fi
+      echo "OK: $expr == $want"
+    }
+
+    check '.inbox_count'         '2'
+    check '.replies_count'       '1'
+    check '.answered'            '1'
+    check '.open'                '1'
+    check '.newest_open_message' 'FRESH OPEN, no reply'
+    EOF
+    touch $out
+  ''


### PR DESCRIPTION
## The bug (#519)

The Sancta heartbeat tick computes a mechanical **trusted-context** (inbox/reply counts, `answered`/`open`, `newest_open_message`) *outside* the model — so a crafted inbox line cannot fake the numbers; the prompt tells the model to trust only that block.

Its `epoch` helper used jq's `fromdateiso8601`, which accepts **only** `%Y-%m-%dT%H:%M:%SZ` and **rejects** the fractional form (`…20.784Z`).

Every real membrane line (`comm-inbox.jsonl` / `comm-replies.jsonl`) is produced by `new Date().toISOString()` and carries `.NNN` fractional seconds. So **every** timestamp was unparseable →

- `answered = 0`
- `open = inbox_count` (inflated — every message looked unanswered)
- `newest_open_message = null` **always**

The consequence: the Tier‑1 reflection «iată ce‑am auzit» could **never** fire — the tick **bare‑ACKed forever**, dead on arrival. Reproduced deterministically.

## The fix (altitude, not bandaid)

1. **Extract the inline jq to a shared file** — `modules/services/sancta-heartbeat-trusted-context.jq` — consumed by the tick via `jq -f`. The module now embeds that path; no behavior change beyond the fix. Verified the tick derivation references the committed `.jq`.
2. **Tolerate fractional seconds** — in `epoch`, strip a trailing `.NNN` before the `Z` (`sub("\\.[0-9]+Z$"; "Z")`) before `fromdateiso8601`. Non‑fractional / already‑`Z` inputs pass through unchanged.

## New drift-proof CI check

`heartbeat-trusted-context` runs the **same committed `.jq`** against real‑format fractional‑second fixtures and asserts `inbox_count=2`, `replies_count=1`, `answered=1`, `open=1`, `newest_open_message="FRESH OPEN, no reply"`. Because the check references the one committed file, the module and the guard **can never drift**. Registered on x86_64 (CI) and aarch64 (native on rpi5, where the tick runs).

**Regression guard is real, not decorative:** reverting `epoch` to the buggy form makes the check fail exactly as the bug manifested — `answered=0`, `open=2`, `newest_open_message=null`. Restoring the `sub(...)` makes it pass again.

## Evidence

- `nix build .#checks.aarch64-linux.heartbeat-trusted-context -L` → **SUCCESS** (parsed output: `answered=1, open=1, inbox_count=2, newest_open_message="FRESH OPEN, no reply"`).
- Buggy‑`epoch` rebuild → **FAIL** (`ASSERTION FAILED: .answered => '0'`), restore → **PASS**.
- `nixos-rebuild dry-build --flake .#rpi5-full` → **EXIT 0** (rebuilds `sancta-heartbeat-tick.drv`).

## Scope / safety

No secrets, systemd hardening, `LoadCredential`, or sandbox posture touched. Tailscale / secret patterns untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)