### PR TITLE
fix(sancta-claw): drop tools-incapable rung from OpenClaw ZDR ladder (#516)

### DIFF
--- a/hosts/sancta-claw/openclaw-service.nix
+++ b/hosts/sancta-claw/openclaw-service.nix
@@ -201,19 +201,34 @@ let
     #   curl -s https://openrouter.ai/api/v1/endpoints/zdr \
     #     | jq -r '.data[].model_id' | sort -u | grep -F '<id>'
     #
+    # TOOLS CONSTRAINT — every rung MUST also expose a tool-use-capable ZDR
+    # endpoint. OpenClaw is an agentic client: EVERY request carries tools, so a
+    # rung whose only ZDR provider lacks function-calling returns
+    # `404 No endpoints found that support tool use` and DEAD-ENDS the ladder.
+    # A tool-404 is NOT a 429 and NOT a context overflow, so it does not trigger
+    # the ladder's fallback (which fires on rate-limits / long context) — it just
+    # hard-fails the request. ZDR-eligibility alone is insufficient. To re-verify
+    # a rung's provider exposes tools before editing:
+    #   curl -s https://openrouter.ai/api/v1/models/<id>/endpoints \
+    #     | jq -r '.data.endpoints[] | "\(.provider_name) tools=\((.supported_parameters//[])|index("tools")!=null)"'
+    # A rung is safe only if at least one ZDR provider prints tools=true.
+    # hermes-3-llama-3.1-405b:free was removed 2026-07-08 — ZDR-eligible but its
+    # Venice endpoint has tools=false → 404s an agentic client, so it dead-ended
+    # the ladder here (do NOT re-add it as a rung).
+    #
     # Ordering rationale:
-    # - Free-first: rungs 0-3 are all :free (zero cost), tried before any paid
+    # - Free-first: rungs 0-2 are all :free (zero cost), tried before any paid
     #   token is ever spent.
     # - 262K rungs first; the agent's working session can accumulate >131K
     #   tokens. Only two FREE ZDR-eligible rungs offer 262K context (rungs 0-1) —
-    #   no other free ZDR model on OpenRouter exceeds 131K — so rungs 2 (131K) and
-    #   3 (65K) are lower-context free options that a long session will
-    #   "Context overflow" past before they serve a token. That is intended: they
-    #   still catch SHORT sessions for free; long sessions fall straight through
-    #   to the 262K paid anchor.
+    #   no other free ZDR model on OpenRouter exceeds 131K — so rung 2 (65K) is a
+    #   lower-context free option that a long session will "Context overflow" past
+    #   before it serves a token. That is intended: it still catches SHORT
+    #   sessions for free; long sessions fall straight through to the 262K paid
+    #   anchor.
     # - Coder-tuned primary because OpenClaw's main role is an "AI programming
     #   partner".
-    # - Rung 4 is the PAID anchor: qwen/qwen3-coder-30b-a3b-instruct is the
+    # - Rung 3 is the PAID anchor: qwen/qwen3-coder-30b-a3b-instruct is the
     #   cheapest coder-tuned, tools-capable, 262K, ZDR-eligible model on
     #   OpenRouter (~$0.07/M input, ~$0.27/M output). It exists so the ladder
     #   never dead-ends once the free tier is unavailable — whether from 429
@@ -224,7 +239,8 @@ let
     LADDER = [
         {"id": "qwen/qwen3-coder:free",                 "name": "Qwen3 Coder (free, ZDR)",         "ctx": 262144},
         {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "name": "Qwen3 Next 80B (free, ZDR)",       "ctx": 262144},
-        {"id": "nousresearch/hermes-3-llama-3.1-405b:free", "name": "Hermes 3 405B (free, ZDR)",   "ctx": 131072},
+        # hermes-3-llama-3.1-405b:free removed 2026-07-08 — ZDR-eligible but its
+        # Venice endpoint has tools=false → 404s an agentic client (see TOOLS CONSTRAINT above).
         {"id": "meta-llama/llama-3.3-70b-instruct:free", "name": "Llama 3.3 70B (free, ZDR)",      "ctx": 65536},
         {"id": "qwen/qwen3-coder-30b-a3b-instruct",     "name": "Qwen3 Coder 30B (paid anchor, ZDR)", "ctx": 262144},
     ]


### PR DESCRIPTION
Closes #516.

## The bug

The OpenClaw ZDR model-ladder in `hosts/sancta-claw/openclaw-service.nix` (the `LADDER` list) was validated for **ZDR-eligibility** but **not** for **tool-use capability**.

OpenClaw is an agentic client — **every** request carries tools — so a rung whose only ZDR provider lacks function-calling returns `404 No endpoints found that support tool use` and **dead-ends**. A tool-404 is neither a 429 nor a context overflow, so it never triggers the ladder's fallback (which fires on rate-limits / long context); it just hard-fails the request.

## Source-verified tools table

Verified at the OpenRouter source with:
```
curl -s https://openrouter.ai/api/v1/models/<id>/endpoints \
  | jq -r '.data.endpoints[] | "\(.provider_name) tools=\((.supported_parameters//[])|index("tools")!=null)"'
```

| rung | model id | ZDR provider | tools | verdict |
|---|---|---|---|---|
| 0 | `qwen/qwen3-coder:free` | Venice | **true** | keep |
| 1 | `qwen/qwen3-next-80b-a3b-instruct:free` | Venice | **true** | keep |
| ~~2~~ | `nousresearch/hermes-3-llama-3.1-405b:free` | Venice | **false** | **REMOVED — dead rung** |
| 2 (was 3) | `meta-llama/llama-3.3-70b-instruct:free` | Venice | **true** | keep |
| 3 (was 4) | `qwen/qwen3-coder-30b-a3b-instruct` (paid anchor) | Novita / SiliconFlow / Amazon Bedrock / Alibaba / DigitalOcean | **true** (all) | keep |

Re-verified at merge time: every **remaining** rung still returns at least one `tools=true` endpoint. None of the survivors regressed to tools=false.

## The fix

1. **Remove** the `nousresearch/hermes-3-llama-3.1-405b:free` rung. Every remaining rung is tool-capable, so the ladder now falls 1→2→3 cleanly.
2. **Add a TOOLS CONSTRAINT** doc block next to the existing ZDR CONSTRAINT: every rung MUST also expose a tool-use-capable ZDR endpoint, with the verification curl above, and a dated one-line note where hermes-3-405b was so nobody re-adds it.
3. Renumbered the ordering-rationale comment (rungs 0-3 → 0-2; paid anchor is now rung 3).

The `LADDER` list is the **single source of truth** — it renders both `provider.models[]` (via `_make_model_entry(r) for r in LADDER`) and `agents.defaults.model.{primary,fallbacks}` (via `LADDER[0]` / `LADDER[1:]`), so this one edit propagates to both openclaw.json paths.

Following the ZDR constraint's precedent, this is documented + a check command, **not** a new in-module runtime enforcer.

## Closing checks

- `nix fmt` — clean (no reformatting of the edit).
- Rendered-config eval (`nix eval --raw .#nixosConfigurations.sancta-claw.config.system.build.openclawBrowserConfigBody`): confirms the hermes `{"id":...}` ladder entry is **GONE** (grep count 0) and rung 0 is still `qwen/qwen3-coder:free`. Both `primary`/`fallbacks` and `provider.models[]` render from `LADDER`.
- `module-eval` `openclaw-free-zdr-ladder-rendered` test: **PASS** (forces the rendered body + required substrings).
- Full `system.build.toplevel` eval can't complete on the aarch64 rpi5 (x86-only IFD); it fails identically on `origin/main`. CI's **Build x86_64 Configs** is the real build gate.

## After merge

The human must **rebuild sancta-claw** (x86 host) for this to take effect. Immediate unblock without a rebuild: `systemctl restart openclaw` re-rolls the running agent to rung 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)