### PR TITLE
feat(codex): preserveScrollback option (--no-alt-screen wrapper)

### DIFF
--- a/hosts/rpi5-full/configuration.nix
+++ b/hosts/rpi5-full/configuration.nix
@@ -100,7 +100,10 @@ in
 
   # OpenAI Codex CLI for the full, active Pi profile. Keep this out of the
   # minimal rpi5 SD-image profile so bootstrap images stay small.
-  customModules.codex.enable = true;
+  customModules.codex = {
+    enable = true;
+    preserveScrollback = true;
+  };
 
   # Package overrides for memory-constrained ARM builds
   nixpkgs.overlays = [

--- a/modules/services/codex.nix
+++ b/modules/services/codex.nix
@@ -7,6 +7,20 @@
 
 let
   cfg = config.customModules.codex;
+
+  codexPackage =
+    if cfg.preserveScrollback then
+      pkgs.symlinkJoin
+        {
+          name = "${lib.getName cfg.package}-preserve-scrollback";
+          paths = [ cfg.package ];
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/codex --add-flags --no-alt-screen
+          '';
+        }
+    else
+      cfg.package;
 in
 {
   options.customModules.codex = {
@@ -21,11 +35,20 @@ in
         Codex moves faster than stable nixpkgs branches.
       '';
     };
+
+    preserveScrollback = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Run the Codex TUI with --no-alt-screen so terminal multiplexers such
+        as Zellij retain normal pane scrollback.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
-      cfg.package
+      codexPackage
     ];
   };
 }


### PR DESCRIPTION
## What

Adds `customModules.codex.preserveScrollback` (default `false`). When `true`, the Codex CLI is wrapped with `--no-alt-screen` via `symlinkJoin` + `wrapProgram`, so terminal multiplexers such as Zellij keep normal pane scrollback instead of the TUI's alternate screen. Enabled on `rpi5-full`.

## Why a separate PR

This change was already present (uncommitted) in the working tree and rode along in #543 (the Aspirator vacuum dashboard). Splitting it out so #543 is purely the HA dashboard and this stands on its own.

## Verification

- Verified **on hardware**: `codex --help` (codex-cli 0.144.1) lists `--no-alt-screen`, and `/run/current-system/sw/bin/codex` is the wrapped binary invoking the flag. (This matters because CI only *evaluates* `rpi5-full`, it doesn't build it — a bad flag wouldn't be caught in CI.)
- `nixos-rebuild build --flake .#rpi5-full` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
