### PR TITLE
feat: sancta-gallery systemd unit — publish gate structural on reboot

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -65,6 +65,7 @@ in
     ../../modules/system/ssh-hardened.nix
     ../../modules/services/shared-memory/shared-memory.nix # fleet shared-memory commons
     ../../modules/services/sancta-heartbeat-tick.nix # sandboxed decoupled heartbeat
+    ../../modules/services/sancta-gallery.nix # Galeria static viewer, publish gate always on
   ];
 
   # Sancta sandboxed decoupled heartbeat — ~30-min cognitive tick that

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -79,6 +79,10 @@ in
   services.sancta-heartbeat-tick.enable = true;
   services.sancta-heartbeat-tick.oauthTokenFile = "/var/lib/sancta-tick/oauth-token";
 
+  # Galeria — Painter's static viewer with the publish gate structurally on.
+  # See modules/services/sancta-gallery.nix (council-20260711T174857Z-569898).
+  services.sancta-gallery.enable = true;
+
   # Fleet shared-memory commons — localhost-bound first deploy.
   # Cross-host access over Tailscale is a deliberate follow-up (bind the
   # tailscale IP / add a tailscale-serve unit) once the allow-all auth seam

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -10,56 +10,91 @@
 # The server itself (server.mjs) is NOT in this repo: the gallery lives in
 # Sancta's index under the home directory (~/.claude/index/gallery). That is
 # deliberate — the pieces and their .passed sidecars are produced there by
-# the painter/publish pipeline. Consequences for hardening:
-#   - ProtectHome must NOT be set (it would hide the entire gallery from the
-#     unit's mount namespace and the service could never start).
+# the painter/publish pipeline, so the content is mutable by design and
+# cannot be a store path. Consequences for hardening:
+#   - ProtectHome=true would hide the gallery entirely, so instead we use
+#     ProtectHome="tmpfs" + BindReadOnlyPaths on ONLY the gallery dir: the
+#     unit sees an empty /home except a read-only bind of the gallery.
+#     Even a fully compromised server process cannot read SSH keys,
+#     credentials, or anything else under /home.
+#   - ConditionPathExists guards the mutable script: if server.mjs is
+#     absent the unit stays inactive instead of crash-looping.
 #   - The unit runs as User=nixos (the index owner), same as the nohup
-#     process it replaces. Keep the rest of the sandbox sane but functional.
+#     process it replaces.
 #   - Binding stays 127.0.0.1 (server default); `tailscale serve` already
-#     proxies it onto the tailnet with TLS.
-{ pkgs, ... }:
+#     proxies it onto the tailnet with TLS. Declaring the serve rule is
+#     intentionally out of scope here (per the 2026-07-11 authorization).
+{ config
+, lib
+, pkgs
+, ...
+}:
 let
