### PR TITLE
fix(heartbeat): tolerate offset timestamps in membrane reflection — close the never-close loop

### DIFF
--- a/modules/services/sancta-heartbeat-tick.nix
+++ b/modules/services/sancta-heartbeat-tick.nix
@@ -153,7 +153,7 @@ let
                   # A simple check (or the deferred ok:false / low-value-streak detector,
                   # backlog sancta-tick-okfalse-streak-detector) can watch this field to
                   # surface a stuck-but-green heartbeat. Minimal by design: one string.
-                  ${jqBin} -n --arg ts "$(${cu}/date -Is)" --argjson ok "$1" \
+                  ${jqBin} -n --arg ts "$(${cu}/date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson ok "$1" \
                     --arg reason "$2" --arg quality "''${3:-}" \
                     '{ts: $ts, ok: $ok, by: "sancta-heartbeat-tick"}
                      + (if $reason != "" then {reason: $reason} else {} end)
@@ -479,7 +479,11 @@ let
     INDEX="${cfg.indexDir}"
     STATE="${stateDir}"
     STAGING="$STATE/staging"
-    TS=$(${cu}/date -Is)
+    # UTC Z, never a local offset: this TS is written into comm-replies.jsonl and
+    # is the answered-computation input in trusted-context.jq. `date -Is` emits a
+    # local +HH:MM offset that the jq epoch parser used to reject → replies never
+    # counted as answered → the tick re-reflected forever (membrane-ts-offset-fix).
+    TS=$(${cu}/date -u +%Y-%m-%dT%H:%M:%SZ)
 
     if [ ! -d "$INDEX" ]; then
       echo "ERROR: index dir $INDEX missing — cannot promote" >&2
@@ -561,7 +565,7 @@ let
     set -euo pipefail
     INDEX="${cfg.indexDir}"
     STATE="${stateDir}"
-    TS=$(${cu}/date -Is)
+    TS=$(${cu}/date -u +%Y-%m-%dT%H:%M:%SZ)
 
     echo "ALERT: sancta-heartbeat-tick.service FAILED — writing feed alert" >&2
 
@@ -645,7 +649,7 @@ let
       if [ "$FSIZE" -gt ${toString cfg.liveFileByteCap} ]; then
         echo "WARNING: $FEED is $FSIZE bytes (> ${toString cfg.liveFileByteCap} cap) — skipping tripwire append; rotate it (follow-up) to resume" >&2
       else
-        ${jqBin} -cn --arg ts "$(${cu}/date -Is)" --arg r "$stale_reason" \
+        ${jqBin} -cn --arg ts "$(${cu}/date -u +%Y-%m-%dT%H:%M:%SZ)" --arg r "$stale_reason" \
           '{ts: $ts, source: "sancta-tick-tripwire", alert: "heartbeat-stale", reason: $r}' \
           >> "$FEED"
       fi

--- a/modules/services/sancta-heartbeat-trusted-context.jq
+++ b/modules/services/sancta-heartbeat-trusted-context.jq
@@ -9,15 +9,38 @@
 # Inputs (via --slurpfile): $inbox, $replies  (arrays of parsed JSONL objects).
 #
 # epoch: seconds for an ISO-8601 ts, or null if absent/unparseable. jq's
