### PR TITLE
Phase 2 (HOLD): soul-volume verify service + booted-VM crash-test suite

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -127,6 +127,16 @@ jobs:
             - name: Build hermes-claw (x86_64-linux)
               run: nix build .#nixosConfigurations.hermes-claw.config.system.build.toplevel
 
+            # Gate 0-A: deterministic production-relay crash windows plus a
+            # booted systemd/LUKS test using the real soul/worker modules. Keep
+            # the VM in this disk-cleaned, branch-protected x86 job rather than
+            # the resource-constrained generic flake-check job.
+            - name: Run Sancta relay crash-window tests (x86_64-linux)
+              run: nix build .#checks.x86_64-linux.sancta-membrane -L
+
+            - name: Run Sancta soul-volume VM test (x86_64-linux)
+              run: nix build .#sancta-soul-volume-test -L
+
             # Heavy VM test (#42): builds n8n from source (unfree, never
             # binary-cached) + boots a KVM VM. Runs here — after the
             # free-disk step, with nothing concurrent — because adding it

--- a/docs/plans/2026-07-21-sancta-migration-gate0-runbook.md
+++ b/docs/plans/2026-07-21-sancta-migration-gate0-runbook.md
@@ -1,0 +1,239 @@
+# Sancta migration Gate 0 — pinned-commit E2E runbook
+
+**Status:** PREPARED / NOT AUTHORIZED FOR LIVE EXECUTION
+**Date:** 2026-07-21
+**Last verified:** 2026-07-22
+**Scope:** migration prerequisite for issue #537; no ingestion-membrane implementation
+
+## Verdict and stop conditions
+
+Gate 0 is currently **FAIL / incomplete**. Gate 0-A is the migration proof in Phases 1–5; Gate 0-B is the human-gated aggregate-presence proof in Phase 6. Gate 0-A may run and produce its own PASS/FAIL record while Gate 0-B remains unresolved, but issue #537 implementation stays blocked until both pass and the final composite regression is green.
+
+- PR #538 remains open at `0d2eedaee91aa4e60cfe7ae7c16f83b620ab3e04`.
+- The required exact-source, Home Manager, worker-order, pure-regression, relay-crash, and booted-VM work exists only in the dirty local tree; `tests/sancta-soul-volume.nix` and this runbook are untracked.
+- The VM package derivation evaluates through a `path:` flake, but ordinary Git-flake evaluation cannot see the untracked VM file, and neither the VM nor crash suite has a recorded successful build/run or exact-SHA CI result.
+- No merged `main` commit contains the complete candidate.
+- No attended deploy/reboot, real resumed-Claude round trip, or aggregate-presence E2E has been recorded for that candidate.
+- The aggregate-presence path is docs-only and human-gated; no broker, client, firewall/ACL proof, or test exists.
+
+Stop the active phase immediately if any command fails, any expected value differs, the worktree is dirty at the selected commit, the live host cannot identify the prior generation, console recovery is unavailable, or a secret would enter a log/chat/argv. Unresolved Home Assistant decisions block Phase 6 and overall Gate 0—not the separately recorded migration-only Phases 1–5. Do not treat a skipped unit, empty output, zero-capability test, generic HA operation, or a successful fake-Claude test as a pass.
+
+Deployment, reboot, symlink moves, the billed `/send`, household-presence actions, key/ACL changes, and rollback are Alexandru-authorized steps. Agents may prepare and review evidence only.
+
+## Fixed identifiers and evidence directory
+
+The executor records, without guessing:
+
+- `MIGRATION_SHA`: the exact 40-character commit on `origin/main` containing PR #538's complete source, mount, ordering, and regression fixes;
+- `MIGRATION_TOPLEVEL`: the exact built `sancta-choir` toplevel store path for `MIGRATION_SHA`;
+- `FINAL_GATE_SHA`: the later exact `origin/main` commit containing both Gate 0-A and the authorized Gate 0-B implementation, used for the final composite regression;
+- `PRIOR_SYSTEM`: `/run/current-system` before staging;
+- `PRIOR_GENERATION`: the bootable generation number before staging;
+- `BOOT_ID_BEFORE` and `BOOT_ID_AFTER`;
+- `SESSION_ID`: `666bcb25-8bc5-467a-b603-4eecce495341`, unless a reviewed config change deliberately replaces it; and
+- a fresh local evidence directory containing only redacted outputs, hashes, counts, paths, and pass/fail markers.
+
+Create the evidence directory outside every repository with `umask 077`. Never copy age plaintext, API/OAuth tokens, the membrane Basic password, live household presence, raw replies, or transcript content into evidence. The deliberately harmless allowlisted challenge may be recorded, but all reply and transcript evidence is limited to hashes, byte/record counts, and boolean schema checks.
+
+## Phase 1 — candidate and CI proof (read-only)
+
+1. Fetch refs and verify that `MIGRATION_SHA` is exactly reachable from `origin/main`, not merely a PR head or dirty local tree.
+2. Record local `git status --porcelain=v1`, refs, and any dirty-diff SHA only as non-candidate context. Every migration evaluation/build/deploy must reference immutable `MIGRATION_SHA` or a separately verified clean detached checkout; never evaluate `.#` from the working tree. The deploy candidate itself must be clean.
+3. Verify the candidate contains all Home Manager/mount invariants:
+   - `After=sancta-soul-mount.service`;
+   - `Requires=sancta-soul-mount.service`; and
+   - `ConditionPathIsMountPoint=/var/lib/sancta/.claude`;
+   - armed open/mount units fail rather than condition-skip when the image/mapper is missing;
+   - the mount script verifies the exact mapper source before changing ownership;
+   - a non-remaining `sancta-soul-verify` oneshot rechecks the target, mapper, image, and mounted source for each dependent start transaction;
+   - the worker both follows and requires successful `home-manager-sancta` activation; and
+   - `sancta-membrane` also hard-requires the verified mount.
+4. Verify the pure regression evaluates to `true`:
+
+   ```bash
+   nix eval --json \
+     "github:alexandru-savinov/nixos-config/${MIGRATION_SHA}#checks.x86_64-linux.module-eval.tests.sancta-choir-home-manager-soul-mount-guard"
+   ```
+
+5. Require a booted NixOS VM test, using the production source/mount units and evaluated host wiring, that proves the expected mapper/image boots through Home Manager and the worker. A symlink/noncanonical target, wrong pre-mounted filesystem, wrong existing mapper, or missing image must prevent Home Manager, worker, membrane, and Serve. After a successful start, replace the mount or mapper only inside the disposable VM and prove stop/restart refuses to unmount/close the replacement and reports failure. Inject failure immediately after mapper creation and after mount creation: any leftover must remain unavailable to dependents, be reported explicitly, and be recoverable only after exact ownership/source verification—never guessed cleanup. A failed Home Manager must prevent the worker; the intentional status-only gateway may remain up only if authenticated `/send` returns unavailable with no inbox/quota mutation and no ready marker. A host mount namespace without its own systemd manager is not equivalent.
+6. Require causal production-relay tests for three ambiguous crash windows: after the in-progress marker but before provider spawn, after provider exit but before reply commit, and after reply rename but before cursor save. A build-time test interposer or unreachable test-only hook must deterministically stop at each point and prove the tested relay otherwise hashes to the production source. The first two cases remain operator-blocked with no automatic second spawn; the committed-checkpoint case advances to EOF on restart with exactly one total fake-provider spawn. Pre-seeding a reply is not a causal substitute.
+
+   ```bash
+   nix build \
+     "github:alexandru-savinov/nixos-config/${MIGRATION_SHA}#sancta-soul-volume-test" -L
+   nix build \
+     "github:alexandru-savinov/nixos-config/${MIGRATION_SHA}#checks.x86_64-linux.sancta-membrane" -L
+   ```
+
+7. Record the successful required CI workflow URL, run ID, workflow SHA, job names, and logs for the exact candidate. The x86_64 job must build `sancta-choir` and run both VM/crash suites; success for `0d2eeda` does not validate a later local fix.
+8. Confirm no #537 ingestion-membrane files or behavior are mixed into the migration candidate.
+
+**Gate:** do not proceed unless the complete candidate is on `main`, the candidate tree is clean, all required checks are green, and the exact CI evidence is recorded.
+
+## Phase 2 — attended host preflight (read-only)
+
+Run from an operator-controlled terminal with provider console recovery already open.
+
+1. Record current boot/system state:
+   - `readlink -f /run/current-system`;
+   - `nixos-rebuild list-generations`;
+   - `cat /proc/sys/kernel/random/boot_id`;
+   - `uname -a`; and
+   - `systemctl --failed`.
+2. Record, without content, the current soul boundary:
+   - `findmnt -n -o SOURCE,FSTYPE,OPTIONS --target /var/lib/sancta/.claude`;
+   - `cryptsetup status sancta-soul`;
+   - owner/mode for `/var/lib/sancta`, the mountpoint, and the image; and
+   - status plus unit text for `sancta-soul-open`, `sancta-soul-mount`, `home-manager-sancta`, `sancta-worker`, `sancta-membrane`, and `sancta-membrane-serve`.
+3. Require the mounted source to be the active `/dev/mapper/sancta-soul` backed by `/var/lib/sancta-soul/soul.img`. `ConditionPathIsMountPoint` alone proves only that *some* filesystem is mounted.
+4. Record hashes/counts—not contents—for:
+   - the inbox, replies, cursor, failure marker, and rate-limit files;
+   - every Claude session transcript and specifically `SESSION_ID`;
+   - `/var/lib/sancta/.claude/settings.json`; and
+   - managed skill/agent/command/`CLAUDE.md` symlink targets; and
+   - a metadata/type/mode/owner/hash manifest of every regular file and symlink in the complete writable `/var/lib/sancta` boundary, without recording contents.
+5. Validate every pre-existing inbox/reply JSONL line, final-newline status, closed record schema, checkpoint uniqueness and offset/hash consistency, cursor schema, failure schema, and rate-limit schema before relying on their counts. Confirm the exact session-marker file exists, exactly one resumable transcript matches `SESSION_ID`, the cursor is an integer at inbox EOF, no unresolved failure marker exists, no proceed-classified item is pending, and at least one rolling-day proceed slot remains.
+6. Confirm the credential file exists with the reviewed owner and mode without reading or hashing its plaintext. Record disk, RAM, and swap headroom against reviewed minimums.
+7. Inventory the pre-existing hand-repaired symlinks against the Home Manager manifest and prepare an explicit collision list. Keep the documented `sancta-soul-hm-files` GC root and the older unmanaged `n8n-*` links until a separate migration retires them.
+
+**Gate:** any wrong mapper, non-EOF cursor, unresolved failure, unexpected session count, missing GC root, or unreviewed collision stops the run.
+
+## Phase 3 — build and stage the exact commit (human-authorized)
+
+On `sancta-choir`, build from the immutable GitHub revision with throttling:
+
+```bash
+nixos-rebuild build \
+  --flake "github:alexandru-savinov/nixos-config/${MIGRATION_SHA}#sancta-choir" \
+  --max-jobs 1 --cores 1
+```
+
+Record `readlink -f result` as `MIGRATION_TOPLEVEL`. Inspect the rendered `sancta-soul-open`, `sancta-soul-mount`, `home-manager-sancta`, worker, membrane, and Serve units in `MIGRATION_TOPLEVEL` and recheck their source, condition, and dependency invariants. Compare a CI store path only if CI published an authenticated `outPath`/`drvPath` artifact for this exact commit; job success alone supplies no path to compare.
+
+Before the final snapshot or any symlink move, freeze without interrupting paid work:
+
+1. Stop only `sancta-membrane-serve.service`, require HTTPS port 8743 absent, and record—but do not alter—the reviewed baseline of unrelated Serve routes.
+2. Wait at least 30 seconds, exceeding the gateway's 15-second request plus 10-second membrane bounds, then require two stable inbox/rate snapshots. If those code bounds differ in `MIGRATION_SHA`, recompute and review the wait instead of copying 30 seconds.
+3. Let the worker drain naturally until the cursor is at EOF and no in-progress/failure marker remains. Never stop it merely because a timeout elapsed.
+4. Only then stop `sancta-membrane` and `sancta-worker` and repeat the complete Phase 2 manifest as the authoritative pre-reboot snapshot.
+
+While ingress remains frozen, Alexandru may move only the exact colliding managed symlinks from the reviewed Phase 2 list into a timestamped backup directory on the encrypted soul. Do not use a broad glob, touch the unmanaged `n8n-*` links, or remove the retained GC root.
+
+After explicit confirmation, stage for the next boot without activating in the current session:
+
+```bash
+sudo nixos-rebuild boot \
+  --flake "github:alexandru-savinov/nixos-config/${MIGRATION_SHA}#sancta-choir" \
+  --max-jobs 1 --cores 1
+```
+
+Record the new generation and the legacy prior generation, but do not label that prior generation safe merely because it is selectable; prove the rescue/emergency path required by Rollback is available. Do not use an unthrottled build, first-time LUKS formatting, or an unattended `switch`.
+
+If staging is cancelled or fails before reboot, restore/recreate only the exact moved links from the collision manifest, re-verify the expected mapper/image/mount, then restart the old worker, membrane, and Serve in that safe order. Require cursor/ready/quota state and the unrelated Serve-route baseline to match the frozen snapshot. Do not leave the host silently frozen or links displaced.
+
+## Phase 4 — reboot and boot-order proof (human-authorized)
+
+Reboot only with console access and the prior generation recorded. After SSH returns:
+
+1. Require a new boot ID and `readlink -f /run/current-system == MIGRATION_TOPLEVEL`.
+2. Require no unexpected failed units.
+3. Prove the healthy-boot order `sancta-soul-open` → `sancta-soul-mount` → exact-source verifier → successful `home-manager-sancta` → worker readiness → membrane/Serve acceptance. For the open/mount/verifier/Home Manager/Serve oneshots require `Result=success`, `ConditionResult=yes`, and the applicable monotonic start/finish inequalities. For the long-running worker and membrane require `ActiveState=active`, `SubState=running`, nonzero `MainPID`, expected `NRestarts`, start timestamps, the worker ready marker/status, and proof that no request was accepted before readiness. `After=` orders start jobs, not application readiness. Retain critical-chain, `systemctl show`, and this-boot journal evidence as supporting data rather than treating their presence as an assertion.
+4. Re-run `findmnt` and `cryptsetup status`; prove the exact mapper/image relationship. The wrong-source negative belongs in the booted NixOS VM from Phase 1—never replace or unmount the live soul and never substitute a host mount namespace for the systemd E2E.
+5. Prove the hidden bare underlay stayed empty using a reviewed private-namespace procedure that non-recursively bind-mounts the root filesystem, remounts that bind read-only, proves the inspected path's source is the root filesystem rather than `sancta-soul`, and then asserts the hidden directory is empty. Never use `--rbind` and never unmount the live soul.
+6. Require Home Manager success and verify the host-owned `/var/lib/sancta/.claude-shared` clone plus managed skill/agent/command/`CLAUDE.md` links resolve. Confirm `model = "opus[1m]"` and `verbose = true` without printing unrelated settings.
+7. Confirm `SESSION_ID`, the transcript hashes/counts, inbox/replies/cursor state, and the retained `n8n-*` compatibility links match preflight expectations.
+8. Confirm the worker remains `--safe-mode`, `--strict-mcp-config`, empty MCP, `Read,Grep,Glob`, and a `2.00` per-turn budget cap.
+9. Confirm Tailscale Serve exposes exactly the reviewed membrane route on HTTPS port 8743, the previously recorded unrelated-route baseline is unchanged, and the gateway reports the worker ready. Do not send a message yet.
+
+**Gate:** stop and roll back on a wrong toplevel, wrong mount source, underlay write, failed Home Manager activation, broken links, missing session, cursor drift, unexpected transcript mutation, widened tool/MCP surface, or unready gateway.
+
+## Phase 5 — one authenticated real resumed turn (human-authorized and billed)
+
+This phase deliberately spends at most the configured `2.00` USD cap and consumes one of the three rolling daily proceed slots.
+
+1. From the operator terminal, generate a unique harmless challenge consisting of `hello` followed immediately by a random 64-character `!`/`?` suffix. This remains inside `comm-membrane`'s exact trivial allowlist; a nonce-echo instruction would escalate and can never exercise the worker. Record the challenge and its SHA-256, but place no response text in evidence and do not require the model to echo it.
+2. Capture pre-send hashes, byte sizes, JSONL counts, cursor offset, failure-marker state, the valid rolling-window quota set, all session transcript hashes, the last committed checkpoint set, and the complete `/var/lib/sancta` metadata/hash manifest.
+3. Discover the exact Serve URL from the live `tailscale serve status`; do not guess a hostname. Send exactly one HTTPS `POST /send` with:
+   - the authenticated Tailscale user path;
+   - interactive `curl --user alexandru` password prompting so the secret never appears in argv/history;
+   - `X-Sancta-Request: send`;
+   - `Content-Type: application/json`; and
+   - the allowlisted challenge as the sole message.
+4. Require HTTP success and membrane decision `proceed`. Do not retry on timeout or ambiguity; inspect state first to avoid double spend.
+5. Poll with a reviewed on-host metadata probe that emits only hashes, counts, offsets, and booleans until exactly one new worker reply is committed or the reviewed timeout expires. Do not fetch `/thread` or `/thread-merged` as evidence, because neither provides the required checkpoint proof without exposing content. Never use `curl -v`, tracing, shell xtrace, or a redirect that could retain Basic credentials, and never issue a second send.
+6. Require all of the following:
+   - inbox grew by exactly one newline-terminated, valid-JSON proceed record;
+   - replies grew by exactly one `source:sancta-worker` record;
+   - that record contains non-empty text, one unique `inbox_checkpoint`, and the correct old/new byte offsets;
+   - `inbox_hash` is SHA-256 of the exact new serialized inbox JSONL line excluding its newline, and `inbox_checkpoint` equals `<old_offset>:<entry.ts>:<line_hash>`;
+   - cursor equals inbox EOF;
+   - failure marker is absent;
+   - an on-host redacting parser proves the challenge hash occurs exactly once as the new user record in `SESSION_ID` and is causally followed by exactly one assistant/result record from that resumed invocation;
+   - only the expected transcript changes, its logical record delta matches one resumed invocation, and every other legitimately mutable Claude metadata path is explicitly allowlisted;
+   - authoritative redacted provider-result evidence proves one invocation and `0 < total_cost_usd <= 2.00` (or an equally authoritative usage field if billing mode reports no per-call cost);
+   - the rate-limit file remains mode `0600`, contains no plaintext login, and its prior valid rolling-window set gains exactly one timestamp inside the request interval for the hashed identity;
+   - no unexpected regular file or symlink outside the encrypted `.claude` allowlist is new or changed anywhere under writable `/var/lib/sancta`; and
+   - no credential, unrelated content, or raw transcript entered evidence/journal.
+7. Restart only `sancta-worker`, wait beyond one polling interval, and prove inbox/reply/cursor/transcript/quota hashes and the full writable-boundary manifest remain unchanged. Label this narrowly as clean-restart/no-new-work durability; the causal crash-window guarantees come from the exact-candidate CI suite in Phase 1.
+
+Any ambiguous HTTP result, Claude failure, reply-commit failure, cursor retention, duplicate reply/checkpoint, second transcript mutation, or budget uncertainty is a FAIL requiring operator review—not an automatic retry. The supported guarantee is no automatic replay after ambiguity; never claim exactly-once model execution without provider idempotency and stronger crash-durable transactions.
+
+Record Gate 0-A as PASS, FAIL-ROLLED-BACK, or NOT-RUN. A Gate 0-A PASS is reusable migration evidence, not an overall Gate 0 PASS while Phase 6 remains unresolved.
+
+## Phase 6 — home-side and aggregate-presence prerequisite
+
+This phase is **blocked by design/consent, not executable yet**. Before implementation, Alexandru must resolve the gates recorded in `2026-07-09-ha-plan-reconciliation.md`, including household assent, wall versus tripwire, broker host/key surgery, source-side consent/apex controls, uniform-null privacy, latency, and standing CI/probe/witness controls. That authoritative plan must also name the consumer host, exact ephemeral action and default/null behavior, downstream protocol and persistence policy, fixed normalization deadline/tolerance, broker identity/state ownership, and the per-UID network enforcement that lets the consumer—but neither `sancta-worker` nor ad-hoc `sancta` processes—reach the broker. Host-level tailnet ACLs alone cannot distinguish Unix UIDs.
+
+The only acceptable V1 capability is Plane A aggregate presence:
+
+- HA on `rpi5-full` computes a human-authored, non-denominated allowlist OR;
+- unknown/unavailable/device-class drift is excluded and all unavailable becomes null;
+- 600-second debounce, a fixed 300-second push cadence, 660-second stale TTL, and at most the single explicitly specified restart-sync exception from the authoritative plan;
+- an exact versioned HMAC algorithm/domain separator/canonical-byte/timestamp protocol; every authenticated timestamp is within 90 seconds and strictly greater than a broker-owned, worker-inaccessible persisted anti-replay high-water mark;
+- TTL uses monotonic receipt time so wall-clock rollback cannot extend freshness;
+- broker holds no HA token, URL, client, history, or egress;
+- the only consumer/read surface is parameterless `GET /presence`; a separate authenticated HA-only ingest exists and is unreachable from choir;
+- fresh response is `{someone_home: bool, ts}`;
+- an accepted signed null advances the durable high-water mark, immediately clears any prior good value, and serves exactly `{"someone_home":null}` without `ts`;
+- fresh boot/restart serves null until a newer authenticated post-boot push, without discarding the persisted replay high-water mark;
+- a rejected push never erases or refreshes a still-fresh prior good value; and
+- every no-value body is byte-identical `{"someone_home":null}`, with status, headers, timing, DNS, connection, and transport failures normalized locally rather than revealing the reason.
+
+Required proof has three parts:
+
+1. A VM/fixture test proves aggregation, scheduled cadence plus the sole restart-sync exception, debounce/staleness, HMAC/replay/reorder denial, latest-value-only storage, uniform full-observable null within the fixed deadline, and no value logging. It causally tests bad-on-empty → null, bad-after-good → unchanged prior good only until its original TTL, good → accepted null, boot → accepted null, null replay/reorder rejection, and wall-clock rollback.
+2. Broker state uses no-follow/no-replace temporary writes or an equivalent transaction, file and directory `fsync`, and acknowledgement only after the high-water/value transaction is durable. Kill after every persistence stage and reboot: a persistence failure neither exposes nor acknowledges the new value; the old timestamp remains rejected, served state is null after restart, and only a newer signed push restores a value.
+3. A separate fixed-purpose consumer UID—not `sancta-worker`—has no writable persistent filesystem, no value-bearing stdout/stderr/journal, and no unapproved persistent downstream action state. The authoritative plan treats the exact approved ephemeral action as an explicit declassification and proves it cannot preserve the raw bit/timestamp or join it with other signals. From the consumer's actual mount/network/cgroup namespaces the fixed read and action succeed, while query/body/entity/path/method variations, broker ingest, history, Plane B, direct HA REST/WebSocket/`:8123`, alternate sockets/proxies, and unrelated routes fail. Cross-UID bypass attempts from the worker and ad-hoc `sancta` fail at the named local enforcement layer.
+4. Alexandru separately witnesses live HA → broker tracking and revoke/veto → null, recording pass/fail only. Agents never inspect household presence.
+5. Select `FINAL_GATE_SHA` only after the authorized HA implementation is on `main` with green CI. Build and boot its exact toplevel, repeat the Phase 1 VM/crash suites and Phase 4 live migration assertions, then repeat Phase 5 only with separate human authorization for the billed call. Overall Gate 0 cannot reuse stale live evidence from `MIGRATION_SHA` as proof that the final combined commit did not regress migration.
+
+Static configuration is insufficient. From the untrusted worker and consumer namespaces, the negative proof must separately record network/ACL denial and target authorized-key absence for ordinary SSH and Tailscale SSH paths to both the RPi and broker identities; a generic SSH `Permission denied` is not proof of pre-auth network denial. Operator management access may remain outside those namespaces. The RPi `nixos` account currently has broad LLAT-backed HA config; a transitive shell would defeat the boundary. Home-side HA execution may remain on RPi, but broad RPi tooling must never become reachable from the VPS worker.
+
+Until this phase is implemented, authorized, and green, Gate 0 remains FAIL and issue #537 stays planning-only.
+
+## Evidence manifest and review
+
+The redacted manifest records:
+
+- deployed repo commit/tree SHA, clean-source proof, and `flake.lock` revisions; any local dirty-diff hash is labeled non-candidate context and never substituted for those identifiers;
+- CI workflow SHA/run URL/jobs and exact test derivations;
+- `MIGRATION_SHA`, `MIGRATION_TOPLEVEL`, `FINAL_GATE_SHA` when selected, `PRIOR_SYSTEM`, generation numbers, boot IDs, and timestamps;
+- unit-file hashes, MainPIDs, UID/GID/groups, namespace IDs, mountinfo, mapper/image relationship, and critical-chain timestamps;
+- before/after hashes, sizes, counts, offsets, checkpoint IDs, and the harmless unique challenge;
+- the HA fixture/live pass/fail matrix without household values; and
+- every deviation, failure, rollback, and persistent test artifact.
+
+A second reviewer must reproduce the count/hash assertions and sign the PASS/FAIL conclusion before issue #537 implementation can begin.
+
+## Rollback
+
+Rollback is code/generation rollback, never deletion or rewriting of soul data:
+
+1. Treat `PRIOR_GENERATION` as legacy and unsafe by default: it lacks the new wrong-source, condition-skip, and Home-Manager/worker protections. A mapper/image/mount failure must enter rescue/emergency recovery or a prebuilt fail-closed recovery specialization that disables Home Manager, worker, membrane, and Serve; never normal-boot the old generation into that fault.
+2. A normal prior-generation rollback is allowed only after rescue-console verification of the exact healthy mapper/image/mount and with the Sancta session marker disarmed. On a reachable non-storage failure, stop Serve ingress, drain safely as in Phase 3, stage with `sudo nixos-rebuild boot --rollback`, and prove the target resolves to `PRIOR_SYSTEM` before a supervised reboot.
+3. Restore or recreate only the exact managed symlinks moved in Phase 3 as required by the prior generation, using the recorded collision manifest; do not touch the unmanaged `n8n-*` links.
+4. Re-run mapper, session, cursor, transcript, complete writable-boundary, link, and service checks before rearming the session marker or ingress.
+5. Preserve failure markers, inbox/reply records, journals, hashes, and moved-link backup for diagnosis. Do not clear a failure marker or retry a turn until checkpoint/transcript/billing are reconciled.
+6. Do not remove the soul image, close/format/recreate LUKS, delete migration history, or discard the retained GC root as “rollback.”
+
+Record the final state as PASS, FAIL-ROLLED-BACK, or NOT-RUN. There is no partial PASS.

