### PR TITLE
chore(flake): bump claude-code to 2.1.215

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782844284,
-        "narHash": "sha256-4UsRYeG9s2lsXz3Ggg0++dcd+6mF+U6mBW8gKfP0Xf0=",
+        "lastModified": 1784484843,
+        "narHash": "sha256-DQpCBkh4J5yoBDKbWIxDqdicKU4nBjnX4Kx+404zD2I=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "a9611e3182acc6e06a35d00e51d8f3a20fa1ffc5",
+        "rev": "6ee481c21e1e069e465abe89bb722c3fcdb78a1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump sadjow/claude-code-nix `a9611e3` (2026-06-30) → `6ee481c` (2026-07-19), bringing Claude Code to **2.1.215** for NixOS hosts. Will deploy to rpi5 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)