### PR TITLE
fix(sancta-self-backup): pin push to the dedicated key + exclude regenerable bloat

### DIFF
--- a/modules/services/sancta-self-backup.nix
+++ b/modules/services/sancta-self-backup.nix
@@ -113,21 +113,56 @@ let
     # placeholder is not a usable OpenSSH private key: self-suppress (no-auth)
     # rather than attempt a doomed push that would (correctly) fail loud every
     # week before the key exists. Once the real key is placed, this passes.
-    if ! ${pkgs.gnugrep}/bin/grep -q "BEGIN OPENSSH PRIVATE KEY" "$SSH_KEY"; then
-      echo "push ssh key is a placeholder / not an OpenSSH private key — self-suppressing (reason: no-auth)" >&2
+    # PARSE-validate with `ssh-keygen -y` (derive-pubkey, no secret printed):
+    # the first live run (2026-07-12) proved a header-only grep is NOT enough —
+    # the placeholder .age contained the literal "BEGIN OPENSSH PRIVATE KEY"
+    # header, passed the old grep gate, and the push proceeded with an
+    # unloadable key.
+    if ! ${openssh}/bin/ssh-keygen -y -f "$SSH_KEY" >/dev/null 2>&1; then
+      echo "push ssh key is a placeholder / not a usable OpenSSH private key — self-suppressing (reason: no-auth)" >&2
       exit 0
     fi
 
-    SSH="${openssh}/bin/ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=${
+    # -o IdentitiesOnly=yes is LOAD-BEARING, not hygiene: without it, ssh also
+    # offers the user's DEFAULT identities (~/.ssh/id_ed25519). On the first
+    # live run that fallback key WAS authorized on root@sancta-claw (DR key,
+    # NO forced command), so sshd ran a plain login shell which tried to
+    # execute `put <name>` as a command → `bash: line 1: put: command not
+    # found`, exit 127. The receiver contract (put/sha256/list/prune) only
+    # exists behind the DEDICATED key's forced-command wrapper — so offer that
+    # key and NOTHING else.
+    SSH="${openssh}/bin/ssh -i $SSH_KEY -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=${
       if effectiveKnownHosts != null then "yes -o UserKnownHostsFile=${effectiveKnownHosts}" else "accept-new"
     } -o ConnectTimeout=30"
 
-    # ── 1. tar the self, EXCLUDING regenerable gallery renders, then gzip.
+    # ── 1. tar the self, EXCLUDING regenerable artifacts, then gzip.
     # --dereference (-h): CLAUDE.md is a home-manager symlink into the nix
     # store — without -h the archive would capture a dangling link, not the
     # file's content. --ignore-failed-read tolerates a source that vanished
     # mid-run (e.g. a temp file) without aborting the whole backup.
     # Excludes are relative to each source root.
+    #
+    # Ratified spec excludes (regenerable gallery art):
+    #   gallery/*.png, gallery/*.gif, gallery/*-preview.txt
+    # Extensions beyond the ratified trio — all REGENERABLE, none is "the
+    # self". The first live run (2026-07-12) produced a 483 MB tar stream vs
+    # the ~110 MB spec-compliant archive; the extra was:
+    #   northstar/venv          — 266 MB pip venv (qiskit); `pip install`
+    #                             recreates it; the self is chsh.py+result.json
+    #                             which STAY in the archive.
+    #   painter/catalog3d/raw   — 33 MB downloaded HYG star database
+    #                             (hygdata_v41.csv, public dataset); the
+    #                             derived guarded catalog + scripts STAY.
+    #   painter/sky/*.png       — regenerable sky renders (same class as
+    #                             gallery art); the scene .json sources STAY.
+    #   painter/sky/.roots      — GC-root SYMLINKS into the nix store
+    #                             (stellarium, xvfb-run). THE actual 373 MB:
+    #                             --dereference (needed for CLAUDE.md) follows
+    #                             them and inhales the whole Stellarium package.
+    #                             Created 2026-07-11 19:37 — the night before
+    #                             the first timer run — which is why the manual
+    #                             2026-07-07 archive was spec-sized and the
+    #                             first automated run was not.
     echo "=== tar + gzip → $OUT ==="
     ${gnutar}/bin/tar \
       --dereference \
@@ -135,6 +170,10 @@ let
       --exclude='gallery/*.png' \
       --exclude='gallery/*.gif' \
       --exclude='gallery/*-preview.txt' \
+      --exclude='northstar/venv' \
+      --exclude='painter/catalog3d/raw' \
+      --exclude='painter/sky/*.png' \
+      --exclude='painter/sky/.roots' \
       -cf - \
       -C ${escapeShellArg (builtins.dirOf cfg.indexDir)} ${escapeShellArg (builtins.baseNameOf cfg.indexDir)} \
       -C ${escapeShellArg (builtins.dirOf cfg.memoryDir)} ${escapeShellArg (builtins.baseNameOf cfg.memoryDir)} \
@@ -276,8 +315,12 @@ let
     # ── (a) REMOTE bit-rot check. Only when a usable push key exists; otherwise
     # skip just this half (the remote copy can't be reached pre-provision) but
     # still run the local decrypt smoke-test below.
