### PR TITLE
Add declarative Codex package

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1.0.171
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -388,11 +388,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {

--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -48,6 +48,8 @@ in
     # Import the base rpi5 configuration
     ../rpi5/configuration.nix
 
+    ../../modules/services/codex.nix
+
     # Open-WebUI and Qdrant disabled — too heavy for RPi5 right now
     # ../../modules/system/open-webui-arm-fix.nix
     # ../../modules/services/open-webui.nix
@@ -88,6 +90,10 @@ in
   # tailscale IP / add a tailscale-serve unit) once the allow-all auth seam
   # is reviewed. Today: same-host writers (drop-box + local curl) only.
   services.sharedMemory.enable = true;
+
+  # OpenAI Codex CLI for the full, active Pi profile. Keep this out of the
+  # minimal rpi5 SD-image profile so bootstrap images stay small.
+  customModules.codex.enable = true;
 
   # Package overrides for memory-constrained ARM builds
   nixpkgs.overlays = [

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -41,14 +41,18 @@
     ../common.nix
     ../../modules/system/dev-tools.nix
     ../../modules/users/root.nix
+    ../../modules/services/codex.nix
     ../../modules/services/claude-shared.nix
     ../../modules/services/herdr.nix
     ../../modules/services/tailscale.nix
     ../../modules/services/open-webui.nix
   ];
 
-  # Enable development tools and Claude Code
+  # Enable development tools and agent CLIs.
   customModules.dev-tools.enable = true;
+  # Codex ships from `pkgs-unstable` (nixpkgs-unstable input), NOT the stable
+  # `pkgs` (nixos-25.11) -- the 25.11 branch caps Codex behind upstream.
+  customModules.codex.enable = true;
   customModules.claudeShared = {
     enable = true;
     # `herdr` is included so the dedicated herdr user (which runs the herdr
@@ -58,16 +62,8 @@
   };
 
   # Agent tooling on the system PATH so herdr panes (which inherit the
-  # herdr-server unit's PATH, not a login shell's) can find + launch them:
-  # OpenAI Codex CLI (github.com/openai/codex) as a second coding agent
-  # alongside Claude Code, plus git + curl that the agents and herdr need.
-  # Codex ships from `pkgs-unstable` (nixpkgs-unstable input), NOT the stable
-  # `pkgs` (nixos-25.11) — the 25.11 branch caps codex at 0.92.0, which is far
-  # behind upstream. Scoping codex alone to unstable (same idiom as
-  # dev-tools' github-copilot-cli and nullclaw's zig) keeps the fast-moving
-  # agent CLI current without dragging the whole host onto unstable nixpkgs.
+  # herdr-server unit's PATH, not a login shell's) can find + launch them.
   environment.systemPackages = [
-    pkgs-unstable.codex
     pkgs.git
     pkgs.curl
     # ralphex — multi-step Claude Code plan orchestrator (umputun/ralphex,

--- a/modules/services/codex.nix
+++ b/modules/services/codex.nix
@@ -1,0 +1,31 @@
+{ config
+, pkgs
+, pkgs-unstable ? pkgs
+, lib
+, ...
+}:
+
+let
+  cfg = config.customModules.codex;
+in
+{
+  options.customModules.codex = {
+    enable = lib.mkEnableOption "OpenAI Codex CLI";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs-unstable.codex;
+      defaultText = lib.literalExpression "pkgs-unstable.codex";
+      description = ''
+        Codex CLI package to install. Defaults to nixpkgs-unstable because
+        Codex moves faster than stable nixpkgs branches.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add a reusable `customModules.codex` NixOS module that installs the Codex CLI from `pkgs-unstable.codex` by default.
- Enable Codex declaratively for the active `rpi5-full` profile while keeping the minimal `rpi5` SD-image profile free of Codex.
- Move `sancta-choir` to the same module and update `nixpkgs-unstable` so Codex resolves to `0.144.1`.

## Why

The prior npm global update path tried to write into the immutable Nix store on NixOS. Managing Codex through the system configuration keeps the install reproducible and avoids npm-managed PATH shadowing.

## Validation

- `nix eval .#nixosConfigurations.rpi5-full.config.customModules.codex.package.name` -> `"codex-0.144.1"`
- `sudo -n nixos-rebuild switch --flake .#rpi5-full`
- `which -a codex` -> `/run/current-system/sw/bin/codex`
- `codex --version` -> `codex-cli 0.144.1`