### PR TITLE
fix(sancta): expose project anchor through home sandbox

### DIFF
--- a/hosts/sancta-choir/sancta-worker.nix
+++ b/hosts/sancta-choir/sancta-worker.nix
@@ -323,7 +323,7 @@ in
         # ── systemd hardening (mirrors openclaw-service.nix) ─────────────────
         NoNewPrivileges = true;
         ProtectSystem = "strict";
-        ProtectHome = true;
+        ProtectHome = "tmpfs";
         # The resumed transcript belongs to the /home/nixos project key. Bind
         # only a dedicated empty anchor into this service's private namespace;
         # never create or change the real host login home.


### PR DESCRIPTION
## Root cause

`ProtectHome=true` makes `/home` untraversable before the worker can reach the selective `/var/lib/sancta/project-anchor:/home/nixos` bind. The relay therefore exits at startup with `EACCES` on `/home/nixos`.

## Fix

Use systemd's `ProtectHome=tmpfs` selective-exposure pattern. Real home contents remain hidden; only the existing read-only empty project anchor is visible at `/home/nixos`.

## Verification

- reproduced on the deployed generation with `EACCES: access '/home/nixos'`
- ephemeral systemd unit with `ProtectHome=tmpfs` can read `/home/nixos`
- the same sandbox cannot see `/home/nixos/.ssh`
- full host evaluation reports `ProtectHome = "tmpfs"`
- repository formatting gate passes