--- a/flake.nix
+++ b/flake.nix
@@ -312,6 +312,11 @@
           # locally with: nix build .#n8n-declarative-test
           n8n-declarative-test = import ./tests/n8n-declarative.nix { inherit pkgs self; };
 
+          # Booted systemd/LUKS proof for the Sancta soul. Kept as a package so
+          # the resource-constrained generic flake-check job does not boot a
+          # second VM; the branch-protected x86 job builds it explicitly.
+          sancta-soul-volume-test = import ./tests/sancta-soul-volume.nix { inherit pkgs; };
+
           # Fresh system installation script
           install = pkgs.writeShellApplication {
             name = "nixos-install";
@@ -388,14 +393,12 @@
           # cursor, successful turns commit once, and truncation never replays.
           sancta-membrane = import ./tests/sancta-membrane.nix { inherit pkgs; };
 
-          # NOTE: the declarative n8n VM test (#42) deliberately lives under
-          # packages.<system>.n8n-declarative-test, NOT here. `nix flake
-          # check` builds every check inside the resource-constrained
-          # "Check Flake & Formatting" CI job — adding the n8n source build
-          # (unfree, never binary-cached) plus a second KVM VM there killed
-          # the runner with a shutdown signal. CI runs the test as an
-          # explicit step in the "Build x86_64 Configs" job instead, which
-          # frees ~30GB disk first and runs nothing concurrently.
+          # NOTE: booted VM tests deliberately live under packages, NOT here.
+          # `nix flake check` builds every check inside the resource-constrained
+          # "Check Flake & Formatting" CI job; adding the n8n source build
+          # (unfree, never binary-cached) plus a second KVM VM previously killed
+          # that runner with a shutdown signal. CI runs both VM packages as
+          # explicit steps in the disk-cleaned "Build x86_64 Configs" job.
         };
 
       # aarch64-linux checks: only the architecture-independent, cheap

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -89,8 +89,14 @@
   # ConditionPathIsMountPoint check refuses activation unless ~/.claude is
   # actually a mountpoint, closing that hole (Phase-1 guard #1).
   systemd.services.home-manager-sancta = {
-    after = [ "sancta-soul-mount.service" ];
-    requires = [ "sancta-soul-mount.service" ];
+    after = [
+      "sancta-soul-mount.service"
+      "sancta-soul-verify.service"
+    ];
+    requires = [
+      "sancta-soul-mount.service"
+      "sancta-soul-verify.service"
+    ];
     unitConfig.ConditionPathIsMountPoint =
       toString config.services.sancta-soul-volume.mountPoint;
   };