-  galleryDir = "/home/nixos/.claude/index/gallery";
+  cfg = config.services.sancta-gallery;
 in
 {
-  systemd.services.sancta-gallery = {
-    description = "Sancta Gallery — read-only static viewer with publish gate";
-    after = [ "network.target" ];
-    wantedBy = [ "multi-user.target" ];
+  options.services.sancta-gallery = {
+    enable = lib.mkEnableOption "Sancta Gallery static viewer with publish gate";
 
-    environment = {
-      # The publish gate: server refuses any artifact without a <file>.passed
-      # sidecar (written by publish.mjs after the non-leak PII test passes).
-      GALLERY_PUBLISH_GATE = "1";
+    galleryDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/home/nixos/.claude/index/gallery";
+      description = "Directory holding server.mjs, the pieces and their .passed sidecars.";
     };
+  };
 
-    serviceConfig = {
-      Type = "simple";
-      User = "nixos";
-      Group = "users";
-      WorkingDirectory = galleryDir;
-      ExecStart = "${pkgs.nodejs}/bin/node ${galleryDir}/server.mjs";
-      Restart = "always";
-      RestartSec = 5;
+  config = lib.mkIf cfg.enable {
+    systemd.services.sancta-gallery = {
+      description = "Sancta Gallery — read-only static viewer with publish gate";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
 
-      # Hardening — sane but functional. No ProtectHome (see header: the
-      # gallery lives under /home). The server is read-only over the gallery
-      # dir; ProtectSystem=strict makes the rest of the filesystem read-only
-      # and we grant no write paths at all (the server never writes).
-      NoNewPrivileges = true;
-      ProtectSystem = "strict";
-      PrivateTmp = true;
-      ProtectKernelTunables = true;
-      ProtectKernelModules = true;
-      ProtectControlGroups = true;
-      RestrictSUIDSGID = true;
-      LockPersonality = true;
-      MemoryDenyWriteExecute = false; # node JIT needs W^X off
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
+      # If the (deliberately non-store) server script is missing, stay
+      # inactive rather than crash-loop.
+      unitConfig.ConditionPathExists = "${cfg.galleryDir}/server.mjs";
+
+      # Rate-limit restarts: a persistently crashing server ends up in a
+      # loud `systemctl --failed` state instead of oscillating forever.
+      startLimitIntervalSec = 60;
+      startLimitBurst = 5;
+
+      environment = {
+        # The publish gate: server refuses any artifact without a
+        # <file>.passed sidecar (written by publish.mjs after the non-leak
+        # PII test passes).
+        GALLERY_PUBLISH_GATE = "1";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = "nixos";
+        Group = "users";
+        WorkingDirectory = cfg.galleryDir;
+        ExecStart = "${pkgs.nodejs}/bin/node ${cfg.galleryDir}/server.mjs";
+        Restart = "always";
+        RestartSec = 5;
+
+        # Hardening. The server only ever READS the gallery dir; it gets a
+        # read-only view of exactly that and nothing else under /home (see
+        # header). ProtectSystem=strict makes the rest of the filesystem
+        # read-only with no write paths granted at all.
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = "tmpfs";
+        BindReadOnlyPaths = [ cfg.galleryDir ];
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # node JIT needs W^X off
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
     };
   };
 }

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -1,0 +1,65 @@
+# Sancta Gallery (Galeria) — declarative systemd unit for the Painter's
+# read-only static viewer, so the publish gate can't silently die on reboot.
+#
+# Authorized: Alexandru 2026-07-11 (decisions 7+8). Risk finding
+# council-20260711T174857Z-569898: the gallery must ALWAYS run with
+# GALLERY_PUBLISH_GATE=1 so only .passed (non-leak-tested) artifacts are
+# served — an ad-hoc nohup process loses that env var on reboot; this unit
+# makes the gate structural.
+#
+# The server itself (server.mjs) is NOT in this repo: the gallery lives in
+# Sancta's index under the home directory (~/.claude/index/gallery). That is
+# deliberate — the pieces and their .passed sidecars are produced there by
+# the painter/publish pipeline. Consequences for hardening:
+#   - ProtectHome must NOT be set (it would hide the entire gallery from the
+#     unit's mount namespace and the service could never start).
+#   - The unit runs as User=nixos (the index owner), same as the nohup
+#     process it replaces. Keep the rest of the sandbox sane but functional.
+#   - Binding stays 127.0.0.1 (server default); `tailscale serve` already
+#     proxies it onto the tailnet with TLS.
+{ pkgs, ... }:
+let
+  galleryDir = "/home/nixos/.claude/index/gallery";
+in
+{
+  systemd.services.sancta-gallery = {
+    description = "Sancta Gallery — read-only static viewer with publish gate";
+    after = [ "network.target" ];
+    wantedBy = [ "multi-user.target" ];
+
+    environment = {
+      # The publish gate: server refuses any artifact without a <file>.passed
+      # sidecar (written by publish.mjs after the non-leak PII test passes).
+      GALLERY_PUBLISH_GATE = "1";
+    };
+
+    serviceConfig = {
+      Type = "simple";
+      User = "nixos";
+      Group = "users";
+      WorkingDirectory = galleryDir;
+      ExecStart = "${pkgs.nodejs}/bin/node ${galleryDir}/server.mjs";
+      Restart = "always";
+      RestartSec = 5;
+
+      # Hardening — sane but functional. No ProtectHome (see header: the
+      # gallery lives under /home). The server is read-only over the gallery
+      # dir; ProtectSystem=strict makes the rest of the filesystem read-only
+      # and we grant no write paths at all (the server never writes).
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+      PrivateTmp = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectControlGroups = true;
+      RestrictSUIDSGID = true;
+      LockPersonality = true;
+      MemoryDenyWriteExecute = false; # node JIT needs W^X off
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+    };
+  };
+}

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -21,9 +21,13 @@
 #     absent the unit stays inactive instead of crash-looping.
 #   - The unit runs as User=nixos (the index owner), same as the nohup
 #     process it replaces.
-#   - Binding stays 127.0.0.1 (server default); `tailscale serve` already
-#     proxies it onto the tailnet with TLS. Declaring the serve rule is
-#     intentionally out of scope here (per the 2026-07-11 authorization).
+#   - Binding stays 127.0.0.1:8739 (server default) and is ENFORCED at the
+#     systemd level (SocketBindAllow tcp:8739 only + IPAddressAllow
+#     loopback only), so even a modified server.mjs cannot silently listen
+#     on 0.0.0.0 or another port. `tailscale serve` already proxies it onto
+#     the tailnet with TLS (the proxy connects over loopback, which stays
+#     allowed). Declaring the serve rule is intentionally out of scope here
+#     (per the 2026-07-11 authorization).
 { config
 , lib
 , pkgs
@@ -37,7 +41,7 @@ in
     enable = lib.mkEnableOption "Sancta Gallery static viewer with publish gate";
 
     galleryDir = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.path;
       default = "/home/nixos/.claude/index/gallery";
       description = "Directory holding server.mjs, the pieces and their .passed sidecars.";
     };
@@ -61,7 +65,11 @@ in
       environment = {
         # The publish gate: server refuses any artifact without a
         # <file>.passed sidecar (written by publish.mjs after the non-leak
-        # PII test passes).
+        # PII test passes). Trust boundary: env-var DELIVERY is structural
+        # (survives reboot), but the gate CHECK lives in server.mjs —
+        # mutable, outside the Nix store. Integrity of server.mjs is the
+        # responsibility of the painter/publish pipeline (Sancta's index),
+        # not of this unit.
         GALLERY_PUBLISH_GATE = "1";
       };
 
@@ -94,6 +102,18 @@ in
           "AF_INET6"
           "AF_UNIX"
         ];
+
+        # Enforce the loopback-only contract at the systemd level, not just
+        # in server.mjs: the process may bind ONLY tcp:8739 and exchange
+        # packets ONLY with loopback. tailscale serve proxies from the same
+        # host over loopback, so the tailnet path keeps working.
+        SocketBindAllow = "tcp:8739";
+        SocketBindDeny = "any";
+        IPAddressAllow = [
+          "127.0.0.1/32"
+          "::1/128"
+        ];
+        IPAddressDeny = "any";
       };
     };
   };


