### PR TITLE
soul-mirror-pull: fix remoteHost (Tailscale SSH bypasses forced-command restriction)

### DIFF
--- a/hosts/rpi5-full/soul-mirror-pull.nix
+++ b/hosts/rpi5-full/soul-mirror-pull.nix
@@ -154,7 +154,15 @@ in
       description = "Path to the SSH PRIVATE pull key (from agenix, decrypted only on rpi5). NEVER a store path. Absent/placeholder → self-suppress (no-auth).";
     };
 
-    remoteHost = mkOption { type = types.str; default = "sancta-choir"; description = "The producer host (Tailscale name) to pull from."; };
+    remoteHost = mkOption {
+      type = types.str;
+      # Public IP, not a Tailscale name — sancta-choir runs Tailscale SSH which
+      # would intercept a tailscale0 connection and bypass the rrsync -ro
+      # forced-command restriction (see PR body / backup-pull's identical
+      # pattern for sancta-claw).
+      default = "116.203.223.113";
+      description = "The producer host to pull from. MUST be reachable WITHOUT going through Tailscale SSH on sancta-choir — that interception authenticates by tailnet identity and does not consult authorized_keys, so it would bypass the rrsync -ro forced-command restriction entirely. Use the public IP (matches services.backup-pull.remoteHost's identical pattern for sancta-claw), not a Tailscale name.";
+    };
     remoteUser = mkOption { type = types.str; default = "sancta"; description = "Account on remoteHost the pull key is authorized under (must match services.sancta-soul-mirror.user there)."; };
     remoteDir = mkOption {
       type = types.str;

--- a/hosts/rpi5-full/soul-mirror-pull.nix
+++ b/hosts/rpi5-full/soul-mirror-pull.nix
@@ -188,7 +188,7 @@ in
     randomizedDelaySec = mkOption { type = types.str; default = "30min"; description = "Timer RandomizedDelaySec."; };
 
     knownHostsFile = mkOption { type = types.nullOr types.str; default = null; description = "Optional known_hosts for StrictHostKeyChecking=yes; else accept-new."; };
-    knownHostsEntry = mkOption { type = types.str; default = ""; description = "Declarative known_hosts line for choir; when set, pins the host key (closes TOFU). `ssh-keyscan -t ed25519 sancta-choir`."; };
+    knownHostsEntry = mkOption { type = types.str; default = ""; description = "Declarative known_hosts line for choir; when set, pins the host key (closes TOFU). Must match remoteHost exactly, e.g. `ssh-keyscan -t ed25519 116.203.223.113`."; };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
## Problem

PR #545's soul-mirror pull failed on rpi5 with:
`ssh: Could not resolve hostname sancta-choir: Name or service not known`

Two layered issues, both from routing over a Tailscale-mesh hostname:

1. `remoteHost` defaulted to `"sancta-choir"`, but the real Tailscale node name is `sancta-choir-1` (hostname-collision suffix).
2. Even the correct Tailscale name would fail differently: sancta-choir runs Tailscale SSH (`--ssh` flag), which intercepts ALL port-22 traffic over `tailscale0` before classic sshd/`authorized_keys` is consulted. The tailnet's `ssh` policy only permits user `root` from rpi5's tag to sancta-choir's tag — not `sancta` — so the pull's actual user is rejected by tailnet policy regardless of hostname. And even if that policy were widened, Tailscale SSH authenticates by WireGuard identity and does NOT consult `authorized_keys` at all — it would silently bypass the `rrsync -ro` forced-command restriction and grant a full shell instead of the intended read-only, single-directory access.

## Fix (Option A)

Route over sancta-choir's public IP (`116.203.223.113`) instead of any Tailscale name — never touches `tailscale0`, so Tailscale's `ssh` policy is irrelevant and classic sshd correctly enforces the forced-command restriction. This exactly mirrors the existing pattern for the sancta-claw backup: `hosts/rpi5-full/configuration.nix`'s `services.backup-pull.remoteHost = "46.225.168.24"` (public IP, same reasoning, already proven in production). No firewall change needed — port 22 is already open on the public interface (`firewall.allowedTCPPorts = [ 22 ]`).

## Option B — considered, rejected

Widening the tailnet `ssh` policy stanza to permit user `sancta` would fix connectivity but silently trade away the design's core security property (read-only, single-directory, forced-command access) for a full interactive shell, since Tailscale SSH doesn't consult `authorized_keys`. Rejected as a security regression; noted here for the audit trail.

## Verification

- `nix eval .#nixosConfigurations.sancta-choir.config.system.build.toplevel.drvPath` — green.
- `nix eval .#nixosConfigurations.rpi5-full.config.system.build.toplevel.drvPath` — green.
- Not yet re-tested end-to-end on real hardware (that's a follow-up manual verification step, same as the rest of this project — merge/deploy/re-test remain Alexandru's own hand).