--- a/hosts/sancta-choir/membrane/relay.mjs
+++ b/hosts/sancta-choir/membrane/relay.mjs
@@ -13,8 +13,26 @@ const claudeBin = process.env.CLAUDE_BIN;
 const claudeArgs = JSON.parse(process.env.CLAUDE_ARGS_JSON);
 const projectDir = process.env.SANCTA_PROJECT_DIR;
 
+// Deterministic process-crash interposer for the Nix test only. The production
+// unit never sets these variables (locked by module-eval), so this cannot pause
+// or alter the managed relay. A manually launched same-UID copy can affect only
+// the paths that caller already selected and owns.
+const testFaultPoint = process.env.SANCTA_RELAY_TEST_FAULT_POINT || "";
+const testFaultReady = process.env.SANCTA_RELAY_TEST_FAULT_READY || "";
+const testFaultAck = process.env.SANCTA_RELAY_TEST_FAULT_ACK || "";
+const TEST_FAULT_ACK = "sancta-relay-crash-window-v1";
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 const log = message => process.stdout.write(new Date().toISOString() + " " + message + "\n");
+
+function testFault(point) {
+  if (testFaultPoint !== point) return;
+  if (testFaultAck !== TEST_FAULT_ACK || !testFaultReady) {
+    throw new Error("invalid relay test-fault configuration");
+  }
+  fs.writeFileSync(testFaultReady, point + "\n", { mode: 0o600 });
+  process.kill(process.pid, "SIGSTOP");
+}
 
 function validateRuntime() {
   const required = { inbox, replies, cursorFile, failureFile, claudeBin, projectDir };
@@ -194,6 +212,7 @@ async function runTurn(message, inboxTs, checkpoint, inboxOffset, nextOffset) {
 
   const text = (resultText || assistantText).trim();
   if (!text) throw new Error("Claude completed without assistant text");
+  testFault("after-provider-exit");
   const reply = {
     ts: new Date().toISOString(),
     from: "sancta",
@@ -269,7 +288,9 @@ for (;;) {
       try {
         await saveFailure(offset, entry.ts, "Claude turn in progress");
         unresolvedFailure = { offset, inbox_ts: entry.ts || null, reason: "Claude turn in progress" };
+        testFault("after-in-progress-marker");
         await runTurn(entry.message, entry.ts, checkpoint, offset, offset + bytes);
+        testFault("after-reply-commit");
         committedCheckpoints.add(checkpoint.key);
         await saveCursor(offset + bytes);
       } catch (error) {

--- a/hosts/sancta-choir/sancta-worker.nix
+++ b/hosts/sancta-choir/sancta-worker.nix
@@ -220,12 +220,22 @@ in
         # The soul volume (~/.claude) must be mounted before the worker starts
         # so CLAUDE_CONFIG_DIR lands on encrypted storage, not the bare dir.
         "sancta-soul-mount.service"
+        # Revalidate the exact mapper/image/source for this start transaction;
+        # the long-lived mount oneshot may already be active.
+        "sancta-soul-verify.service"
+        # Host-owned skills/settings must finish activating on that mount before
+        # the resumed session reads them.
+        "home-manager-sancta.service"
       ];
       wants = [ "network-online.target" ];
       # Encryption integrity: pull in + order after the soul mount so an armed
       # worker never runs onto the bare (unencrypted) ~/.claude dir. (`after`
       # alone is only ordering; `requires` also brings the mount into the txn.)
-      requires = [ "sancta-soul-mount.service" ];
+      requires = [
+        "sancta-soul-mount.service"
+        "sancta-soul-verify.service"
+        "home-manager-sancta.service"
+      ];
       # INERT-BY-DEFAULT: the unit is skipped unless a session marker exists.
       # With session=null the guard points at a marker path that is NEVER
       # created (the literal ".__no-session__"), so even a manual `systemctl
@@ -338,7 +348,17 @@ in
     systemd.services.sancta-membrane = {
       description = "Sancta tailnet membrane gateway";
       wantedBy = lib.optional (cfg.session != null) "multi-user.target";
-      after = [ "sancta-worker.service" ];
+      after = [
+        "sancta-soul-mount.service"
+        "sancta-soul-verify.service"
+        "sancta-worker.service"
+      ];
+      # The gateway writes inbox/rate-limit state under the encrypted index.
+      # Its soft worker dependency must not let it run on a wrong/bare mount.
+      requires = [
+        "sancta-soul-mount.service"
+        "sancta-soul-verify.service"
+      ];
       # Keep history and status available after a one-shot worker failure. The
       # HTTP gateway rejects new messages unless the worker readiness file is
       # present, so this soft dependency cannot grow an unattended queue.

--- a/hosts/sancta-choir/soul-volume.nix
+++ b/hosts/sancta-choir/soul-volume.nix
@@ -3,9 +3,11 @@
 # ══════════════════════════════════════════════════════════════════════════
 # STAGING NOTE (Sancta→sancta-choir migration): AUTHORED first, deployed via
 # the normal PR → CI → main → herdr-deploy path. Merging the PR is fine and
-# expected; what must NOT happen from this repo alone is ARMING — the loopback
-# image is created by hand and the module stays a no-op until it exists
-# (ConditionPathExists). No real key material is written by this repo.
+# expected; what must NOT happen from this repo alone is first-time creation —
+# the loopback image is created by hand and the units remain absent until a key
+# is wired. Once armed, a missing/wrong image fails closed and is never created,
+# truncated, formatted, or replaced by this module. No real key material is
+# written by this repo.
 # ══════════════════════════════════════════════════════════════════════════
 #
 # WHY LOOPBACK-FILE LUKS (not disko / not re-imaging):
@@ -16,7 +18,7 @@
 # root — the least-destructive dedicated-encrypted-volume mechanism that
 # evaluates cleanly and needs no disk surgery. gocryptfs was the alternative
 # (no fixed-size preallocation, per-file overhead) but LUKS gives a real block
-# device + one clean fscrypt boundary and reuses the LUKS idioms already in
+# device + one clean dm-crypt boundary and reuses the LUKS idioms already in
 # this repo (sancta-claw / sancta-core).
 #
 # ── KEY DELIVERY (HIS-HAND — no real key in this repo) ─────────────────────
@@ -36,10 +38,135 @@
 
 let
   cfg = config.services.sancta-soul-volume;
+  mapperPath = "/dev/mapper/${cfg.mapperName}";
+  testFaultAck = "sancta-soul-crash-window-v1";
+
+  # Deterministic booted-VM fault interposer. Production units do not set
+  # either environment variable, and module-eval locks that invariant. The
+  # control file lets one disposable VM exercise multiple causal windows.
+  maybeInjectTestFault = point: ''
+    if [ "''${SANCTA_SOUL_TEST_FAULT_ACK:-}" = ${lib.escapeShellArg testFaultAck} ] \
+      && [ -n "''${SANCTA_SOUL_TEST_FAULT_FILE:-}" ] \
+      && [ -f "''${SANCTA_SOUL_TEST_FAULT_FILE:-}" ] \
+      && [ "$(${pkgs.coreutils}/bin/cat -- \
+        "''${SANCTA_SOUL_TEST_FAULT_FILE}")" = ${lib.escapeShellArg point} ]; then
+      echo "TEST ONLY: injected soul-volume fault at ${point}" >&2
+      exit 97
+    fi
+  '';
+
+  verifyImageTarget = pkgs.writeShellScript "sancta-soul-verify-image-target" ''
+    set -euo pipefail
+
+    if [ -L ${lib.escapeShellArg (toString cfg.imagePath)} ] \
+      || [ ! -f ${lib.escapeShellArg (toString cfg.imagePath)} ]; then
+      echo "soul image must be an existing non-symlink regular file: ${cfg.imagePath}" >&2
+      exit 1
+    fi
+    actual_image="$(${pkgs.coreutils}/bin/readlink -f -- \
+      ${lib.escapeShellArg (toString cfg.imagePath)})"
+    if [ "$actual_image" != ${lib.escapeShellArg (toString cfg.imagePath)} ]; then
+      echo "refusing non-canonical soul image path: ${cfg.imagePath}" >&2
+      exit 1
+    fi
+  '';
+
+  verifyMountTarget = pkgs.writeShellScript "sancta-soul-verify-mount-target" ''
+    set -euo pipefail
+
+    if [ -L ${lib.escapeShellArg (toString cfg.mountPoint)} ] \
+      || [ ! -d ${lib.escapeShellArg (toString cfg.mountPoint)} ]; then
+      echo "soul mount target must be an existing non-symlink directory: ${cfg.mountPoint}" >&2
+      exit 1
+    fi
+    actual_target="$(${pkgs.coreutils}/bin/readlink -f -- \
+      ${lib.escapeShellArg (toString cfg.mountPoint)})"
+    if [ "$actual_target" != ${lib.escapeShellArg (toString cfg.mountPoint)} ]; then
+      echo "refusing non-canonical soul mount target: ${cfg.mountPoint}" >&2
+      exit 1
+    fi
+  '';
+
+  verifyMapper = pkgs.writeShellScript "sancta-soul-verify-mapper" ''
+    set -euo pipefail
+    export LC_ALL=C
+
+    ${verifyImageTarget}
+    if [ ! -e ${lib.escapeShellArg mapperPath} ]; then
+      echo "expected mapper ${mapperPath} is missing" >&2
+      exit 1
+    fi
+
+    expected_image="$(${pkgs.coreutils}/bin/readlink -f -- \
+      ${lib.escapeShellArg (toString cfg.imagePath)})"
+    mapper_status="$(${pkgs.cryptsetup}/bin/cryptsetup status \
+      ${lib.escapeShellArg cfg.mapperName})" || {
+      echo "unable to inspect mapper ${cfg.mapperName}" >&2
+      exit 1
+    }
+    mapper_devices="$(printf '%s\n' "$mapper_status" \
+      | ${pkgs.gawk}/bin/awk '$1 == "device:" { print $2 }')"
+    mapper_device_count="$(printf '%s\n' "$mapper_devices" \
+      | ${pkgs.gawk}/bin/awk 'NF { count++ } END { print count + 0 }')"
+    if [ "$mapper_device_count" -ne 1 ]; then
+      echo "mapper ${cfg.mapperName} must report exactly one backing device" >&2
+      exit 1
+    fi
+    mapper_device="$(printf '%s\n' "$mapper_devices" \
+      | ${pkgs.gawk}/bin/awk 'NF { print; exit }')"
+    backing_files="$(${pkgs.util-linux}/bin/losetup \
+      --noheadings --raw --output BACK-FILE -- "$mapper_device" \
+      2>/dev/null || true)"
+    backing_file_count="$(printf '%s\n' "$backing_files" \
+      | ${pkgs.gawk}/bin/awk 'NF { count++ } END { print count + 0 }')"
+    if [ "$backing_file_count" -ne 1 ]; then
+      echo "mapper ${cfg.mapperName} must resolve to exactly one loopback file" >&2
+      exit 1
+    fi
+    backing_file="$(printf '%s\n' "$backing_files" \
+      | ${pkgs.gawk}/bin/awk 'NF { print; exit }')"
+    actual_image="$(${pkgs.coreutils}/bin/readlink -f -- \
+      "$backing_file" 2>/dev/null || true)"
+    if [ -z "$actual_image" ] || [ "$actual_image" != "$expected_image" ]; then
+      echo "refusing unexpected mapper ${cfg.mapperName} backing" >&2
+      exit 1
+    fi
+  '';
+
+  verifyMount = pkgs.writeShellScript "sancta-soul-verify-mount" ''
+    set -euo pipefail
+
+    ${verifyMountTarget}
+    ${verifyMapper}
+    if ! ${pkgs.util-linux}/bin/mountpoint -q \
+      ${lib.escapeShellArg (toString cfg.mountPoint)}; then
+      echo "expected mountpoint ${cfg.mountPoint} is not mounted" >&2
+      exit 1
+    fi
+    expected_source="$(${pkgs.coreutils}/bin/readlink -f -- \
+      ${lib.escapeShellArg mapperPath})"
+    source_output="$(${pkgs.util-linux}/bin/findmnt -rn -o SOURCE \
+      --mountpoint ${lib.escapeShellArg (toString cfg.mountPoint)})" || {
+      echo "unable to inspect mounted source at ${cfg.mountPoint}" >&2
+      exit 1
+    }
+    source_count="$(printf '%s\n' "$source_output" \
+      | ${pkgs.gawk}/bin/awk 'NF { count++ } END { print count + 0 }')"
+    if [ "$source_count" -ne 1 ]; then
+      echo "expected exactly one mounted source at ${cfg.mountPoint}" >&2
+      exit 1
+    fi
+    actual_source="$(${pkgs.coreutils}/bin/readlink -f -- \
+      "$source_output" 2>/dev/null || true)"
+    if [ -z "$actual_source" ] || [ "$actual_source" != "$expected_source" ]; then
+      echo "refusing unexpected mounted source at ${cfg.mountPoint}" >&2
+      exit 1
+    fi
+  '';
 in
 {
   options.services.sancta-soul-volume = {
-    enable = lib.mkEnableOption "sancta-choir encrypted soul volume (LUKS-on-loopback) — STUB";
+    enable = lib.mkEnableOption "sancta-choir encrypted soul volume (LUKS-on-loopback)";
 
     imagePath = lib.mkOption {
       type = lib.types.path;
@@ -47,9 +174,9 @@ in
       description = ''
         Path to the LUKS2 loopback container file on the existing ext4 root.
         HIS-HAND: created ONCE, out of band, by Alexandru (see init commands).
-        This module never creates or truncates it — it only opens + mounts it,
-        and only if it already exists (ConditionPathExists), so a deploy on a
-        box where the image is missing is a no-op, never destructive.
+        This module never creates or truncates it — it only opens + mounts it.
+        Once a key is wired, a missing image fails the unit and its dependents
+        without creating, replacing, or formatting anything.
       '';
     };
 
@@ -126,64 +253,70 @@ in
     ];
 
     # ── OPEN: cryptsetup luksOpen the loopback image → /dev/mapper/<name> ────
-    # INERT-BY-DEFAULT: skipped unless BOTH the image exists AND a key is wired.
-    # Never formats — luksOpen on a non-LUKS or missing file just fails cleanly
-    # (and ConditionPathExists guards it), so this can NEVER wipe the root.
+    # INERT-BY-DEFAULT: the unit is absent until a key is wired. Once armed, a
+    # missing image or mismatched pre-existing mapper fails loudly so dependents
+    # cannot mistake another device for the soul. This service never formats.
     systemd.services.sancta-soul-open = lib.mkIf (cfg.keyFile != null) {
-      description = "Open sancta-choir encrypted soul volume (LUKS loopback) — STUB";
+      description = "Open sancta-choir encrypted soul volume (LUKS loopback)";
       after = [ "local-fs.target" ];
       before = [ "sancta-soul-mount.service" ];
       requiredBy = [ "sancta-soul-mount.service" ];
-      unitConfig.ConditionPathExists = cfg.imagePath;
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
         ExecStart = pkgs.writeShellScript "sancta-soul-open" ''
           set -euo pipefail
-          # Crash-recovery: a mapper left over from an unclean shutdown is NOT
-          # trusted blindly — verify it is backed by OUR image (cryptsetup
-          # status prints the backing loop file); otherwise close + reopen.
-          if [ -e /dev/mapper/${cfg.mapperName} ]; then
-            if ! ${pkgs.cryptsetup}/bin/cryptsetup status ${cfg.mapperName} \
-                 | grep -qF ${lib.escapeShellArg (toString cfg.imagePath)}; then
-              echo "stale mapper ${cfg.mapperName} not backed by our image; reopening" >&2
-              ${pkgs.cryptsetup}/bin/cryptsetup luksClose ${cfg.mapperName} || true
-            fi
+
+          ${verifyImageTarget}
+
+          # Crash-recovery: never close or reuse an unexpected live mapper.
+          # Failing requires explicit operator review and cannot disrupt an
+          # unrelated mapping that happens to have the configured name.
+          if [ -e ${lib.escapeShellArg mapperPath} ]; then
+            ${verifyMapper}
           fi
-          if [ ! -e /dev/mapper/${cfg.mapperName} ]; then
+          if [ ! -e ${lib.escapeShellArg mapperPath} ]; then
             ${pkgs.cryptsetup}/bin/cryptsetup luksOpen \
               --key-file ${lib.escapeShellArg (toString cfg.keyFile)} \
-              ${lib.escapeShellArg (toString cfg.imagePath)} ${cfg.mapperName}
+              ${lib.escapeShellArg (toString cfg.imagePath)} \
+              ${lib.escapeShellArg cfg.mapperName}
+            ${maybeInjectTestFault "after-mapper-open"}
           fi
+          ${verifyMapper}
         '';
         ExecStop = pkgs.writeShellScript "sancta-soul-close" ''
           set -euo pipefail
-          ${pkgs.cryptsetup}/bin/cryptsetup luksClose ${cfg.mapperName} || true
-          # Defensive: cryptsetup auto-attaches a loop device to back a file-based
-          # LUKS container; older cryptsetup/util-linux may leave it attached after
-          # close. Detach any loop still backing the image so open/close cycles
-          # don't leak loop minors or leave a stale device across restarts.
-          for dev in $(${pkgs.util-linux}/bin/losetup -j ${lib.escapeShellArg (toString cfg.imagePath)} -O NAME -n 2>/dev/null || true); do
-            ${pkgs.util-linux}/bin/losetup -d "$dev" 2>/dev/null || true
-          done
+          if [ ! -e ${lib.escapeShellArg mapperPath} ]; then
+            exit 0
+          fi
+          # Never close a mapping with the same name unless it still resolves
+          # to the configured loopback image.
+          ${verifyMapper}
+          ${pkgs.cryptsetup}/bin/cryptsetup luksClose \
+            ${lib.escapeShellArg cfg.mapperName}
+          # cryptsetup owns the loop it auto-attached and is responsible for
+          # releasing it. Never detach `losetup -j image` results here: another
+          # loop may legitimately reference the same file, and guessing during
+          # teardown is more dangerous than surfacing a leaked loop for review.
         '';
       };
     };
 
     # ── MOUNT: /dev/mapper/<name> → ~/.claude ───────────────────────────────
-    # A systemd mount unit (not fileSystems.*) because the backing device is a
+    # A systemd oneshot service (not fileSystems.*) because the backing device is a
     # dynamically-opened mapper, not a boot-time-known disk — keeping it out of
     # fileSystems.* means a missing/locked volume never blocks boot.
     systemd.services.sancta-soul-mount = lib.mkIf (cfg.keyFile != null) {
-      description = "Mount sancta-choir soul volume at ~/.claude — STUB";
+      description = "Mount sancta-choir soul volume at ~/.claude";
       after = [ "sancta-soul-open.service" ];
       requires = [ "sancta-soul-open.service" ];
-      unitConfig.ConditionPathExists = "/dev/mapper/${cfg.mapperName}";
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
         ExecStart = pkgs.writeShellScript "sancta-soul-mount" ''
           set -euo pipefail
+
+          ${verifyMountTarget}
           if ! ${pkgs.util-linux}/bin/mountpoint -q ${lib.escapeShellArg (toString cfg.mountPoint)}; then
             # Refuse to mount over a NON-EMPTY dir: mounting would silently
             # shadow (hide, not destroy) any state already written to the bare
@@ -194,9 +327,14 @@ in
               echo "refusing to mount over non-empty ${cfg.mountPoint} (would shadow existing data)" >&2
               exit 1
             fi
-            ${pkgs.util-linux}/bin/mount /dev/mapper/${cfg.mapperName} \
+            ${pkgs.util-linux}/bin/mount ${lib.escapeShellArg mapperPath} \
               ${lib.escapeShellArg (toString cfg.mountPoint)}
+            ${maybeInjectTestFault "after-mount"}
           fi
+          # A mountpoint alone is insufficient: reject a pre-mounted tmpfs,
+          # bind mount, or other mapper before changing ownership or allowing
+          # Home Manager/worker/gateway dependents to run.
+          ${verifyMount}
           # ext4's root inode owns the visible mount-point metadata, so tmpfiles'
           # mode on the covered directory is not enough. Enforce both invariants
           # after every start, including when the filesystem was already mounted.
@@ -207,8 +345,27 @@ in
         '';
         ExecStop = pkgs.writeShellScript "sancta-soul-umount" ''
           set -euo pipefail
-          ${pkgs.util-linux}/bin/umount ${lib.escapeShellArg (toString cfg.mountPoint)} || true
+          if ! ${pkgs.util-linux}/bin/mountpoint -q \
+            ${lib.escapeShellArg (toString cfg.mountPoint)}; then
+            exit 0
+          fi
+          # Never unmount a filesystem that replaced the configured soul.
+          ${verifyMount}
+          ${pkgs.util-linux}/bin/umount ${lib.escapeShellArg (toString cfg.mountPoint)}
         '';
+      };
+    };
+
+    # Re-run the exact source/image check for every dependent start transaction.
+    # The mount service remains active after boot, so depending on it alone would
+    # not notice an operator-side replacement that happened later.
+    systemd.services.sancta-soul-verify = lib.mkIf (cfg.keyFile != null) {
+      description = "Verify sancta-choir soul mapper and mount source";
+      after = [ "sancta-soul-mount.service" ];
+      requires = [ "sancta-soul-mount.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = verifyMount;
       };
     };
   };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -800,6 +800,67 @@ let
       else
         builtins.throw "FAIL: sancta-claw smokeTestBody missing check titles: ${builtins.toJSON missing}";
 
+    # Keep Home Manager from activating onto the bare ~/.claude underlay when
+    # the encrypted soul mount fails or is condition-skipped. This is a pure
+    # host-config wiring check; the live Gate 0 test must additionally prove
+    # that the mounted source is the expected LUKS mapper.
+    sancta-choir-home-manager-soul-mount-guard =
+      let
+        cfg = self.nixosConfigurations.sancta-choir.config;
+        service = cfg.systemd.services.home-manager-sancta;
+        openService = cfg.systemd.services.sancta-soul-open;
+        mountService = cfg.systemd.services.sancta-soul-mount;
+        verifyService = cfg.systemd.services.sancta-soul-verify;
+        workerService = cfg.systemd.services.sancta-worker;
+        membraneService = cfg.systemd.services.sancta-membrane;
+        mountUnit = "sancta-soul-mount.service";
+        verifyUnit = "sancta-soul-verify.service";
+        homeManagerUnit = "home-manager-sancta.service";
+        checks = {
+          mountUnitExists = builtins.hasAttr "sancta-soul-mount" cfg.systemd.services;
+          verifyUnitExists = builtins.hasAttr "sancta-soul-verify" cfg.systemd.services;
+          orderedAfter = builtins.elem mountUnit service.after;
+          hardRequired = builtins.elem mountUnit service.requires;
+          homeManagerOrderedAfterVerify = builtins.elem verifyUnit service.after;
+          homeManagerRequiresVerify = builtins.elem verifyUnit service.requires;
+          guardedByActualMountPoint =
+            service.unitConfig.ConditionPathIsMountPoint
+            == toString cfg.services.sancta-soul-volume.mountPoint;
+          armedOpenHasNoSkipCondition = !(openService.unitConfig ? ConditionPathExists);
+          armedMountHasNoSkipCondition = !(mountService.unitConfig ? ConditionPathExists);
+          productionSoulUnitsHaveNoCrashTestHook =
+            !(openService.environment ? SANCTA_SOUL_TEST_FAULT_ACK)
+            && !(openService.environment ? SANCTA_SOUL_TEST_FAULT_FILE)
+            && !(mountService.environment ? SANCTA_SOUL_TEST_FAULT_ACK)
+            && !(mountService.environment ? SANCTA_SOUL_TEST_FAULT_FILE);
+          verifierOrderedAfterMount = builtins.elem mountUnit verifyService.after;
+          verifierRequiresMount = builtins.elem mountUnit verifyService.requires;
+          workerOrderedAfterHomeManager = builtins.elem homeManagerUnit workerService.after;
+          workerRequiresHomeManager = builtins.elem homeManagerUnit workerService.requires;
+          workerOrderedAfterVerify = builtins.elem verifyUnit workerService.after;
+          workerRequiresVerify = builtins.elem verifyUnit workerService.requires;
+          workerGuardedByActualMountPoint =
+            workerService.unitConfig.ConditionPathIsMountPoint
+            == toString cfg.services.sancta-soul-volume.mountPoint;
+          workerHasNoCrashTestHook =
+            !(workerService.environment ? SANCTA_RELAY_TEST_FAULT_POINT)
+            && !(workerService.environment ? SANCTA_RELAY_TEST_FAULT_READY)
+            && !(workerService.environment ? SANCTA_RELAY_TEST_FAULT_ACK);
+          gatewayOrderedAfterMount = builtins.elem mountUnit membraneService.after;
+          gatewayRequiresMount = builtins.elem mountUnit membraneService.requires;
+          gatewayOrderedAfterVerify = builtins.elem verifyUnit membraneService.after;
+          gatewayRequiresVerify = builtins.elem verifyUnit membraneService.requires;
+          gatewayGuardedByActualMountPoint =
+            membraneService.unitConfig.ConditionPathIsMountPoint
+            == toString cfg.services.sancta-soul-volume.mountPoint;
+        };
+        failed = builtins.filter (name: !checks.${name}) (builtins.attrNames checks);
+      in
+      if failed == [ ] then
+        true
+      else
+        builtins.throw "FAIL: sancta Home Manager soul-mount guard failed: ${builtins.toJSON failed}";
+
   };
 
   # ── Build the check derivation ──────────────────────────────────

--- a/tests/sancta-membrane.nix
+++ b/tests/sancta-membrane.nix
@@ -2,6 +2,7 @@
 
 let
   relay = ../hosts/sancta-choir/membrane/relay.mjs;
+  relayHash = builtins.hashFile "sha256" relay;
   server = ../hosts/sancta-choir/membrane/comm/server.mjs;
   membrane = ../hosts/sancta-choir/membrane/bin/comm-membrane;
   authLogin = "owner@example.com";
@@ -18,6 +19,19 @@ let
     ${pkgs.coreutils}/bin/cat >/dev/null
     exit 7
   '';
+
+  fakeCounting = pkgs.writeShellScript "sancta-fake-counting-success" ''
+    set -eu
+    count_file="$SANCTA_TEST_SPAWN_COUNT"
+    count=0
+    if [ -f "$count_file" ]; then
+      count="$(${pkgs.coreutils}/bin/cat "$count_file")"
+    fi
+    ${pkgs.coreutils}/bin/printf '%s\n' "$((count + 1))" > "$count_file"
+    ${pkgs.coreutils}/bin/cat >/dev/null
+    ${pkgs.coreutils}/bin/printf '%s\n' \
+      '{"type":"result","result":"counted test reply"}'
+  '';
 in
 pkgs.runCommand "sancta-membrane-tests"
 {
@@ -32,6 +46,7 @@ pkgs.runCommand "sancta-membrane-tests"
         node --check ${relay}
         node --check ${server}
         node --check ${membrane}
+        test "$(${pkgs.coreutils}/bin/sha256sum ${relay} | ${pkgs.coreutils}/bin/cut -d ' ' -f 1)" = '${relayHash}'
 
         guard_home="$TMPDIR/guard-home"
         mkdir -p "$guard_home/.claude/index"
@@ -340,6 +355,124 @@ pkgs.runCommand "sancta-membrane-tests"
           if (reply.inbox_ts !== "success-ts" || fs.existsSync(dir + "/failure")) process.exit(1);
           if ((fs.statSync(dir + "/ready").mode & 0o777) !== 0o600) process.exit(1);
         ' "$success"
+
+        # Causal crash-window coverage against the exact production relay
+        # source. The managed service never receives these test-only env vars;
+        # module-eval locks that absence.
+        run_crash_window() {
+          local name="$1"
+          local point="$2"
+          local expected_spawns="$3"
+          local committed="$4"
+          local dir="$TMPDIR/crash-$name"
+          local relay_pid
+          local recovery_status
+
+          mkdir -p "$dir"
+          printf '%s\n' '{"ts":"crash-ts","decision":"proceed","message":"test"}' > "$dir/inbox"
+          printf '%s\n' '{"offset":0}' > "$dir/cursor"
+
+          env \
+            SANCTA_INBOX="$dir/inbox" \
+            SANCTA_REPLIES="$dir/replies" \
+            SANCTA_CURSOR="$dir/cursor" \
+            SANCTA_FAILURE="$dir/failure" \
+            SANCTA_WORKER_READY="$dir/worker-ready" \
+            SANCTA_PROJECT_DIR="$TMPDIR" \
+            SANCTA_TEST_SPAWN_COUNT="$dir/spawn-count" \
+            SANCTA_RELAY_TEST_FAULT_POINT="$point" \
+            SANCTA_RELAY_TEST_FAULT_READY="$dir/fault-ready" \
+            SANCTA_RELAY_TEST_FAULT_ACK=sancta-relay-crash-window-v1 \
+            CLAUDE_BIN=${fakeCounting} \
+            CLAUDE_ARGS_JSON='[]' \
+            node ${relay} > "$dir/first.log" 2>&1 &
+          relay_pid=$!
+
+          for _ in $(seq 1 100); do
+            if [ -f "$dir/fault-ready" ]; then
+              break
+            fi
+            if ! kill -0 "$relay_pid" 2>/dev/null; then
+              echo "relay exited before crash point $point" >&2
+              ${pkgs.coreutils}/bin/cat "$dir/first.log" >&2
+              exit 1
+            fi
+            sleep 0.05
+          done
+          if [ ! -f "$dir/fault-ready" ]; then
+            echo "relay never reached crash point $point" >&2
+            kill -KILL "$relay_pid" 2>/dev/null || true
+            wait "$relay_pid" 2>/dev/null || true
+            exit 1
+          fi
+          test "$(${pkgs.coreutils}/bin/cat "$dir/fault-ready")" = "$point"
+          kill -KILL "$relay_pid"
+          wait "$relay_pid" 2>/dev/null || true
+
+          node -e '
+            const fs = require("fs");
+            const dir = process.argv[1];
+            const expected = Number(process.argv[2]);
+            const committed = process.argv[3] === "yes";
+            const count = fs.existsSync(dir + "/spawn-count")
+              ? Number(fs.readFileSync(dir + "/spawn-count", "utf8")) : 0;
+            const cursor = JSON.parse(fs.readFileSync(dir + "/cursor", "utf8"));
+            const failure = JSON.parse(fs.readFileSync(dir + "/failure", "utf8"));
+            if (count !== expected || cursor.offset !== 0) process.exit(1);
+            if (failure.offset !== 0 || failure.reason !== "Claude turn in progress") process.exit(1);
+            if (fs.existsSync(dir + "/replies") !== committed) process.exit(1);
+            if (committed) {
+              const replies = fs.readFileSync(dir + "/replies", "utf8").trim().split("\n");
+              if (replies.length !== 1) process.exit(1);
+            }
+          ' "$dir" "$expected_spawns" "$committed"
+
+          set +e
+          timeout 1s env \
+            SANCTA_INBOX="$dir/inbox" \
+            SANCTA_REPLIES="$dir/replies" \
+            SANCTA_CURSOR="$dir/cursor" \
+            SANCTA_FAILURE="$dir/failure" \
+            SANCTA_WORKER_READY="$dir/worker-ready" \
+            SANCTA_PROJECT_DIR="$TMPDIR" \
+            SANCTA_TEST_SPAWN_COUNT="$dir/spawn-count" \
+            CLAUDE_BIN=${fakeCounting} \
+            CLAUDE_ARGS_JSON='[]' \
+            node ${relay} > "$dir/recovery.log" 2>&1
+          recovery_status=$?
+          set -e
+
+          if [ "$committed" = yes ]; then
+            test "$recovery_status" -eq 124
+          else
+            test "$recovery_status" -ne 0
+            test "$recovery_status" -ne 124
+          fi
+
+          node -e '
+            const fs = require("fs");
+            const dir = process.argv[1];
+            const expected = Number(process.argv[2]);
+            const committed = process.argv[3] === "yes";
+            const count = fs.existsSync(dir + "/spawn-count")
+              ? Number(fs.readFileSync(dir + "/spawn-count", "utf8")) : 0;
+            const cursor = JSON.parse(fs.readFileSync(dir + "/cursor", "utf8"));
+            const size = fs.statSync(dir + "/inbox").size;
+            if (count !== expected) process.exit(1);
+            if (committed) {
+              if (cursor.offset !== size || fs.existsSync(dir + "/failure")) process.exit(1);
+              const replies = fs.readFileSync(dir + "/replies", "utf8").trim().split("\n");
+              if (replies.length !== 1) process.exit(1);
+            } else {
+              if (cursor.offset !== 0 || !fs.existsSync(dir + "/failure")) process.exit(1);
+              if (fs.existsSync(dir + "/replies")) process.exit(1);
+            }
+          ' "$dir" "$expected_spawns" "$committed"
+        }
+
+        run_crash_window marker after-in-progress-marker 0 no
+        run_crash_window provider after-provider-exit 1 no
+        run_crash_window reply after-reply-commit 1 yes
 
         replay="$TMPDIR/replay"
         mkdir -p "$replay"

--- a/tests/sancta-soul-volume.nix
+++ b/tests/sancta-soul-volume.nix
@@ -1,0 +1,408 @@
+{ pkgs }:
+
+let
+  testLogin = "owner@example.com";
+  testLoginHash = builtins.hashString "sha256" testLogin;
+  testPassword = "test-membrane-password-0123456789abcdef";
+  soulFaultAck = "sancta-soul-crash-window-v1";
+  soulFaultEnvironment = {
+    SANCTA_SOUL_TEST_FAULT_ACK = soulFaultAck;
+    SANCTA_SOUL_TEST_FAULT_FILE = "/run/sancta-test/soul-fault";
+  };
+in
+pkgs.testers.nixosTest {
+  name = "sancta-soul-volume";
+
+  nodes.machine = { lib, pkgs, ... }: {
+    imports = [
+      ../hosts/sancta-choir/soul-volume.nix
+      ../hosts/sancta-choir/sancta-worker.nix
+    ];
+
+    _module.args.claude-code = {
+      packages.${pkgs.system}.default = pkgs.writeShellScriptBin "claude" ''
+        echo "test-only claude must not run" >&2
+        exit 99
+      '';
+    };
+
+    users.users.sancta = {
+      isSystemUser = true;
+      group = "sancta";
+      home = "/var/lib/sancta";
+      createHome = true;
+    };
+    users.groups.sancta = { };
+
+    services.sancta-soul-volume = {
+      enable = true;
+      imagePath = "/var/lib/sancta-soul/soul.img";
+      keyFile = "/run/sancta-test/soul.key";
+      mapperName = "sancta-soul";
+      mountPoint = "/var/lib/sancta/.claude";
+      owner = "sancta";
+    };
+
+    services.sancta-worker = {
+      enable = true;
+      session = "vm-session";
+      apiKeyFile = "/run/sancta-test/anthropic-key";
+      authSecretFile = "/run/sancta-test/membrane-auth";
+      operatorLoginSha256 = testLoginHash;
+      port = 18743;
+    };
+
+    # Prepare only disposable test material before the production open unit.
+    systemd.services.sancta-test-prepare = {
+      description = "Create disposable LUKS soul fixture";
+      before = [ "sancta-soul-open.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      path = [
+        pkgs.coreutils
+        pkgs.cryptsetup
+        pkgs.e2fsprogs
+      ];
+      script = ''
+        set -euo pipefail
+        install -d -m 0750 -o root -g sancta /run/sancta-test
+        install -d -m 0700 -o root -g root /var/lib/sancta-soul
+        install -d -m 0700 -o sancta -g sancta /var/lib/sancta/session
+        printf '%s\n' 'disposable-soul-key' > /run/sancta-test/soul.key
+        printf '%s\n' 'sk-ant-api-disposable-test-key' > /run/sancta-test/anthropic-key
+        printf '%s\n' '${testPassword}' > /run/sancta-test/membrane-auth
+        chown sancta:sancta /run/sancta-test/anthropic-key
+        chmod 0400 /run/sancta-test/anthropic-key
+        chmod 0600 /run/sancta-test/soul.key /run/sancta-test/membrane-auth
+        touch /var/lib/sancta/session/vm-session
+
+        if [ ! -f /var/lib/sancta-soul/soul.img ]; then
+          truncate -s 128M /var/lib/sancta-soul/soul.img
+          # Test-only bounded KDF avoids Argon2 memory/time variance in CI.
+          cryptsetup luksFormat --batch-mode --type luks2 \
+            --pbkdf pbkdf2 --iter-time 10 \
+            --key-file /run/sancta-test/soul.key \
+            /var/lib/sancta-soul/soul.img
+          cryptsetup luksOpen \
+            --key-file /run/sancta-test/soul.key \
+            /var/lib/sancta-soul/soul.img sancta-soul-init
+          mkfs.ext4 -q /dev/mapper/sancta-soul-init
+          cryptsetup luksClose sancta-soul-init
+        fi
+      '';
+    };
+
+    systemd.services.sancta-soul-open = {
+      after = [ "sancta-test-prepare.service" ];
+      requires = [ "sancta-test-prepare.service" ];
+      environment = soulFaultEnvironment;
+    };
+
+    systemd.services.sancta-soul-mount.environment = soulFaultEnvironment;
+
+    # A lightweight stand-in for the real HM activation body, with the exact
+    # production dependency/condition contract. Pure module-eval separately
+    # locks the real host unit to the same wiring.
+    systemd.services.home-manager-sancta = {
+      description = "Sancta Home Manager ordering probe";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "sancta-soul-mount.service"
+        "sancta-soul-verify.service"
+      ];
+      requires = [
+        "sancta-soul-mount.service"
+        "sancta-soul-verify.service"
+      ];
+      unitConfig.ConditionPathIsMountPoint = "/var/lib/sancta/.claude";
+      serviceConfig = {
+        Type = "oneshot";
+        User = "sancta";
+        RemainAfterExit = true;
+      };
+      script = ''
+        set -euo pipefail
+        if [ -e /run/sancta-test/fail-home-manager ]; then
+          exit 23
+        fi
+        mkdir -p /var/lib/sancta/.claude/index
+        touch /var/lib/sancta/.claude/.hm-succeeded
+        touch /var/lib/sancta/session/.hm-ran
+      '';
+    };
+
+    # Keep all production unit dependencies/conditions/hardening, replacing
+    # only the paid Claude process with a readiness marker plus an idle process.
+    systemd.services.sancta-worker.serviceConfig.ExecStart = lib.mkForce (
+      pkgs.writeShellScript "sancta-worker-vm-probe" ''
+        set -euo pipefail
+        test -f "$CLAUDE_CONFIG_DIR/.hm-succeeded"
+        touch "$SANCTA_WORKER_READY"
+        exec ${pkgs.coreutils}/bin/sleep infinity
+      ''
+    );
+
+    # Tailscale itself is outside this LUKS/systemd test. Preserve the real
+    # gateway and replace only its Serve edge with a dependent oneshot marker.
+    systemd.services.sancta-membrane-serve = {
+      after = lib.mkForce [ "sancta-membrane.service" ];
+      wants = lib.mkForce [ ];
+      requires = lib.mkForce [ "sancta-membrane.service" ];
+      script = lib.mkForce ''
+        touch /run/sancta-test/serve-started
+      '';
+      preStop = lib.mkForce "";
+    };
+
+    environment.systemPackages = [
+      pkgs.cryptsetup
+      pkgs.curl
+      pkgs.jq
+      pkgs.util-linux
+    ];
+
+    virtualisation.memorySize = 1024;
+  };
+
+  testScript = ''
+    import json
+
+    MOUNT = "/var/lib/sancta/.claude"
+
+    def stop_consumers():
+        machine.succeed("systemctl stop sancta-membrane-serve.service")
+        machine.succeed("systemctl stop sancta-membrane.service")
+        machine.succeed("systemctl stop sancta-worker.service")
+        machine.succeed("systemctl stop home-manager-sancta.service")
+        machine.succeed("rm -f /run/sancta-test/serve-started")
+
+    def stop_soul():
+        machine.succeed("systemctl stop sancta-soul-verify.service")
+        machine.succeed("systemctl stop sancta-soul-mount.service")
+        machine.succeed("systemctl stop sancta-soul-open.service")
+
+    def reset_units():
+        machine.succeed("systemctl reset-failed")
+
+    def assert_consumers_down():
+        for unit in (
+            "home-manager-sancta.service",
+            "sancta-worker.service",
+            "sancta-membrane.service",
+            "sancta-membrane-serve.service",
+        ):
+            machine.fail(f"systemctl is-active --quiet {unit}")
+        machine.succeed("test ! -e /var/lib/sancta/session/.hm-ran")
+        machine.succeed("test ! -e /run/sancta-worker/ready")
+        machine.succeed("test ! -e /run/sancta-test/serve-started")
+        machine.fail("curl --connect-timeout 1 --silent http://127.0.0.1:18743/")
+
+    def assert_mapper_backing(image):
+        machine.succeed(
+            """set -euo pipefail
+            mapper_device="$(cryptsetup status sancta-soul | awk '$1 == "device:" { print $2 }')"
+            test -n "$mapper_device"
+            backing="$(losetup --noheadings --raw --output BACK-FILE -- "$mapper_device")"
+            test "$(readlink -f -- "$backing")" = "$(readlink -f -- "%s")"
+            """ % image
+        )
+
+    def assert_exact_mount():
+        machine.succeed("test $(readlink -f $(findmnt -rn -o SOURCE --mountpoint /var/lib/sancta/.claude)) = $(readlink -f /dev/mapper/sancta-soul)")
+
+    def assert_mount_metadata():
+        machine.succeed("test \"$(stat -c '%U:%G %a' /var/lib/sancta/.claude)\" = 'sancta:sancta 700'")
+
+    start_all()
+
+    machine.wait_for_unit("home-manager-sancta.service")
+    machine.wait_for_unit("sancta-worker.service")
+    machine.wait_for_unit("sancta-membrane.service")
+    machine.wait_for_unit("sancta-membrane-serve.service")
+    machine.wait_for_open_port(18743)
+    machine.succeed("test -f /var/lib/sancta/.claude/.hm-succeeded")
+    machine.succeed("test -f /run/sancta-worker/ready")
+    machine.succeed("test -f /run/sancta-test/serve-started")
+    assert_exact_mount()
+    assert_mount_metadata()
+    assert_mapper_backing("/var/lib/sancta-soul/soul.img")
+    machine.succeed("cryptsetup status sancta-soul | grep -Eq '^[[:space:]]*device:[[:space:]]+/dev/loop'")
+
+    # A symlink target must fail before root mounts anything through it.
+    stop_consumers()
+    stop_soul()
+    machine.succeed("rm -f /var/lib/sancta/session/.hm-ran")
+    machine.succeed("rmdir /var/lib/sancta/.claude")
+    machine.succeed("mkdir /run/sancta-test/redirect && ln -s /run/sancta-test/redirect /var/lib/sancta/.claude")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.succeed("test ! -e /var/lib/sancta/session/.hm-ran")
+    machine.succeed("test ! -e /run/sancta-test/redirect/.hm-succeeded")
+    machine.fail("mountpoint -q /run/sancta-test/redirect")
+    machine.succeed("rm /var/lib/sancta/.claude && mkdir /var/lib/sancta/.claude && chown sancta:sancta /var/lib/sancta/.claude")
+    machine.succeed("systemctl stop sancta-soul-open.service")
+    reset_units()
+
+    # An existing wrong filesystem is rejected and left untouched.
+    machine.succeed("mount -t tmpfs tmpfs /var/lib/sancta/.claude")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.succeed("test ! -e /var/lib/sancta/session/.hm-ran")
+    machine.succeed("test $(findmnt -rn -o FSTYPE --mountpoint /var/lib/sancta/.claude) = tmpfs")
+    machine.succeed("test ! -e /var/lib/sancta/.claude/.hm-succeeded")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    machine.succeed("systemctl stop sancta-soul-open.service")
+    reset_units()
+
+    # An existing mapper backed by another image fails without being closed.
+    machine.succeed("truncate -s 128M /var/lib/sancta-soul/wrong.img")
+    machine.succeed("cryptsetup luksFormat --batch-mode --type luks2 --pbkdf pbkdf2 --iter-time 10 --key-file /run/sancta-test/soul.key /var/lib/sancta-soul/wrong.img")
+    machine.succeed("cryptsetup luksOpen --key-file /run/sancta-test/soul.key /var/lib/sancta-soul/wrong.img sancta-soul")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    assert_mapper_backing("/var/lib/sancta-soul/wrong.img")
+    machine.succeed("cryptsetup luksClose sancta-soul")
+    reset_units()
+
+    # A missing configured image fails and is never recreated.
+    machine.succeed("mv /var/lib/sancta-soul/soul.img /var/lib/sancta-soul/soul.img.held")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.succeed("test ! -e /var/lib/sancta-soul/soul.img")
+    machine.succeed("mv /var/lib/sancta-soul/soul.img.held /var/lib/sancta-soul/soul.img")
+    reset_units()
+
+    # The configured image path itself must be canonical, never a symlink.
+    machine.succeed("mv /var/lib/sancta-soul/soul.img /var/lib/sancta-soul/soul.img.held")
+    machine.succeed("ln -s soul.img.held /var/lib/sancta-soul/soul.img")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.succeed("test -L /var/lib/sancta-soul/soul.img")
+    machine.succeed("rm /var/lib/sancta-soul/soul.img && mv /var/lib/sancta-soul/soul.img.held /var/lib/sancta-soul/soul.img")
+    reset_units()
+
+    # Crash immediately after cryptsetup creates the mapper. The failed start
+    # leaves the exact mapper visible for diagnosis but no dependent available.
+    machine.succeed("printf '%s\n' after-mapper-open > /run/sancta-test/soul-fault")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.fail("mountpoint -q /var/lib/sancta/.claude")
+    machine.succeed("test -z \"$(ls -A /var/lib/sancta/.claude)\"")
+    assert_mapper_backing("/var/lib/sancta-soul/soul.img")
+    machine.succeed("journalctl -b -u sancta-soul-open.service --no-pager | grep -F 'TEST ONLY: injected soul-volume fault at after-mapper-open'")
+    machine.succeed("rm /run/sancta-test/soul-fault")
+    reset_units()
+    machine.succeed("systemctl start sancta-membrane-serve.service")
+    machine.wait_for_unit("home-manager-sancta.service")
+    machine.wait_for_unit("sancta-worker.service")
+    machine.wait_for_unit("sancta-membrane.service")
+    machine.wait_for_unit("sancta-membrane-serve.service")
+    assert_exact_mount()
+    assert_mount_metadata()
+    machine.succeed("test -e /var/lib/sancta/session/.hm-ran")
+    stop_consumers()
+    stop_soul()
+
+    # Crash immediately after mount creates the filesystem attachment. The
+    # exact mount remains for diagnosis; retry succeeds only through verifier.
+    machine.succeed("rm -f /var/lib/sancta/session/.hm-ran")
+    machine.succeed("printf '%s\n' after-mount > /run/sancta-test/soul-fault")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    assert_exact_mount()
+    assert_mapper_backing("/var/lib/sancta-soul/soul.img")
+    machine.succeed("test ! -e /var/lib/sancta/session/.hm-ran")
+    machine.succeed("journalctl -b -u sancta-soul-mount.service --no-pager | grep -F 'TEST ONLY: injected soul-volume fault at after-mount'")
+    machine.succeed("rm /run/sancta-test/soul-fault")
+    reset_units()
+    machine.succeed("systemctl start sancta-membrane-serve.service")
+    machine.wait_for_unit("home-manager-sancta.service")
+    machine.wait_for_unit("sancta-worker.service")
+    machine.wait_for_unit("sancta-membrane.service")
+    machine.wait_for_unit("sancta-membrane-serve.service")
+    assert_exact_mount()
+    assert_mount_metadata()
+    machine.succeed("test -e /var/lib/sancta/session/.hm-ran")
+    stop_consumers()
+    stop_soul()
+
+    # With the long-lived mount unit still active, replace only the underlying
+    # attachment. A new Serve transaction must rerun the non-remaining verifier
+    # and reject the tmpfs without touching its sentinel or rerunning HM.
+    machine.succeed("systemctl start home-manager-sancta.service")
+    machine.succeed("systemctl stop home-manager-sancta.service")
+    machine.succeed("rm -f /var/lib/sancta/session/.hm-ran")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    machine.succeed("mount -t tmpfs tmpfs /var/lib/sancta/.claude")
+    machine.succeed("printf '%s\n' verifier-sentinel > /var/lib/sancta/.claude/sentinel")
+    machine.fail("systemctl start sancta-membrane-serve.service")
+    assert_consumers_down()
+    machine.succeed("test \"$(systemctl show sancta-soul-verify.service -p Result --value)\" = exit-code")
+    machine.succeed("test \"$(cat /var/lib/sancta/.claude/sentinel)\" = verifier-sentinel")
+    machine.succeed("test \"$(findmnt -rn -o FSTYPE --mountpoint /var/lib/sancta/.claude)\" = tmpfs")
+    machine.succeed("test ! -e /var/lib/sancta/session/.hm-ran")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    reset_units()
+    machine.succeed("systemctl restart sancta-soul-mount.service")
+    assert_exact_mount()
+    assert_mount_metadata()
+
+    # Replacement after activation: both stop and restart must refuse it and
+    # surface failure rather than unmounting the unexpected filesystem.
+    machine.succeed("systemctl start home-manager-sancta.service")
+    machine.succeed("systemctl stop home-manager-sancta.service")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    machine.succeed("mount -t tmpfs tmpfs /var/lib/sancta/.claude")
+    machine.fail("systemctl stop sancta-soul-mount.service")
+    machine.succeed("test $(findmnt -rn -o FSTYPE --mountpoint /var/lib/sancta/.claude) = tmpfs")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    reset_units()
+    machine.succeed("systemctl start sancta-soul-mount.service")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    machine.succeed("mount -t tmpfs tmpfs /var/lib/sancta/.claude")
+    machine.fail("systemctl restart sancta-soul-mount.service")
+    machine.succeed("test $(findmnt -rn -o FSTYPE --mountpoint /var/lib/sancta/.claude) = tmpfs")
+    machine.succeed("umount /var/lib/sancta/.claude")
+    reset_units()
+    machine.succeed("systemctl start sancta-soul-mount.service")
+    machine.succeed("systemctl stop sancta-soul-mount.service")
+
+    # Mapper replacement after activation is likewise never closed by either
+    # stop or restart; assert the exact wrong backing survives both attempts.
+    machine.succeed("cryptsetup luksClose sancta-soul")
+    machine.succeed("cryptsetup luksOpen --key-file /run/sancta-test/soul.key /var/lib/sancta-soul/wrong.img sancta-soul")
+    machine.fail("systemctl stop sancta-soul-open.service")
+    assert_mapper_backing("/var/lib/sancta-soul/wrong.img")
+    machine.succeed("cryptsetup luksClose sancta-soul")
+    reset_units()
+    machine.succeed("systemctl start sancta-soul-open.service")
+    machine.succeed("cryptsetup luksClose sancta-soul")
+    machine.succeed("cryptsetup luksOpen --key-file /run/sancta-test/soul.key /var/lib/sancta-soul/wrong.img sancta-soul")
+    machine.fail("systemctl restart sancta-soul-open.service")
+    assert_mapper_backing("/var/lib/sancta-soul/wrong.img")
+    machine.succeed("cryptsetup luksClose sancta-soul")
+    reset_units()
+
+    # Failed Home Manager blocks the worker. The intentional status-only
+    # gateway may run, but /send must return 503 without inbox/quota mutation.
+    machine.succeed("touch /run/sancta-test/fail-home-manager")
+    machine.fail("systemctl start sancta-worker.service")
+    machine.succeed("test \"$(systemctl show home-manager-sancta.service -p Result --value)\" = exit-code")
+    machine.succeed("test \"$(systemctl show home-manager-sancta.service -p ExecMainStatus --value)\" = 23")
+    machine.fail("systemctl is-active --quiet sancta-worker.service")
+    assert_exact_mount()
+    machine.succeed("systemctl start sancta-membrane.service")
+    machine.wait_for_open_port(18743)
+    before = machine.succeed("sha256sum /var/lib/sancta/.claude/index/comm-inbox.jsonl /var/lib/sancta/.claude/index/comm-rate-limit.json 2>/dev/null || true")
+    status = machine.succeed("curl -sS -o /run/sancta-test/send-response -w '%{http_code}' -u alexandru:${testPassword} -H 'Tailscale-User-Login: ${testLogin}' -H 'X-Sancta-Request: send' -H 'Content-Type: application/json' --data '{\"message\":\"hello\"}' http://127.0.0.1:18743/send").strip()
+    assert status == "503", status
+    response = json.loads(machine.succeed("cat /run/sancta-test/send-response"))
+    assert response.get("error") == "worker unavailable", response
+    assert response.get("worker", {}).get("status") in {"stopped", "failed"}, response
+    after = machine.succeed("sha256sum /var/lib/sancta/.claude/index/comm-inbox.jsonl /var/lib/sancta/.claude/index/comm-rate-limit.json 2>/dev/null || true")
+    assert before == after
+    machine.succeed("test ! -e /run/sancta-worker/ready")
+  '';
+}


### PR DESCRIPTION
**CARVE-AND-HOLD — do not deploy or merge.** Phase 2 of the sancta claudeShared migration. Phase 1 (users + guard #1, the actual skills-fix) is the base branch / #538 and is independently safe on unchanged soul-volume semantics.

This branch splits out the **security-critical LUKS boot-logic hardening** for its own review:
- `soul-volume.nix`: inline verify → dedicated `sancta-soul-verify.service`; assert mapper/mount are backed by exactly our loopback image; drop `ConditionPathExists` skip-guards so an armed unit with a missing/mismatched image **fails loud** instead of running dependents on a bare unencrypted dir; crash-recovery refuses to reuse an unexpected same-named mapper.
- Ordering: `home-manager-sancta`, worker, membrane after the verify service.
- Test rigor: booted systemd/LUKS VM proof (`tests/sancta-soul-volume.nix`, a package so `nix flake check` doesn't boot a 2nd VM), membrane causal crash-window coverage + relay hash-pin, module-eval wiring checks; CI runs both VM packages in the disk-cleaned x86 job.

**Provenance:** this is a point-in-time snapshot of in-flight working-tree work (captured 2026-07-22 10:26) committed from an isolated worktree so it wouldn't race the authoring session. If that session advanced the work, refresh this branch. Local eval green: `module-eval`, `sancta-choir` toplevel, and `sancta-soul-volume-test` all produce drvPaths.

Held for @alexandru-savinov to read before any deploy. Deploy stays attended + human-gated per the migration goal.