### PR TITLE
fix(sancta-choir): serve sancta's soul skills from choir's own claudeShared build

### DIFF
--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -80,9 +80,19 @@
   # At boot, per-user HM activation must not run before the encrypted soul
   # volume is mounted at ~/.claude — otherwise its symlinks land on the bare
   # underlay dir and are shadowed by the later mount.
+  #
+  # Belt-and-suspenders, mirroring sancta-worker.nix's guard for the same
+  # hazard: `after` only sequences and `requires` only pulls the mount into the
+  # transaction — but a ConditionPathExists-skipped soul-mount counts as
+  # satisfied for Requires=, so on a boot where the LUKS chain doesn't complete
+  # HM would still activate onto the bare, unencrypted dir. The
+  # ConditionPathIsMountPoint check refuses activation unless ~/.claude is
+  # actually a mountpoint, closing that hole (Phase-1 guard #1).
   systemd.services.home-manager-sancta = {
     after = [ "sancta-soul-mount.service" ];
-    wants = [ "sancta-soul-mount.service" ];
+    requires = [ "sancta-soul-mount.service" ];
+    unitConfig.ConditionPathIsMountPoint =
+      toString config.services.sancta-soul-volume.mountPoint;
   };
 
   # Agent tooling on the system PATH so herdr panes (which inherit the

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -61,7 +61,28 @@
     # `herdr` is included so the dedicated herdr user (which runs the herdr
     # server + agent panes) gets the full Claude Code stack — claude CLI, skills,
     # agents, commands — under /var/lib/herdr/.claude, not just root.
-    users = [ "root" "herdr" ];
+    # `sancta` is included so the soul volume's skills/agents/commands are
+    # built and owned by THIS host's home-manager (clone at
+    # /var/lib/sancta/.claude-shared), replacing the 2026-07-21 hand-copied
+    # rpi5 store paths that seeded the migrated soul.
+    users = [ "root" "herdr" "sancta" ];
+  };
+
+  # The claude-shared settings activation rewrites ~/.claude/settings.json
+  # from the merged declarative set; without these keys it would strip the
+  # runtime-chosen model/verbose that the migrated soul carried over from
+  # rpi5 (and that the sancta-worker's resumed session runs with).
+  home-manager.users.sancta.programs.claude-code.extraSettings = {
+    model = "opus[1m]";
+    verbose = true;
+  };
+
+  # At boot, per-user HM activation must not run before the encrypted soul
+  # volume is mounted at ~/.claude — otherwise its symlinks land on the bare
+  # underlay dir and are shadowed by the later mount.
+  systemd.services.home-manager-sancta = {
+    after = [ "sancta-soul-mount.service" ];
+    wants = [ "sancta-soul-mount.service" ];
   };
 
   # Agent tooling on the system PATH so herdr panes (which inherit the


### PR DESCRIPTION
## What

Add `sancta` to sancta-choir's `customModules.claudeShared.users`, so the soul volume's `~/.claude` skills/agents/commands/CLAUDE.md are built and owned by **this host's** home-manager (live clone at `/var/lib/sancta/.claude-shared`), replacing the 2026-07-21 hand-applied fix (nix-copied rpi5 HM store path + hand-rsynced `/home/nixos/.claude-shared` clone) that restored the dangling symlinks the soul migration carried over.

Also:
- `extraSettings = { model = "opus[1m]"; verbose = true; }` for sancta — the claude-shared settings activation rewrites `settings.json` from the declarative set on every activation; without these keys it would strip the runtime-chosen model/verbose the migrated soul (and the armed worker session) runs with.
- Order `home-manager-sancta.service` after `sancta-soul-mount.service` so boot-time HM activation never writes symlinks onto the bare underlay dir that the LUKS soul mount later shadows.

## Verification

- `nix eval .#nixosConfigurations.sancta-choir.config.home-manager.users.sancta.home.homeDirectory` → `"/var/lib/sancta"`
- `home.file` managed skill entries for sancta: brainstorming, council, ralphex, scout, verify-first, yourself (pinned claude-shared rev)
- `extraSettings` evals to `{"model":"opus[1m]","verbose":true}`
- Full `config.system.build.toplevel.drvPath` evals clean

## Deploy notes (attended switch on choir)

First activation collides with the soul's pre-existing unowned symlinks (no `backupFileExtension` on this host): stash the old skill/agent/command/CLAUDE.md symlinks aside immediately before `nixos-rebuild switch`. The soul's `n8n-*` skill symlinks come from an older claude-shared pin and are NOT managed by the current rev — they keep resolving through the hand-copied store path + `/home/nixos/.claude-shared`, so the GC root `/nix/var/nix/gcroots/sancta-soul-hm-files` must stay until they're retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)