### PR TITLE
chore: upgrade claude-code (2.1.215 → 2.1.219)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784484843,
-        "narHash": "sha256-DQpCBkh4J5yoBDKbWIxDqdicKU4nBjnX4Kx+404zD2I=",
+        "lastModified": 1784914161,
+        "narHash": "sha256-xncQGg/L7hVuTq15GWcyc7M236fU9dH4v0R5Bzl5hzg=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "6ee481c21e1e069e465abe89bb722c3fcdb78a1f",
+        "rev": "fc2b0e376dec752577cd8419992e6c510e7c5463",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bumps the `claude-code` flake input (github:sadjow/claude-code-nix) from rev `6ee481c2` (2026-07-19) to rev `fc2b0e37` (2026-07-24).
- Package version: `2.1.215` → `2.1.219`.
- Update done via `nix flake update claude-code`; only `flake.lock` changes.

## Verification
- Confirmed new package version via `nix eval github:sadjow/claude-code-nix/fc2b0e376dec752577cd8419992e6c510e7c5463#packages.x86_64-linux.default.version` → `"2.1.219"` (old rev evaluated to `"2.1.215"`).
- Eval-verified `sancta-choir` toplevel: `nix eval .#nixosConfigurations.sancta-choir.config.system.build.toplevel.drvPath` → printed a clean `.drv` path, no error.
- Also eval-verified `rpi5-full`'s sibling `rpi5` config toplevel — clean `.drv` path, no error.

Takes effect on the next `nixos-rebuild` deploy (Alexandru's hand).

## Test plan
- [x] `flake.lock` diff limited to the `claude-code` input
- [x] `nix eval` toplevel for sancta-choir succeeds
- [x] `nix eval` toplevel for rpi5 succeeds
- [ ] Full `nix flake check` (left to CI)