### PR DESCRIPTION
## Summary

Declarative systemd unit for the Galeria (`~/.claude/index/gallery/server.mjs`, 127.0.0.1:8739, proxied by tailscale serve), so `GALLERY_PUBLISH_GATE=1` can't silently die on reboot. Companion to the local server.mjs hardening (static paths now also require `<file>.passed`).

Authorized: Alexandru 2026-07-11 (decisions 7+8); risk finding council-20260711T174857Z-569898.

- `modules/services/sancta-gallery.nix` — `services.sancta-gallery.enable` (mkEnableOption) + `galleryDir` option; `User=nixos`, `Environment=GALLERY_PUBLISH_GATE=1`, `Restart=always` (start-limited 5/60s), `After=network.target`, node from `pkgs.nodejs`, `ConditionPathExists` on the (deliberately non-store) server.mjs.
- Least-privilege home: **`ProtectHome=tmpfs` + `BindReadOnlyPaths` of only the gallery dir** — the unit sees an empty /home except a read-only bind of the gallery. Runtime-verified via transient systemd-run instance: serves `gate:true`, rest of /home invisible in the namespace.
- Loopback contract enforced by systemd, not just by the script: `SocketBindAllow=tcp:8739` + `SocketBindDeny=any`, `IPAddressAllow=127.0.0.1/32 ::1/128` + `IPAddressDeny=any`. Runtime-verified: allowed port serves; other port fails `listen EPERM`.
- Trust boundary documented: env-var delivery is structural; the gate CHECK lives in mutable server.mjs (painter/publish pipeline's responsibility).
- Wired into `hosts/rpi5-full/configuration.nix` (`services.sancta-gallery.enable = true`).
- Tailscale-serve declaration intentionally deferred per the authorization ("tailscale serve already proxies"); possible follow-up.

## Verification

- `nix fmt` clean; `nixos-rebuild dry-build --flake .#rpi5-full` → exit 0
- `nix eval ...sancta-gallery.serviceConfig.ExecStart` → `.../nodejs-22.22.0/bin/node /home/nixos/.claude/index/gallery/server.mjs`; `environment.GALLERY_PUBLISH_GATE` → `"1"`
- Transient-unit runtime tests (positive serve + namespace blindness + bind EPERM) pasted in the review thread.

## On merge + rebuild (Alexandru's hand)

The systemd unit takes over. Kill the interim nohup process **once** (it runs with CWD = the gallery dir):

```
kill $(ls -l /proc/[0-9]*/cwd 2>/dev/null | awk '/index\/gallery$/ {split($9,a,"/"); print a[3]}') ; sudo systemctl restart sancta-gallery
```

Then verify: `curl -s http://127.0.0.1:8739/api/latest` shows `"gate":true`, and `systemctl status sancta-gallery` is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)