### PR TITLE
chore(flake): bump claude-shared for centralized codex plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782080166,
-        "narHash": "sha256-1ilas1xF22+GqHYsUSxl9BQjBtEf99yLJE+h+i8ScR0=",
+        "lastModified": 1784555316,
+        "narHash": "sha256-j6RsVMRAAAHKWzKqiw7Y16bo4R+vZtf5OX1MFyREkrk=",
         "owner": "alexandru-savinov",
         "repo": "claude-shared",
-        "rev": "a517f4ebca606edd9da6268ed96f54c3a9064f6e",
+        "rev": "05ab87fe81d7b50b78886b55eee5946399bc937a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump claude-shared `c15b9bc` → `05ab87f`: ships `codex@openai-codex` (openai/codex-plugin-cc v1.0.6) to all consumers via the shared HM module, merging into `installed_plugins.json` instead of overwriting so rpi5's project-scope plugins stay registered. Will deploy to rpi5 (`rpi5-full`) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)