-    if [ -s "$SSH_KEY" ] && ${pkgs.gnugrep}/bin/grep -q "BEGIN OPENSSH PRIVATE KEY" "$SSH_KEY"; then
-      SSH="${openssh}/bin/ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=${
+    # Same gate as the backup script: `ssh-keygen -y` PARSE-validation (a
+    # header-only grep passed on a placeholder key, 2026-07-12) and
+    # IdentitiesOnly=yes (never fall back to an unrestricted default identity
+    # — the receiver contract lives behind the dedicated key's forced command).
+    if [ -s "$SSH_KEY" ] && ${openssh}/bin/ssh-keygen -y -f "$SSH_KEY" >/dev/null 2>&1; then
+      SSH="${openssh}/bin/ssh -i $SSH_KEY -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=${
         if effectiveKnownHosts != null then "yes -o UserKnownHostsFile=${effectiveKnownHosts}" else "accept-new"
       } -o ConnectTimeout=30"
       echo "=== remote sha256 (bit-rot check) → $REMOTE:$BASENAME ==="


### PR DESCRIPTION
## The failure (journal, first live timer run)

```
Jul 12 04:13:34 rpi5 …-sancta-self-backup[1108607]: === push → root@sancta-claw:/root/dr/sancta-self-2026-07-12.tar.gz.age ===
Jul 12 04:13:34 rpi5 …-sancta-self-backup[1109123]: /run/current-system/sw/bin/bash: line 1: put: command not found
Jul 12 04:13:35 rpi5 systemd[1]: sancta-self-backup.service: Main process exited, code=exited, status=127/n/a
```

## Bug 1 — push executed by a plain remote shell, not the forced-command wrapper

The receiver contract (`hosts/sancta-claw/sancta-selfbackup-receiver.nix`): the dedicated key is authorized with `restrict,command=<wrapper>`; the wrapper dispatches on `$SSH_ORIGINAL_COMMAND` over `put <name>` (stdin → `/root/dr/<name>`) / `sha256 <name>` / `list` / `prune <keep>`. The client line `$SSH "$REMOTE" "put $BASENAME" < "$OUT"` already matches that contract — the bug was **which key authenticated**:

- The committed agenix placeholder *contains the literal `BEGIN OPENSSH PRIVATE KEY` header*, so the old no-auth gate (`grep -q "BEGIN OPENSSH PRIVATE KEY"`) passed — but `ssh-keygen -y` on it exits 255 (not a parseable key).
- Without `IdentitiesOnly=yes`, ssh silently fell back to the **default identity** `~/.ssh/id_ed25519` — authorized on `root@sancta-claw` for DR with **no forced command** — so sshd ran a plain shell that tried to execute `put sancta-self-….tar.gz.age` as a command → `bash: line 1: put: command not found`, exit 127 (relayed into the rpi5 journal via ssh stderr).

Fix (client side, both backup + G2 verify scripts):

```diff
-    if ! ${pkgs.gnugrep}/bin/grep -q "BEGIN OPENSSH PRIVATE KEY" "$SSH_KEY"; then
+    if ! ${openssh}/bin/ssh-keygen -y -f "$SSH_KEY" >/dev/null 2>&1; then
```
```diff
-    SSH="${openssh}/bin/ssh -i $SSH_KEY -o BatchMode=yes -o StrictHostKeyChecking=…"
+    SSH="${openssh}/bin/ssh -i $SSH_KEY -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=…"
```

Parse-validation restores the intended pre-provision self-suppression (no weekly alert storm); `IdentitiesOnly=yes` guarantees only the dedicated forced-command key is ever offered, so the receiver contract is the only reachable surface.

## Bug 2 — 483 MB tar stream vs the ~110 MB spec archive

The dominant cause: `index/painter/sky/.roots/{stellarium,xvfb-run}` — GC-root **symlinks into the nix store** created **2026-07-11 19:37, the night before the first run** (which is why the manual 2026-07-07 archive was spec-sized). `--dereference` (needed for CLAUDE.md) follows them and inhales the whole Stellarium package. Plus `northstar/venv` (266 MB pip/qiskit venv) and `painter/catalog3d/raw` (33 MB downloaded HYG star database).

Ratified trio kept: `gallery/*.png`, `gallery/*.gif`, `gallery/*-preview.txt`. **Extensions beyond the trio (all regenerable, declared per spec):**

- `northstar/venv` — pip recreates it; `chsh.py` + `result.json` **stay**
- `painter/catalog3d/raw` — public HYG dataset (`hygdata_v41.csv`); derived guarded catalog + scripts **stay**
- `painter/sky/*.png` — regenerable sky renders; scene `.json` sources **stay**
- `painter/sky/.roots` — the store symlinks above

Result: tar stream 483 MB → **53 MB**; encrypted archive → **~22 MB**.

## Verification

- `bash -n` on the generated script from the built unit: clean.
- Generated script run **end-to-end with a stub ssh implementing the receiver contract** (put→stdin store, sha256, prune): exit 0, and the stub log proves the exact shape —
  ```
  SSH_ARGV: -i <dedicated-key> -o IdentitiesOnly=yes -o BatchMode=yes … root@sancta-claw put sancta-self-2026-07-12.tar.gz.age
  SSH_ORIGINAL_COMMAND: put sancta-self-2026-07-12.tar.gz.age
  STDIN_BYTES: 21974475   (byte-exact = archive size; sha256 round-trip verified)
  ```
- G2 verify unit rebuilt + `bash -n` clean; it globs the same `sancta-self-*.tar.gz.age` naming, so the next verify run works against a correctly-built archive.
- `nixos-rebuild dry-build --flake .#rpi5-full` → **exit 0**.

## Still needs Alexandru's hand

Full e2e against the real receiver waits on the **real agenix push key** (`agenix -e secrets/sancta-selfbackup-push-ssh-key.age` + setting `backupPushPubKey` in the receiver, then rebuilding both hosts). Until then the service now self-suppresses cleanly (exit 0, no-auth) instead of pushing via the wrong key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)