-# fromdateiso8601 accepts ONLY %Y-%m-%dT%H:%M:%SZ and REJECTS the fractional
-# form (…20.784Z) that new Date().toISOString() actually emits — every real
-# membrane line carries .NNN. Left unhandled it made every message unparseable
-# → answered=0, open=inbox_count, newest_open_message=null → the reflection
-# could never fire (bare-ACK forever). Strip the ".NNN" before the trailing Z;
-# non-fractional / already-Z inputs pass through unchanged.
+# fromdateiso8601 accepts ONLY %Y-%m-%dT%H:%M:%SZ and REJECTS both the
+# fractional form (…20.784Z, from new Date().toISOString()) AND any numeric
+# offset (…+03:00 / …-05:00, from `date -Is`). Left unhandled either made a
+# message unparseable → answered=0, open=inbox_count, newest_open_message=null.
+# #524 fixed the fractional-Z case only; the tick's OWN reply lines still used
+# `date -Is`, which emits a LOCAL offset (+HH:MM). Those replies never parsed,
+# so they never counted as answered and the tick re-reflected the same
+# newest-open message every 30 min forever (the never-close loop). His own
+# messages are `.NNN Z` (JS toISOString) so they parsed — only the tick's did not.
+#
+# Total (never throws): strip fractional seconds regardless of what follows; if
+# a trailing ±HH:MM offset remains, parse the wall-clock [0:19] as Z then adjust
+# to UTC (+HH:MM is ahead of UTC → SUBTRACT the offset; -HH:MM → ADD it); else
+# ensure a single trailing Z and parse. Anything unparseable degrades to null.
 def epoch: (.ts // "")
-  | sub("\\.[0-9]+Z$"; "Z")
-  | (try fromdateiso8601 catch null);
+  | sub("\\.[0-9]+"; "")
+  | . as $s
+  | if test("[+-][0-9]{2}:[0-9]{2}$") then
+      ($s | .[0:19]) as $wall
+      | ($s | .[19:]) as $off
+      | ($off | .[1:3] | tonumber) as $oh
+      | ($off | .[4:6] | tonumber) as $om
+      | ($oh * 3600 + $om * 60) as $osec
+      | (try (($wall + "Z") | fromdateiso8601) catch null) as $base
+      | if $base == null then null
+        elif ($off | .[0:1]) == "+" then $base - $osec
+        else $base + $osec
+        end
+    else
+      ($s | sub("Z$"; "") + "Z")
+      | (try fromdateiso8601 catch null)
+    end;
 
 ($replies | map(epoch) | map(select(. != null))) as $rep_epochs
 | ($inbox

--- a/tests/heartbeat-trusted-context.nix
+++ b/tests/heartbeat-trusted-context.nix
@@ -50,6 +50,51 @@ pkgs.runCommand "heartbeat-trusted-context"
     check '.answered'            '1'
     check '.open'                '1'
     check '.newest_open_message' 'FRESH OPEN, no reply'
+
+    # ── Offset-timestamp case (membrane-ts-offset-fix, the never-close loop) ──
+    # Exact live failure: his messages are `.NNN Z` (JS toISOString), but the
+    # tick's OWN reply lines were written with `date -Is` → a LOCAL offset
+    # (+HH:MM). jq's fromdateiso8601 rejects offsets, so those replies never
+    # parsed, never counted as answered, and the tick re-reflected the same
+    # newest-open message every 30 min forever. This pins BOTH the parser
+    # tolerance (offset → correct instant) AND the producer contract: an
+    # offset-carrying reply that is LATER than an inbox message must answer it.
+    cat > inbox2.jsonl <<'JSON'
+    {"ts":"2026-07-07T15:00:00.100Z","message":"asked at 15:00Z, answered by an offset reply"}
+    {"ts":"2026-07-07T16:00:00.200Z","message":"asked at 16:00Z, still open"}
+    JSON
+    # +03:00 wall-clock 18:01:42 == 15:01:42Z (after msg 1 @15:00Z, before msg 2 @16:00Z).
+    cat > replies2.jsonl <<'JSON'
+    {"ts":"2026-07-07T18:01:42+03:00","from":"sancta-tick","text":"offset reply, 15:01:42Z"}
+    JSON
+
+    OUT2="$(
+      jq -n \
+        --slurpfile inbox <(jq -R 'fromjson? // empty' inbox2.jsonl) \
+        --slurpfile replies <(jq -R 'fromjson? // empty' replies2.jsonl) \
+        -f "$trustedContextJq"
+    )"
+    echo "trusted-context output (offset case):"
+    echo "$OUT2"
+
+    check2() {
+      local expr="$1" want="$2"
+      local got
+      got="$(printf '%s' "$OUT2" | jq -r "$expr")"
+      if [ "$got" != "$want" ]; then
+        echo "ASSERTION FAILED (offset): $expr => '$got' (expected '$want')" >&2
+        exit 1
+      fi
+      echo "OK (offset): $expr == $want"
+    }
+
+    # The +03:00 reply (15:01:42Z) is later than msg 1 (15:00:00Z) → answered;
+    # msg 2 (16:00:00Z) is later than the reply → still open and newest.
+    check2 '.inbox_count'         '2'
+    check2 '.replies_count'       '1'
+    check2 '.answered'            '1'
+    check2 '.open'                '1'
+    check2 '.newest_open_message' 'asked at 16:00Z, still open'
     EOF
     touch $out
   ''


### PR DESCRIPTION
## The bug (membrane-ts-offset-fix)

The membrane heartbeat tick re-reflected the **same** newest-open message every 30 min forever (open stuck, answered frozen — a never-close loop).

**Root cause:** the promote unit wrote reply/feed/state timestamps with `date -Is`, which emits a **local offset** (e.g. `2026-07-07T18:01:42+03:00`). The answered-computation in `sancta-heartbeat-trusted-context.jq` uses jq `fromdateiso8601`, which accepts **only** UTC `Z` and **rejects** `+HH:MM`/`-HH:MM` offsets. So every tick-written reply was unparseable → never counted as answered → the tick re-reflected the same open message indefinitely.

His own messages are `.NNN Z` (JS `toISOString`) so they parsed — **only the tick's own replies didn't**.

## Why #524 didn't cover it

#524 taught the parser to strip **fractional seconds before `Z`** (`…20.784Z`), but not to handle a trailing numeric **offset**. The tick's own `date -Is` replies carried a `+HH:MM` offset that #524 never touched.

## The fix — belt-and-suspenders, both in one PR

1. **Producer** (`sancta-heartbeat-tick.nix`): all four ts sites now write UTC `date -u +%Y-%m-%dT%H:%M:%SZ` — the promote reply/feed ts (load-bearing for the answered math) plus `last-tick`, `alert`, `tripwire`. Closes the live stuck messages on the next tick.
2. **Parser** (`sancta-heartbeat-trusted-context.jq`, defense in depth — any writer, any tz): the `epoch` def strips fractional seconds regardless of what follows; converts a trailing `±HH:MM` offset to the correct UTC instant (`+` → subtract, `-` → add); else ensures a trailing `Z` and parses. Stays **total** (unparseable → `null`, never throws).
3. **Regression fixture** (`tests/heartbeat-trusted-context.nix`): an offset-ts case — inbox in `.NNN Z`, a later reply carrying `+03:00` — asserts the reply counts it as answered (open decremented, newest_open advances). Mirrors the exact live failure; runs the committed jq so module and guard can't drift.

## Verification

**5 parser fixtures (against the committed jq):**

| ts | epoch | note |
|---|---|---|
| `2026-07-07T11:11:20.784Z` | `1783422680` | fractional Z parses |
| `2026-07-07T18:01:42+03:00` | `1783436502` | == `2026-07-07T15:01:42Z` ✓ |
| `2026-07-07T10:00:00.500-05:00` | `1783436400` | == `2026-07-07T15:00:00Z` ✓ |
| `2026-07-07T17:00:00Z` | `1783443600` | plain Z parses |
| `garbage` | `null` | degrades to null ✓ |

**Regression guard (FAIL → RESTORE → PASS):** reverting only the epoch offset-handling to the #524 fractional-Z-only form makes the check fail exactly as the live bug did — `ASSERTION FAILED (offset): .answered => '0' (expected '1')`; restoring the fix → all offset assertions OK.

- `nix build .#checks.aarch64-linux.heartbeat-trusted-context` → PASS (with new offset fixture)
- `nix fmt` clean; `nixos-rebuild dry-build --flake .#rpi5-full` → EXIT 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)