### PR TITLE
feat(sancta): doctrine guard — assert the authored substrate is present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,21 +91,11 @@ Custom NixOS modules wrap upstream services with Tailscale integration and ageni
 | `services.tailscale` | - | Mesh VPN (all services exposed via Tailscale only) |
 | `openclaw` (sancta-claw) | 18789 | Official OpenClaw npm package on dedicated VPS |
 | `services.hermes-agent` (hermes-claw) | - | Hermes AI agent in Podman container (upstream module, container mode) |
-| `services.sancta-gallery` (sancta-choir) | 8739 | Rendered surface, publish-gated. **Binds the tailnet address directly** — see the exception below |
+| `services.sancta-gallery` (sancta-choir) | 8739 | Rendered surface, publish-gated. Binds the tailnet address directly — documented exception below |
 
 **Security Pattern:** Services bind to `127.0.0.1` only, accessed via Tailscale Serve HTTPS proxy. Localhost binding provides defense-in-depth. OpenClaw uses a different model: file-based inbox with per-UID nftables network restriction (no listener).
 
-**Documented exception — `sancta-gallery` on sancta-choir.** It binds the tailnet
-address directly instead of loopback + Serve. On 2026-07-26 a page mounted as a *path*
-under Serve's `/ → 127.0.0.1:8080` catch-all failed silently, and the URL returned
-**200 with Open-WebUI's page**: longest-prefix routing makes `/` the parent of every
-path and an SPA history-fallback answers 200 to anything, so composed they form a total
-function over the URL space in which no mistake is representable. Binding its own origin
-makes a dead service fail as `ECONNREFUSED`, which cannot be mistaken for content.
-Traffic stays inside WireGuard either way; `IPAddressAllow` is narrowed to Tailscale's
-CGNAT/ULA ranges and a wildcard bind is rejected by assertion. **New services should
-still follow the loopback + Serve norm** — this exception is for a surface whose whole
-job is that a wrong URL must be visibly wrong.
+**Documented exception — `sancta-gallery` on `sancta-choir`.** It binds its tailnet address directly instead of loopback + Serve. A page mounted as a *path* under Serve's `/ → 127.0.0.1:8080` catch-all failed silently and the URL returned 200 with the proxied app's own page: longest-prefix routing makes `/` the parent of every path, and an SPA history-fallback answers 200 to anything, so composed they form a total function over the URL space in which no mistake is representable. Binding its own origin makes a dead service fail as `ECONNREFUSED`, which cannot be mistaken for content. Traffic stays inside WireGuard either way; `IPAddressAllow` is narrowed to Tailscale's CGNAT/ULA ranges and a non-Tailscale bind is rejected by assertion. **New services should still follow the loopback + Serve norm** — this exception is for a surface whose whole job is that a wrong URL must be visibly wrong.
 
 Access URLs (HTTPS via Tailscale Serve):
 - Open-WebUI: `https://rpi5.tail4249a9.ts.net`
@@ -203,10 +193,10 @@ from the [claude-shared](https://github.com/alexandru-savinov/claude-shared)
 flake. This repo only:
 
 1. Imports the shared module via `modules/services/claude-shared.nix`
-(exposes `customModules.claudeShared.{enable,users}`).
+   (exposes `customModules.claudeShared.{enable,users}`).
 2. Wires it into hosts that should get the full CC stack. Currently:
-`rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
-the legacy `customModules.claude` (package install only — no skills/agents).
+   `rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
+   the legacy `customModules.claude` (package install only — no skills/agents).
 3. Carries **project-level** skills under `.claude/skills/` — see below.
 
 ### Where to edit Claude Code content
@@ -264,11 +254,11 @@ formatting failures.
 
 1. **State the hypothesis** — one sentence: *"I believe the root cause is X because Y."* Name the exact option, file, or behavior.
 2. **Design a minimal test** — the smallest command that confirms or refutes the hypothesis *without making changes*:
-```bash
-nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
-nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
-grep -r "optionName" modules/                                              # find where it's set
-```
+   ```bash
+   nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
+   nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
+   grep -r "optionName" modules/                                              # find where it's set
+   ```
 3. **Run the test** — if it refutes the hypothesis, revise and repeat from step 1. Do NOT apply the fix anyway.
 4. **Apply the fix** — minimal change only, exactly what the hypothesis identified.
 5. **Verify** — re-run the same test. Confirm the problem is gone and no new warnings appeared.
@@ -301,9 +291,9 @@ Known pitfalls — do not repeat these:
 
 1. Create module in `modules/services/<name>.nix`
 2. Follow the Tailscale wrapper pattern:
-- Bind to `127.0.0.1` only
-- Create `<name>-tailscale-serve.service` for HTTPS proxy
-- Use `age.secrets` for sensitive config
+   - Bind to `127.0.0.1` only
+   - Create `<name>-tailscale-serve.service` for HTTPS proxy
+   - Use `age.secrets` for sensitive config
 3. Add to host configuration
 4. Add secret to `secrets/secrets.nix` if needed
 
@@ -314,9 +304,9 @@ For long-running n8n workflows (>60s), use the async job pattern to prevent brow
 ### Architecture
 ```
 User → Main Webhook → Create Job ID → Trigger Worker → Return HTTP 202 immediately
-│
-↓ (fire-and-forget)
-Background Worker → Process → Update Status File
+                         │
+                         ↓ (fire-and-forget)
+                   Background Worker → Process → Update Status File
 
 UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 ```
@@ -333,8 +323,8 @@ UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 To trigger background work without blocking:
 ```json
 {
-"options": { "timeout": 1000 },
-"continueOnFail": true
+  "options": { "timeout": 1000 },
+  "continueOnFail": true
 }
 ```
 
@@ -342,7 +332,7 @@ To trigger background work without blocking:
 Enable Node.js built-in modules for file-based status tracking:
 ```nix
 extraEnvironment = {
-NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
+  NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
 };
 ```
 
@@ -416,7 +406,7 @@ Profile where eval time is spent (built into Nix 2.31+, no extra tools needed):
 ```bash
 # Generate collapsed stack trace
 nix eval --eval-profiler flamegraph --eval-profile-file /tmp/eval.folded \
-.#nixosConfigurations.rpi5-full.config.system.build.toplevel
+  .#nixosConfigurations.rpi5-full.config.system.build.toplevel
 
 # Visualize: upload /tmp/eval.folded to https://speedscope.app
 # Or generate SVG:
@@ -473,8 +463,8 @@ Each service has its own environment variable for binding:
 2. **Service ordering:** Tailscale Serve systemd services use `after` + `requires` on the main service, but this only waits for service start, not for the port to be listening
 
 3. **Idempotent setup:** Check if serve is already configured before adding:
-```bash
-if ! tailscale serve status | grep -q "https:PORT"; then
-tailscale serve --bg --https PORT http://127.0.0.1:PORT
-fi
-```
+   ```bash
+   if ! tailscale serve status | grep -q "https:PORT"; then
+     tailscale serve --bg --https PORT http://127.0.0.1:PORT
+   fi
+   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,21 @@ Custom NixOS modules wrap upstream services with Tailscale integration and ageni
 | `services.tailscale` | - | Mesh VPN (all services exposed via Tailscale only) |
 | `openclaw` (sancta-claw) | 18789 | Official OpenClaw npm package on dedicated VPS |
 | `services.hermes-agent` (hermes-claw) | - | Hermes AI agent in Podman container (upstream module, container mode) |
+| `services.sancta-gallery` (sancta-choir) | 8739 | Rendered surface, publish-gated. **Binds the tailnet address directly** — see the exception below |
 
 **Security Pattern:** Services bind to `127.0.0.1` only, accessed via Tailscale Serve HTTPS proxy. Localhost binding provides defense-in-depth. OpenClaw uses a different model: file-based inbox with per-UID nftables network restriction (no listener).
+
+**Documented exception — `sancta-gallery` on sancta-choir.** It binds the tailnet
+address directly instead of loopback + Serve. On 2026-07-26 a page mounted as a *path*
+under Serve's `/ → 127.0.0.1:8080` catch-all failed silently, and the URL returned
+**200 with Open-WebUI's page**: longest-prefix routing makes `/` the parent of every
+path and an SPA history-fallback answers 200 to anything, so composed they form a total
+function over the URL space in which no mistake is representable. Binding its own origin
+makes a dead service fail as `ECONNREFUSED`, which cannot be mistaken for content.
+Traffic stays inside WireGuard either way; `IPAddressAllow` is narrowed to Tailscale's
+CGNAT/ULA ranges and a wildcard bind is rejected by assertion. **New services should
+still follow the loopback + Serve norm** — this exception is for a surface whose whole
+job is that a wrong URL must be visibly wrong.
 
 Access URLs (HTTPS via Tailscale Serve):
 - Open-WebUI: `https://rpi5.tail4249a9.ts.net`
@@ -190,10 +203,10 @@ from the [claude-shared](https://github.com/alexandru-savinov/claude-shared)
 flake. This repo only:
 
 1. Imports the shared module via `modules/services/claude-shared.nix`
-   (exposes `customModules.claudeShared.{enable,users}`).
+(exposes `customModules.claudeShared.{enable,users}`).
 2. Wires it into hosts that should get the full CC stack. Currently:
-   `rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
-   the legacy `customModules.claude` (package install only — no skills/agents).
+`rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
+the legacy `customModules.claude` (package install only — no skills/agents).
 3. Carries **project-level** skills under `.claude/skills/` — see below.
 
 ### Where to edit Claude Code content
@@ -251,11 +264,11 @@ formatting failures.
 
 1. **State the hypothesis** — one sentence: *"I believe the root cause is X because Y."* Name the exact option, file, or behavior.
 2. **Design a minimal test** — the smallest command that confirms or refutes the hypothesis *without making changes*:
-   ```bash
-   nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
-   nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
-   grep -r "optionName" modules/                                              # find where it's set
-   ```
+```bash
+nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
+nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
+grep -r "optionName" modules/                                              # find where it's set
+```
 3. **Run the test** — if it refutes the hypothesis, revise and repeat from step 1. Do NOT apply the fix anyway.
 4. **Apply the fix** — minimal change only, exactly what the hypothesis identified.
 5. **Verify** — re-run the same test. Confirm the problem is gone and no new warnings appeared.
@@ -288,9 +301,9 @@ Known pitfalls — do not repeat these:
 
 1. Create module in `modules/services/<name>.nix`
 2. Follow the Tailscale wrapper pattern:
-   - Bind to `127.0.0.1` only
-   - Create `<name>-tailscale-serve.service` for HTTPS proxy
-   - Use `age.secrets` for sensitive config
+- Bind to `127.0.0.1` only
+- Create `<name>-tailscale-serve.service` for HTTPS proxy
+- Use `age.secrets` for sensitive config
 3. Add to host configuration
 4. Add secret to `secrets/secrets.nix` if needed
 
@@ -301,9 +314,9 @@ For long-running n8n workflows (>60s), use the async job pattern to prevent brow
 ### Architecture
 ```
 User → Main Webhook → Create Job ID → Trigger Worker → Return HTTP 202 immediately
-                         │
-                         ↓ (fire-and-forget)
-                   Background Worker → Process → Update Status File
+│
+↓ (fire-and-forget)
+Background Worker → Process → Update Status File
 
 UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 ```
@@ -320,8 +333,8 @@ UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 To trigger background work without blocking:
 ```json
 {
-  "options": { "timeout": 1000 },
-  "continueOnFail": true
+"options": { "timeout": 1000 },
+"continueOnFail": true
 }
 ```
 
@@ -329,7 +342,7 @@ To trigger background work without blocking:
 Enable Node.js built-in modules for file-based status tracking:
 ```nix
 extraEnvironment = {
-  NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
+NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
 };
 ```
 
@@ -403,7 +416,7 @@ Profile where eval time is spent (built into Nix 2.31+, no extra tools needed):
 ```bash
 # Generate collapsed stack trace
 nix eval --eval-profiler flamegraph --eval-profile-file /tmp/eval.folded \
-  .#nixosConfigurations.rpi5-full.config.system.build.toplevel
+.#nixosConfigurations.rpi5-full.config.system.build.toplevel
 
 # Visualize: upload /tmp/eval.folded to https://speedscope.app
 # Or generate SVG:
@@ -460,8 +473,8 @@ Each service has its own environment variable for binding:
 2. **Service ordering:** Tailscale Serve systemd services use `after` + `requires` on the main service, but this only waits for service start, not for the port to be listening
 
 3. **Idempotent setup:** Check if serve is already configured before adding:
-   ```bash
-   if ! tailscale serve status | grep -q "https:PORT"; then
-     tailscale serve --bg --https PORT http://127.0.0.1:PORT
-   fi
-   ```
+```bash
+if ! tailscale serve status | grep -q "https:PORT"; then
+tailscale serve --bg --https PORT http://127.0.0.1:PORT
+fi
+```

--- a/flake.nix
+++ b/flake.nix
@@ -388,6 +388,11 @@
           # cursor, successful turns commit once, and truncation never replays.
           sancta-membrane = import ./tests/sancta-membrane.nix { inherit pkgs; };
 
+          # Doctrine guard branch coverage. Every case asserts a NON-ZERO exit
+          # and the specific message: a guard that cannot be shown to fail is
+          # the 2026-07-21 silent loss with better paperwork.
+          sancta-doctrine-guard = import ./tests/sancta-doctrine-guard.nix { inherit pkgs; };
+
           # NOTE: the declarative n8n VM test (#42) deliberately lives under
           # packages.<system>.n8n-declarative-test, NOT here. `nix flake
           # check` builds every check inside the resource-constrained
@@ -411,6 +416,7 @@
         {
           heartbeat-trusted-context = import ./tests/heartbeat-trusted-context.nix { inherit pkgs; };
           sancta-membrane = import ./tests/sancta-membrane.nix { inherit pkgs; };
+          sancta-doctrine-guard = import ./tests/sancta-doctrine-guard.nix { inherit pkgs; };
         };
 
       # Apps - makes packages runnable with `nix run`

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -50,6 +50,7 @@
     ./soul-volume.nix # encrypted ~/.claude (LUKS-on-loopback, non-destructive)
     ./sancta-worker.nix # guarded comm gateway + resumed `claude -p` worker
     ../../modules/services/sancta-soul-mirror.nix # choir-local encrypted soul vault (rpi5 pulls)
+    ../../modules/services/sancta-doctrine-guard.nix # assert the authored substrate is present + recoverable
   ];
 
   # Enable development tools and agent CLIs.
@@ -246,6 +247,17 @@
     # Private half is agenix secrets/soul-mirror-pull-ssh-key.age (rpi5-only).
     pullPubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIENdU1AjMRcMptUBi/7BGnOFZjTA11Z0pHFpZt0kbeNO rpi5 -> sancta-choir soul-mirror pull";
   };
+
+  # The mirror above backs up whatever is on the volume — INCLUDING a hole. On
+  # 2026-07-21 six council assessor files were lost in the migration and the
+  # weekly mirror faithfully archived their absence for four days. This unit
+  # asserts the authored substrate is actually PRESENT, daily, and fails loud
+  # into the mirror's existing alert path.
+  #
+  # Its assertion table is derived from `git ls-files` inside the soul volume,
+  # never typed here: a hand-maintained list is the same bug wearing a new hat,
+  # and this repo is PUBLIC so no skill name belongs in it anyway.
+  services.sancta-doctrine-guard.enable = true;
 
   # ==========================================================================
   # Open-WebUI — AI chat gateway via OpenRouter

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -51,6 +51,7 @@
     ./sancta-worker.nix # guarded comm gateway + resumed `claude -p` worker
     ../../modules/services/sancta-soul-mirror.nix # choir-local encrypted soul vault (rpi5 pulls)
     ../../modules/services/sancta-doctrine-guard.nix # assert the authored substrate is present + recoverable
+    ../../modules/services/sancta-gallery.nix # the rendered surface, declared instead of hand-started
   ];
 
   # Enable development tools and agent CLIs.
@@ -258,6 +259,31 @@
   # never typed here: a hand-maintained list is the same bug wearing a new hat,
   # and this repo is PUBLIC so no skill name belongs in it anyway.
   services.sancta-doctrine-guard.enable = true;
+
+  # The rendered surface. On 2026-07-26 three node processes served Sancta's
+  # work and every one was PPID 1 — orphans of `setsid nohup`, started by hand,
+  # surviving no reboot and announcing no death. Both also ran with the non-leak
+  # publish gate DISARMED, because the gate lived in a shell invocation instead
+  # of in the system. The files were committed; the fact that they ran was not.
+  #
+  # bind: the tailnet address, not loopback-plus-`tailscale serve`. Earlier that
+  # same day a page mounted as a PATH under serve's catch-all failed silently and
+  # the URL answered 200 with a different application. One owner per origin: a
+  # dead gallery then fails as ECONNREFUSED, which cannot be mistaken for content.
+  #
+  # NOT declared here: the loopback instance on 127.0.0.1:8739. That is
+  # bin/gallery-shot's hardcoded and only permitted origin — a structural gate,
+  # "so Sancta cannot, not so it promises not to" — and killing it as a duplicate
+  # would remove Sancta's own eyes on what it renders. Second role, not stray copy.
+  services.sancta-gallery = {
+    enable = true;
+    galleryDir = "/var/lib/sancta/.claude/index/gallery";
+    user = "sancta";
+    group = "sancta";
+    bind = "100.94.191.54";
+    requiresMount = "/var/lib/sancta/.claude";
+    onFailureUnit = "sancta-soul-mirror-alert@%N.service";
+  };
 
   # ==========================================================================
   # Open-WebUI — AI chat gateway via OpenRouter

--- a/modules/services/sancta-doctrine-guard.nix
+++ b/modules/services/sancta-doctrine-guard.nix
@@ -106,6 +106,15 @@ in
         assertion = config.services.sancta-soul-mirror.enable or false;
         message = "services.sancta-doctrine-guard requires services.sancta-soul-mirror — it raises alerts through that module's sancta-soul-mirror-alert@ template, which does not exist when the mirror is disabled.";
       }
+      {
+        # The alert template runs as the MIRROR's user, not this guard's. Both
+        # default to "sancta", so there is no live bug — but changing only one
+        # would silently execute the alert under the other account, and the
+        # symptom would be a missing alert, i.e. the failure this module exists
+        # to detect, hiding the failure this module exists to report.
+        assertion = cfg.user == (config.services.sancta-soul-mirror.user or cfg.user);
+        message = "services.sancta-doctrine-guard.user must equal services.sancta-soul-mirror.user — the shared sancta-soul-mirror-alert@ template runs as the mirror's user, so a mismatch would run this guard's alerts under the wrong account.";
+      }
     ];
 
     systemd.services.sancta-doctrine-guard = {

--- a/modules/services/sancta-doctrine-guard.nix
+++ b/modules/services/sancta-doctrine-guard.nix
@@ -8,7 +8,7 @@
 # Nothing on this host was CAPABLE of noticing. Every existing soul unit
 # (soul-open, soul-mount, worker, soul-mirror) gates on the volume being
 # MOUNTED; not one asserts its CONTENT. The backup faithfully archived the
-# absence, weekly, as zero-knowledge ciphertext.
+# absence, weekly, as zero-knowledge ciphertext — a mirror of a hole is a hole.
 #
 # The control case proves it was never the mechanism that failed: compliance.md,
 # opportunity.md and risk.md sat in the same directory, went through the same
@@ -19,16 +19,22 @@
 #
 # THREE RULES THIS MODULE OBEYS, AND WHY
 #
-#   1. Assertions are DERIVED from `git ls-files`, never typed here. A
-#      hand-maintained list of "files that must exist" is the 2026-07-21 bug
-#      wearing a new hat: it goes stale the moment a skill is added, and the
-#      thing that would remind you is the same passive signal that already
-#      failed once. Commit a skill and it is asserted automatically.
+#   1. Assertions are DERIVED from `git ls-files`, never typed. A hand-maintained
+#      list of "files that must exist" is the 2026-07-21 bug wearing a new hat:
+#      it goes stale the moment a skill is added, and the thing that would remind
+#      you is the same passive signal that already failed once. Commit a skill
+#      and it is asserted automatically.
 #
 #      Consequence for the volatility axis: the MECHANISM lives here in Nix
 #      (deploy-speed); WHAT COUNTS AS DOCTRINE lives in git inside the soul
-#      volume (thought-speed). Neither leaks into the other, and no skill name
-#      ever appears in this PUBLIC repo.
+#      volume (thought-speed). Neither leaks into the other.
+#
+#      Precisely: no PRIVATE doctrine name appears in this PUBLIC repo. The one
+#      hardcoded list in the script — compliance/opportunity/risk — is the
+#      deliberate exception, and naming those three costs nothing because they
+#      are already public in the claude-shared flake. They are also the only
+#      entries that CANNOT be derived: they live outside both private repos, so
+#      no `git ls-files` reaches them. The derived half is the half that grows.
 #
 #   2. Drift — a skill on disk that was never committed — is FATAL, not a
 #      warning. This host is headless. Nobody reads a journal warning; that is
@@ -40,110 +46,20 @@
 #      gets muted within a fortnight, and a muted guard is worse than none —
 #      it returns you to silence while feeling covered.
 #
+# The logic lives in sancta-doctrine-guard.sh rather than inline here so that
+# tests/sancta-doctrine-guard.nix can exercise its branches against fixture
+# trees. Tools come from PATH: systemd `path` here, nativeBuildInputs there.
+#
 # WHAT IT DOES NOT PROVE: correctness. A committed file edited to garbage will
 # not fire. This proves existence and recoverability only. Named, not hidden.
 
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkOption mkEnableOption types escapeShellArg;
+  inherit (lib) mkIf mkOption mkEnableOption types;
   cfg = config.services.sancta-doctrine-guard;
   soulRoot = toString config.services.sancta-soul-volume.mountPoint;
-
-  guardScript = pkgs.writeShellScript "sancta-doctrine-guard" ''
-    set -uo pipefail
-
-    CLAUDE=${escapeShellArg soulRoot}
-    SKILLS="$CLAUDE/skills"
-    LENSES="$CLAUDE/lenses"
-
-    GIT=${pkgs.git}/bin/git
-    JQ=${pkgs.jq}/bin/jq
-    DIFF=${pkgs.diffutils}/bin/diff
-    MOUNTPOINT=${pkgs.util-linux}/bin/mountpoint
-
-    # git must not take the index lock: the unit runs with ReadOnlyPaths on the
-    # soul volume, so an index refresh would fail the run for the wrong reason.
-    export GIT_OPTIONAL_LOCKS=0
-
-    fails=0
-    miss() { printf 'FAIL: %s\n' "$*" >&2; fails=$((fails + 1)); }
-    note() { printf 'ok:   %s\n' "$*"; }
-
-    # 0. The volume itself. The unit is ConditionPathIsMountPoint-gated, but the
-    #    script must also be safe to run by hand where nothing gates it.
-    if ! "$MOUNTPOINT" -q "$CLAUDE"; then
-      echo "SKIP: $CLAUDE is not a mountpoint — soul volume not mounted" >&2
-      exit 0
-    fi
-
-    # 1. Tracked: derived from git, never typed.
-    for repo in "$SKILLS" "$LENSES"; do
-      if [ ! -d "$repo/.git" ]; then
-        miss "not a git repo: $repo"
-        continue
-      fi
-      n=0
-      while IFS= read -r f; do
-        n=$((n + 1))
-        [ -s "$repo/$f" ] || miss "missing or empty: $repo/$f"
-      done < <("$GIT" -C "$repo" --no-optional-locks ls-files)
-      [ "$n" -gt 0 ] || miss "no tracked files at all in $repo"
-      note "$(basename "$repo"): $n tracked entries asserted"
-    done
-
-    # 2. Drift — FATAL. Only real directories count; the home-manager symlinks
-    #    are wiring, not doctrine, and are correctly out of scope.
-    committed=$("$GIT" -C "$SKILLS" --no-optional-locks ls-files -- '*/SKILL.md' 2>/dev/null | sort)
-    ondisk=$(cd "$SKILLS" 2>/dev/null && for d in */; do
-      b="''${d%/}"
-      [ -L "$b" ] && continue
-      [ -f "$b/SKILL.md" ] && echo "$b/SKILL.md"
-    done | sort)
-
-    if [ "$committed" != "$ondisk" ]; then
-      while IFS= read -r line; do
-        [ -z "$line" ] && continue
-        case "$line" in
-          \>*) miss "skill on disk but NEVER COMMITTED: ''${line#> }" ;;
-          \<*) miss "skill committed but missing from disk: ''${line#< }" ;;
-        esac
-      done < <("$DIFF" <(echo "$committed") <(echo "$ondisk") | ${pkgs.gnugrep}/bin/grep -E '^[<>]')
-    else
-      note "drift: committed set == on-disk set"
-    fi
-
-    # 3. Present: lives outside both repos. Small, static — this list does NOT
-    #    grow when a skill is added; that half is derived above.
-    for p in "$CLAUDE/settings.json" "$CLAUDE/CLAUDE.md"; do
-      [ -s "$p" ] || miss "missing or empty: $p"
-    done
-    # The three PUBLIC voting assessors, reached THROUGH the council symlink and
-    # never via a hardcoded target, so the contract survives claude-shared being
-    # relaid out internally.
-    for a in compliance opportunity risk; do
-      p="$SKILLS/council/assessors/$a.md"
-      [ -s "$p" ] || miss "missing or empty public assessor: council/assessors/$a.md"
-    done
-
-    # 4. The settings.json hook block.
-    #    `jq -e '.hooks.UserPromptSubmit'` PASSES on {"UserPromptSubmit":[]} —
-    #    jq -e fails only on null/false. An empty array is the most likely shape
-    #    of the 2026-07-25 10:32 regression, where a settings writer preserved
-    #    the key and dropped the contents. `length > 0` is the fix; verified in
-    #    both directions before this shipped.
-    if [ -s "$CLAUDE/settings.json" ]; then
-      "$JQ" -e '(.hooks.UserPromptSubmit // []) | length > 0' "$CLAUDE/settings.json" >/dev/null 2>&1 \
-        || miss "settings.json lost hooks.UserPromptSubmit (empty or absent)"
-    fi
-
-    if [ "$fails" -gt 0 ]; then
-      printf '\nsancta-doctrine-guard: %d assertion(s) FAILED\n' "$fails" >&2
-      exit 1
-    fi
-    printf '\nsancta-doctrine-guard: all assertions hold\n'
-    exit 0
-  '';
+  guardScript = ./sancta-doctrine-guard.sh;
 in
 {
   options.services.sancta-doctrine-guard = {
@@ -183,17 +99,35 @@ in
 
     systemd.services.sancta-doctrine-guard = {
       description = "Sancta doctrine guard (assert the authored substrate is present and recoverable)";
-      # Reuse the EXISTING alert path rather than inventing a second one.
+      # Reuse the EXISTING alert path rather than inventing a second one. That
+      # handler derives all of its user-facing text from the unit name it is
+      # passed (%N), so an alert raised here names this unit — including the
+      # journalctl hint. Hardcoded "soul-mirror" wording there would send an
+      # operator to an idle journal, which is the signal-gets-missed failure
+      # this whole unit exists to close.
       onFailure = [ "sancta-soul-mirror-alert@%N.service" ];
       after = [ "sancta-soul-mount.service" ];
       requires = [ "sancta-soul-mount.service" ];
       unitConfig.ConditionPathIsMountPoint = soulRoot;
+      path = with pkgs; [
+        git
+        jq
+        diffutils
+        util-linux
+        gnugrep
+        coreutils
+      ];
       serviceConfig = {
         Type = "oneshot";
         User = cfg.user;
-        ExecStart = guardScript;
-        # git wants a HOME; without it `git -C` warns and can behave oddly.
-        Environment = [ "HOME=${builtins.dirOf soulRoot}" ];
+        ExecStart = "${pkgs.bash}/bin/bash ${guardScript}";
+        Environment = [
+          "SANCTA_DOCTRINE_ROOT=${soulRoot}"
+          # Belt and braces beside ConditionPathIsMountPoint above; the unit
+          # gate is the real one, this only makes the script safe standalone.
+          "SANCTA_DOCTRINE_REQUIRE_MOUNT=1"
+          "HOME=${builtins.dirOf soulRoot}"
+        ];
         TimeoutStartSec = "5m";
         Nice = 15;
         IOSchedulingClass = "idle";

--- a/modules/services/sancta-doctrine-guard.nix
+++ b/modules/services/sancta-doctrine-guard.nix
@@ -1,0 +1,230 @@
+# sancta-doctrine-guard — assert the authored substrate is present and recoverable.
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-07-21: the RPi5 → sancta-choir migration lost six council assessor files.
+# 2026-07-25: found four days later, by accident, during an unrelated /doctor run.
+#
+# Nothing on this host was CAPABLE of noticing. Every existing soul unit
+# (soul-open, soul-mount, worker, soul-mirror) gates on the volume being
+# MOUNTED; not one asserts its CONTENT. The backup faithfully archived the
+# absence, weekly, as zero-knowledge ciphertext.
+#
+# The control case proves it was never the mechanism that failed: compliance.md,
+# opportunity.md and risk.md sat in the same directory, went through the same
+# migration, and survived — because they were committed. The three that lived
+# were in a repo. The six that died were not.
+#
+# Design: ~/.claude/index/docs/plans/2026-07-25-substrate-permanence-design.md §4
+#
+# THREE RULES THIS MODULE OBEYS, AND WHY
+#
+#   1. Assertions are DERIVED from `git ls-files`, never typed here. A
+#      hand-maintained list of "files that must exist" is the 2026-07-21 bug
+#      wearing a new hat: it goes stale the moment a skill is added, and the
+#      thing that would remind you is the same passive signal that already
+#      failed once. Commit a skill and it is asserted automatically.
+#
+#      Consequence for the volatility axis: the MECHANISM lives here in Nix
+#      (deploy-speed); WHAT COUNTS AS DOCTRINE lives in git inside the soul
+#      volume (thought-speed). Neither leaks into the other, and no skill name
+#      ever appears in this PUBLIC repo.
+#
+#   2. Drift — a skill on disk that was never committed — is FATAL, not a
+#      warning. This host is headless. Nobody reads a journal warning; that is
+#      precisely the class of signal that let four days pass. A hard failure is
+#      a ten-second fix.
+#
+#   3. Worktree cleanliness is NEVER checked. A dirty tree mid-edit is normal;
+#      a missing file never is. A guard that cries wolf during ordinary work
+#      gets muted within a fortnight, and a muted guard is worse than none —
+#      it returns you to silence while feeling covered.
+#
+# WHAT IT DOES NOT PROVE: correctness. A committed file edited to garbage will
+# not fire. This proves existence and recoverability only. Named, not hidden.
+
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkOption mkEnableOption types escapeShellArg;
+  cfg = config.services.sancta-doctrine-guard;
+  soulRoot = toString config.services.sancta-soul-volume.mountPoint;
+
+  guardScript = pkgs.writeShellScript "sancta-doctrine-guard" ''
+    set -uo pipefail
+
+    CLAUDE=${escapeShellArg soulRoot}
+    SKILLS="$CLAUDE/skills"
+    LENSES="$CLAUDE/lenses"
+
+    GIT=${pkgs.git}/bin/git
+    JQ=${pkgs.jq}/bin/jq
+    DIFF=${pkgs.diffutils}/bin/diff
+    MOUNTPOINT=${pkgs.util-linux}/bin/mountpoint
+
+    # git must not take the index lock: the unit runs with ReadOnlyPaths on the
+    # soul volume, so an index refresh would fail the run for the wrong reason.
+    export GIT_OPTIONAL_LOCKS=0
+
+    fails=0
+    miss() { printf 'FAIL: %s\n' "$*" >&2; fails=$((fails + 1)); }
+    note() { printf 'ok:   %s\n' "$*"; }
+
+    # 0. The volume itself. The unit is ConditionPathIsMountPoint-gated, but the
+    #    script must also be safe to run by hand where nothing gates it.
+    if ! "$MOUNTPOINT" -q "$CLAUDE"; then
+      echo "SKIP: $CLAUDE is not a mountpoint — soul volume not mounted" >&2
+      exit 0
+    fi
+
+    # 1. Tracked: derived from git, never typed.
+    for repo in "$SKILLS" "$LENSES"; do
+      if [ ! -d "$repo/.git" ]; then
+        miss "not a git repo: $repo"
+        continue
+      fi
+      n=0
+      while IFS= read -r f; do
+        n=$((n + 1))
+        [ -s "$repo/$f" ] || miss "missing or empty: $repo/$f"
+      done < <("$GIT" -C "$repo" --no-optional-locks ls-files)
+      [ "$n" -gt 0 ] || miss "no tracked files at all in $repo"
+      note "$(basename "$repo"): $n tracked entries asserted"
+    done
+
+    # 2. Drift — FATAL. Only real directories count; the home-manager symlinks
+    #    are wiring, not doctrine, and are correctly out of scope.
+    committed=$("$GIT" -C "$SKILLS" --no-optional-locks ls-files -- '*/SKILL.md' 2>/dev/null | sort)
+    ondisk=$(cd "$SKILLS" 2>/dev/null && for d in */; do
+      b="''${d%/}"
+      [ -L "$b" ] && continue
+      [ -f "$b/SKILL.md" ] && echo "$b/SKILL.md"
+    done | sort)
+
+    if [ "$committed" != "$ondisk" ]; then
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        case "$line" in
+          \>*) miss "skill on disk but NEVER COMMITTED: ''${line#> }" ;;
+          \<*) miss "skill committed but missing from disk: ''${line#< }" ;;
+        esac
+      done < <("$DIFF" <(echo "$committed") <(echo "$ondisk") | ${pkgs.gnugrep}/bin/grep -E '^[<>]')
+    else
+      note "drift: committed set == on-disk set"
+    fi
+
+    # 3. Present: lives outside both repos. Small, static — this list does NOT
+    #    grow when a skill is added; that half is derived above.
+    for p in "$CLAUDE/settings.json" "$CLAUDE/CLAUDE.md"; do
+      [ -s "$p" ] || miss "missing or empty: $p"
+    done
+    # The three PUBLIC voting assessors, reached THROUGH the council symlink and
+    # never via a hardcoded target, so the contract survives claude-shared being
+    # relaid out internally.
+    for a in compliance opportunity risk; do
+      p="$SKILLS/council/assessors/$a.md"
+      [ -s "$p" ] || miss "missing or empty public assessor: council/assessors/$a.md"
+    done
+
+    # 4. The settings.json hook block.
+    #    `jq -e '.hooks.UserPromptSubmit'` PASSES on {"UserPromptSubmit":[]} —
+    #    jq -e fails only on null/false. An empty array is the most likely shape
+    #    of the 2026-07-25 10:32 regression, where a settings writer preserved
+    #    the key and dropped the contents. `length > 0` is the fix; verified in
+    #    both directions before this shipped.
+    if [ -s "$CLAUDE/settings.json" ]; then
+      "$JQ" -e '(.hooks.UserPromptSubmit // []) | length > 0' "$CLAUDE/settings.json" >/dev/null 2>&1 \
+        || miss "settings.json lost hooks.UserPromptSubmit (empty or absent)"
+    fi
+
+    if [ "$fails" -gt 0 ]; then
+      printf '\nsancta-doctrine-guard: %d assertion(s) FAILED\n' "$fails" >&2
+      exit 1
+    fi
+    printf '\nsancta-doctrine-guard: all assertions hold\n'
+    exit 0
+  '';
+in
+{
+  options.services.sancta-doctrine-guard = {
+    enable = mkEnableOption "Sancta doctrine guard (assert the authored substrate is present and recoverable)";
+
+    user = mkOption {
+      type = types.str;
+      default = "sancta";
+      description = "Account that owns the soul volume and the doctrine repos.";
+    };
+
+    onCalendar = mkOption {
+      type = types.str;
+      default = "*-*-* 09:00:00";
+      description = ''
+        systemd OnCalendar. Daily by default: the 2026-07-21 loss went four days
+        undetected, and a daily check bounds that window to ~24h. Cheap enough
+        (two `git ls-files` and a handful of stat calls) that a tighter cadence
+        would buy nothing.
+      '';
+    };
+
+    randomizedDelaySec = mkOption {
+      type = types.str;
+      default = "10m";
+      description = "systemd RandomizedDelaySec, so the guard never lands exactly on another unit's minute.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.sancta-soul-volume.enable or false;
+        message = "services.sancta-doctrine-guard requires services.sancta-soul-volume — it asserts content ON that mount.";
+      }
+    ];
+
+    systemd.services.sancta-doctrine-guard = {
+      description = "Sancta doctrine guard (assert the authored substrate is present and recoverable)";
+      # Reuse the EXISTING alert path rather than inventing a second one.
+      onFailure = [ "sancta-soul-mirror-alert@%N.service" ];
+      after = [ "sancta-soul-mount.service" ];
+      requires = [ "sancta-soul-mount.service" ];
+      unitConfig.ConditionPathIsMountPoint = soulRoot;
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        ExecStart = guardScript;
+        # git wants a HOME; without it `git -C` warns and can behave oddly.
+        Environment = [ "HOME=${builtins.dirOf soulRoot}" ];
+        TimeoutStartSec = "5m";
+        Nice = 15;
+        IOSchedulingClass = "idle";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = false;
+        # Read-only over the whole soul volume: this unit asserts, it never
+        # repairs. Anything that could write is out of scope by construction.
+        ReadOnlyPaths = [ soulRoot ];
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        # No network. It reads local files and nothing else.
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        SystemCallFilter = [ "@system-service" ];
+      };
+    };
+
+    systemd.timers.sancta-doctrine-guard = {
+      description = "Daily Sancta doctrine guard";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.onCalendar;
+        Persistent = true;
+        RandomizedDelaySec = cfg.randomizedDelaySec;
+      };
+    };
+  };
+}

--- a/modules/services/sancta-doctrine-guard.nix
+++ b/modules/services/sancta-doctrine-guard.nix
@@ -95,6 +95,17 @@ in
         assertion = config.services.sancta-soul-volume.enable or false;
         message = "services.sancta-doctrine-guard requires services.sancta-soul-volume — it asserts content ON that mount.";
       }
+      {
+        # onFailure below targets sancta-soul-mirror-alert@, which is declared
+        # inside sancta-soul-mirror's own `mkIf cfg.enable`. Enable this guard
+        # on a host with the volume but not the mirror and systemd resolves
+        # OnFailure= to a non-existent unit: it records a failed transient job
+        # and the alert script never runs, so a real failure never reaches the
+        # feed. That is silently-lost-signal — the exact thing this module was
+        # written to end — so it fails at BUILD time instead.
+        assertion = config.services.sancta-soul-mirror.enable or false;
+        message = "services.sancta-doctrine-guard requires services.sancta-soul-mirror — it raises alerts through that module's sancta-soul-mirror-alert@ template, which does not exist when the mirror is disabled.";
+      }
     ];
 
     systemd.services.sancta-doctrine-guard = {

--- a/modules/services/sancta-doctrine-guard.sh
+++ b/modules/services/sancta-doctrine-guard.sh
@@ -116,6 +116,41 @@ else
   fi
 fi
 
+# ── 2b. drift in the LENSES repo — also FATAL ──────────────────────────────
+# Section 1 catches a lens that was committed and then vanished. It cannot catch
+# the opposite: a lens WRITTEN but never committed — and that half is exactly
+# how the 2026-07-21 loss happened. The six assessors sat on disk for days and
+# nothing minded, because nothing was tracking them.
+#
+# Skills are directories with a manifest, so their on-disk set is `*/SKILL.md`.
+# Lenses are flat markdown at the repo root, so theirs is `*.md`, compared
+# against the tracked set filtered the same way. Nested paths (bin/, any future
+# subdirectory) stay covered by section 1's existence check and deliberately not
+# by this one — widening it would make the two sets disagree by construction and
+# the guard would cry wolf on every run.
+if [ ! -d "$LENSES/.git" ]; then
+  note "lens drift: SKIPPED — lenses repo unusable (see failures above)"
+else
+  lens_committed=$(git -C "$LENSES" --no-optional-locks ls-files -- ':(glob)*.md' 2>/dev/null | sort)
+  lens_ondisk=$(cd "$LENSES" 2>/dev/null && for f in *.md; do
+    [ -e "$f" ] || continue # no matches leaves the pattern itself; skip it
+    [ -L "$f" ] && continue # symlinks are wiring, same rule as skills
+    echo "$f"
+  done | sort)
+
+  if [ "$lens_committed" != "$lens_ondisk" ]; then
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      case "$line" in
+        \>*) miss "lens on disk but NEVER COMMITTED: ${line#> }" ;;
+        \<*) miss "lens committed but missing from disk: ${line#< }" ;;
+      esac
+    done < <(diff <(echo "$lens_committed") <(echo "$lens_ondisk") | grep -E '^[<>]')
+  else
+    note "lens drift: committed set == on-disk set"
+  fi
+fi
+
 # ── 3. present: lives outside both repos. Small, static. ───────────────────
 # This list does NOT grow when a skill is added — that half is derived above.
 for p in "$CLAUDE/settings.json" "$CLAUDE/CLAUDE.md"; do

--- a/modules/services/sancta-doctrine-guard.sh
+++ b/modules/services/sancta-doctrine-guard.sh
@@ -85,7 +85,12 @@ done
 if [ "$skills_usable" -eq 0 ]; then
   note "drift: SKIPPED — skills repo unusable (see failures above)"
 else
-  committed=$(git -C "$SKILLS" --no-optional-locks ls-files -- '*/SKILL.md' 2>/dev/null | sort)
+  # :(glob) is load-bearing: git's DEFAULT pathspec is wildmatch, where a bare *
+  # crosses '/', so '*/SKILL.md' would also match a/b/SKILL.md while the on-disk
+  # side below enumerates exactly one level. The two sets would then disagree
+  # permanently and drift would fire forever, unfixable by renaming - the
+  # cry-wolf outcome this module exists to avoid.
+  committed=$(git -C "$SKILLS" --no-optional-locks ls-files -- ':(glob)*/SKILL.md' 2>/dev/null | sort)
   ondisk=$(cd "$SKILLS" 2>/dev/null && for d in */; do
     b="${d%/}"
     # home-manager symlinks are wiring, not doctrine. In production these point

--- a/modules/services/sancta-doctrine-guard.sh
+++ b/modules/services/sancta-doctrine-guard.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# sancta-doctrine-guard — assert the authored substrate is present and recoverable.
+#
+# A plain script rather than an inline Nix string so tests/sancta-doctrine-guard.nix
+# can exercise its branches against fixture trees. Tools come from PATH; the unit
+# supplies them via systemd `path`, the test via nativeBuildInputs.
+#
+# Contract:
+#   SANCTA_DOCTRINE_ROOT      required — the soul root to assert against
+#   SANCTA_DOCTRINE_REQUIRE_MOUNT=1  optional — refuse to run unless that root is
+#                             a mountpoint. The unit sets it; tests do not. This
+#                             is belt-and-braces only: the real gate is systemd's
+#                             ConditionPathIsMountPoint, which no env var reaches.
+#
+# Exit 0 = every assertion holds. Exit 1 = at least one failed; all are printed.
+#
+# Proves existence and recoverability. NOT correctness: a committed file edited
+# to garbage will not fire. Named here rather than hidden.
+
+set -uo pipefail
+
+CLAUDE="${SANCTA_DOCTRINE_ROOT:-}"
+if [ -z "$CLAUDE" ]; then
+  echo "FAIL: SANCTA_DOCTRINE_ROOT is unset" >&2
+  exit 1
+fi
+SKILLS="$CLAUDE/skills"
+LENSES="$CLAUDE/lenses"
+
+export GIT_OPTIONAL_LOCKS=0 # the unit runs read-only over the volume
+
+fails=0
+miss() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+note() { printf 'ok:   %s\n' "$*"; }
+
+# ── 0. the volume itself ───────────────────────────────────────────────────
+if [ "${SANCTA_DOCTRINE_REQUIRE_MOUNT:-0}" = "1" ] && ! mountpoint -q "$CLAUDE"; then
+  echo "SKIP: $CLAUDE is not a mountpoint — soul volume not mounted" >&2
+  exit 0
+fi
+
+# ── 1. tracked: derived from git, never typed ──────────────────────────────
+skills_usable=1
+for repo in "$SKILLS" "$LENSES"; do
+  if [ ! -d "$repo/.git" ]; then
+    miss "not a git repo: $repo"
+    [ "$repo" = "$SKILLS" ] && skills_usable=0
+    continue
+  fi
+  n=0
+  while IFS= read -r f; do
+    n=$((n + 1))
+    [ -s "$repo/$f" ] || miss "missing or empty: $repo/$f"
+  done < <(git -C "$repo" --no-optional-locks ls-files)
+  if [ "$n" -eq 0 ]; then
+    miss "no tracked files at all in $repo"
+    [ "$repo" = "$SKILLS" ] && skills_usable=0
+  fi
+  note "$(basename "$repo"): $n tracked entries asserted"
+done
+
+# ── 2. drift — FATAL ───────────────────────────────────────────────────────
+# Guarded on skills_usable: with the skills repo missing, BOTH sides degrade to
+# the empty string and compare equal — so the worst case (whole tree gone) would
+# print a reassuring "committed set == on-disk set" into the very journal
+# someone is reading to diagnose the failure. A comforting line beside a failure
+# is how a real signal gets talked away.
+if [ "$skills_usable" -eq 0 ]; then
+  note "drift: SKIPPED — skills repo unusable (see failures above)"
+else
+  committed=$(git -C "$SKILLS" --no-optional-locks ls-files -- '*/SKILL.md' 2>/dev/null | sort)
+  ondisk=$(cd "$SKILLS" 2>/dev/null && for d in */; do
+    b="${d%/}"
+    [ -L "$b" ] && continue # home-manager symlinks are wiring, not doctrine
+    [ -f "$b/SKILL.md" ] && echo "$b/SKILL.md"
+  done | sort)
+
+  if [ "$committed" != "$ondisk" ]; then
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      case "$line" in
+        \>*) miss "skill on disk but NEVER COMMITTED: ${line#> }" ;;
+        \<*) miss "skill committed but missing from disk: ${line#< }" ;;
+      esac
+    done < <(diff <(echo "$committed") <(echo "$ondisk") | grep -E '^[<>]')
+  else
+    note "drift: committed set == on-disk set"
+  fi
+fi
+
+# ── 3. present: lives outside both repos. Small, static. ───────────────────
+# This list does NOT grow when a skill is added — that half is derived above.
+for p in "$CLAUDE/settings.json" "$CLAUDE/CLAUDE.md"; do
+  [ -s "$p" ] || miss "missing or empty: $p"
+done
+# The three PUBLIC voting assessors, reached THROUGH the council symlink and
+# never via a hardcoded target, so the contract survives claude-shared being
+# relaid out internally. These are the only entries that cannot be derived:
+# they live outside both private repos, so no `git ls-files` reaches them.
+for a in compliance opportunity risk; do
+  p="$SKILLS/council/assessors/$a.md"
+  [ -s "$p" ] || miss "missing or empty public assessor: council/assessors/$a.md"
+done
+
+# ── 4. the settings.json hook block ────────────────────────────────────────
+# `jq -e '.hooks.UserPromptSubmit'` PASSES on {"UserPromptSubmit":[]} — jq -e
+# fails only on null/false. An empty array is the most likely shape of the
+# 2026-07-25 10:32 regression, where a settings writer preserved the key and
+# dropped the contents. So the obvious check passes on the exact bug it was
+# written for. `length > 0` is the fix.
+if [ -s "$CLAUDE/settings.json" ]; then
+  jq -e '(.hooks.UserPromptSubmit // []) | length > 0' "$CLAUDE/settings.json" >/dev/null 2>&1 \
+    || miss "settings.json lost hooks.UserPromptSubmit (empty or absent)"
+fi
+
+# ── verdict ────────────────────────────────────────────────────────────────
+if [ "$fails" -gt 0 ]; then
+  printf '\nsancta-doctrine-guard: %d assertion(s) FAILED\n' "$fails" >&2
+  exit 1
+fi
+printf '\nsancta-doctrine-guard: all assertions hold\n'
+exit 0

--- a/modules/services/sancta-doctrine-guard.sh
+++ b/modules/services/sancta-doctrine-guard.sh
@@ -50,11 +50,25 @@ for repo in "$SKILLS" "$LENSES"; do
     [ "$repo" = "$SKILLS" ] && skills_usable=0
     continue
   fi
+
+  # Capture status separately from output. `git ls-files` can fail for reasons
+  # that are NOT "the repo is empty" — most realistically "detected dubious
+  # ownership" if the volume's uid/gid ever drifts from the unit's User=.
+  # Reporting that as "no tracked files at all" would send whoever is reading
+  # this down a repo-is-empty path when the real answer is ownership.
+  if ! listing=$(git -C "$repo" --no-optional-locks ls-files 2>&1); then
+    miss "git ls-files FAILED in $repo (not an empty repo — check ownership/permissions): $listing"
+    [ "$repo" = "$SKILLS" ] && skills_usable=0
+    continue
+  fi
+
   n=0
   while IFS= read -r f; do
+    [ -z "$f" ] && continue
     n=$((n + 1))
     [ -s "$repo/$f" ] || miss "missing or empty: $repo/$f"
-  done < <(git -C "$repo" --no-optional-locks ls-files)
+  done <<<"$listing"
+
   if [ "$n" -eq 0 ]; then
     miss "no tracked files at all in $repo"
     [ "$repo" = "$SKILLS" ] && skills_usable=0
@@ -74,7 +88,13 @@ else
   committed=$(git -C "$SKILLS" --no-optional-locks ls-files -- '*/SKILL.md' 2>/dev/null | sort)
   ondisk=$(cd "$SKILLS" 2>/dev/null && for d in */; do
     b="${d%/}"
-    [ -L "$b" ] && continue # home-manager symlinks are wiring, not doctrine
+    # home-manager symlinks are wiring, not doctrine. In production these point
+    # at REAL store directories, so they DO match the */ glob above and this
+    # skip is load-bearing: without it every symlinked skill would be reported
+    # as "on disk but NEVER COMMITTED" on every run, and a guard that cries
+    # wolf gets muted. (A *dangling* symlink never matches */ at all, which is
+    # why the test fixture must use a resolvable one to cover this line.)
+    [ -L "$b" ] && continue
     [ -f "$b/SKILL.md" ] && echo "$b/SKILL.md"
   done | sort)
 
@@ -111,9 +131,16 @@ done
 # 2026-07-25 10:32 regression, where a settings writer preserved the key and
 # dropped the contents. So the obvious check passes on the exact bug it was
 # written for. `length > 0` is the fix.
+#
+# Validity is checked FIRST and reported distinctly: malformed JSON and
+# hooks-were-stripped are different incidents with different fixes, and giving
+# them the same message would send whoever reads it looking for the wrong one.
 if [ -s "$CLAUDE/settings.json" ]; then
-  jq -e '(.hooks.UserPromptSubmit // []) | length > 0' "$CLAUDE/settings.json" >/dev/null 2>&1 \
-    || miss "settings.json lost hooks.UserPromptSubmit (empty or absent)"
+  if ! jq -e . "$CLAUDE/settings.json" >/dev/null 2>&1; then
+    miss "settings.json is not valid JSON (parse error — NOT the hooks regression)"
+  elif ! jq -e '(.hooks.UserPromptSubmit // []) | length > 0' "$CLAUDE/settings.json" >/dev/null 2>&1; then
+    miss "settings.json lost hooks.UserPromptSubmit (empty or absent)"
+  fi
 fi
 
 # ── verdict ────────────────────────────────────────────────────────────────

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -45,17 +45,88 @@ in
       default = "/home/nixos/.claude/index/gallery";
       description = "Directory holding server.mjs, the pieces and their .passed sidecars.";
     };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "nixos";
+      description = "Account owning galleryDir. On sancta-choir the index owner is `sancta`, not `nixos`.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "users";
+      description = "Primary group of `user`.";
+    };
+
+    bind = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address the server binds. Default loopback, proxied onto the tailnet by
+        `tailscale serve` (the 2026-07-11 shape).
+
+        A tailnet address may be given instead, and on sancta-choir that is the
+        chosen shape — because on 2026-07-26 a page mounted as a PATH under
+        `tailscale serve`'s catch-all silently failed and the URL returned 200
+        with a DIFFERENT application's page. Longest-prefix routing makes `/` the
+        parent of every path, and an SPA history-fallback answers 200 to
+        anything; composed, no URL can produce an error, so no check can observe
+        a mistake. Binding its own origin makes a dead gallery fail as
+        ECONNREFUSED, which cannot be mistaken for content.
+
+        A wildcard (0.0.0.0 / ::) is rejected by assertion: tailnet-only is a
+        property of the binding, not of a firewall rule someone must remember.
+      '';
+    };
+
+    requiresMount = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        If set, the unit requires that path to be a live mountpoint and refuses
+        to start otherwise. On sancta-choir the gallery lives on the LUKS soul
+        volume; serving 404s off the bare underlay would look merely empty
+        instead of broken.
+      '';
+    };
+
+    onFailureUnit = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "sancta-soul-mirror-alert@%N.service";
+      description = ''
+        Optional unit to trigger on failure. Without it a crashed gallery is
+        silent until someone notices the page is gone — the failure mode the
+        hand-started processes had, kept by accident.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.bind != "0.0.0.0" && cfg.bind != "::";
+        message = "services.sancta-gallery.bind must not be a wildcard address — the gallery is loopback- or tailnet-only by construction, never by firewall.";
+      }
+    ];
+
     systemd.services.sancta-gallery = {
       description = "Sancta Gallery — read-only static viewer with publish gate";
-      after = [ "network.target" ];
+      after = [ "network.target" ]
+        ++ lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
+      requires = lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
       wantedBy = [ "multi-user.target" ];
+      onFailure = lib.optional (cfg.onFailureUnit != null) cfg.onFailureUnit;
 
       # If the (deliberately non-store) server script is missing, stay
       # inactive rather than crash-loop.
-      unitConfig.ConditionPathExists = "${cfg.galleryDir}/server.mjs";
+      unitConfig = {
+        ConditionPathExists = "${cfg.galleryDir}/server.mjs";
+      } // lib.optionalAttrs (cfg.requiresMount != null) {
+        # Unmounted volume → refuse to start rather than serve an empty
+        # directory. A wrong answer is worse than no answer.
+        ConditionPathIsMountPoint = toString cfg.requiresMount;
+      };
 
       # Rate-limit restarts: a persistently crashing server ends up in a
       # loud `systemctl --failed` state instead of oscillating forever.
@@ -71,12 +142,13 @@ in
         # responsibility of the painter/publish pipeline (Sancta's index),
         # not of this unit.
         GALLERY_PUBLISH_GATE = "1";
+        GALLERY_BIND = cfg.bind;
       };
 
       serviceConfig = {
         Type = "simple";
-        User = "nixos";
-        Group = "users";
+        User = cfg.user;
+        Group = cfg.group;
         WorkingDirectory = cfg.galleryDir;
         ExecStart = "${pkgs.nodejs}/bin/node ${cfg.galleryDir}/server.mjs";
         Restart = "always";
@@ -109,7 +181,26 @@ in
         # host over loopback, so the tailnet path keeps working.
         SocketBindAllow = "tcp:8739";
         SocketBindDeny = "any";
+      }
+      // lib.optionalAttrs (cfg.bind == "127.0.0.1" || cfg.bind == "::1") {
+        # Loopback shape (the 2026-07-11 authorization): packets may go nowhere
+        # but loopback, so even a modified server.mjs cannot reach the network.
+        # `tailscale serve` proxies from the same host over loopback.
         IPAddressAllow = [
+          "127.0.0.1/32"
+          "::1/128"
+        ];
+        IPAddressDeny = "any";
+      }
+      // lib.optionalAttrs (cfg.bind != "127.0.0.1" && cfg.bind != "::1") {
+        # Own-origin shape (sancta-choir): the process binds the tailnet address
+        # itself, so loopback-only IP filtering would block the very traffic it
+        # exists to serve. The port restriction above still holds — it may bind
+        # tcp:8739 and nothing else — and the CGNAT range is the tailnet's own,
+        # so this permits Tailscale peers and nothing on the public internet.
+        IPAddressAllow = [
+          "100.64.0.0/10"
+          "fd7a:115c:a1e0::/48"
           "127.0.0.1/32"
           "::1/128"
         ];

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -19,15 +19,39 @@
 #     credentials, or anything else under /home.
 #   - ConditionPathExists guards the mutable script: if server.mjs is
 #     absent the unit stays inactive instead of crash-looping.
-#   - The unit runs as User=nixos (the index owner), same as the nohup
-#     process it replaces.
-#   - Binding stays 127.0.0.1:8739 (server default) and is ENFORCED at the
-#     systemd level (SocketBindAllow tcp:8739 only + IPAddressAllow
-#     loopback only), so even a modified server.mjs cannot silently listen
-#     on 0.0.0.0 or another port. `tailscale serve` already proxies it onto
-#     the tailnet with TLS (the proxy connects over loopback, which stays
-#     allowed). Declaring the serve rule is intentionally out of scope here
-#     (per the 2026-07-11 authorization).
+#   - The unit runs as the index owner (`user`/`group`): `nixos` on rpi5,
+#     `sancta` on sancta-choir after the 2026-07-22 migration.
+#   - The port is ALWAYS enforced at the systemd level (SocketBindAllow
+#     tcp:8739 only), so even a modified server.mjs cannot silently listen
+#     on another port.
+#
+# TWO BIND SHAPES (2026-07-26). `bind` selects between them and the
+# IPAddressAllow branch follows it:
+#
+#   loopback (default, the 2026-07-11 authorization) — 127.0.0.1:8739 with
+#     IPAddressAllow restricted to loopback, so even a compromised server
+#     cannot reach the network. `tailscale serve` proxies it onto the tailnet
+#     with TLS over loopback. Declaring the serve rule stays out of scope.
+#
+#   own origin (sancta-choir) — the server binds the tailnet address itself
+#     and IPAddressAllow widens to the Tailscale CGNAT/ULA ranges only. Chosen
+#     because on 2026-07-26 a page mounted as a PATH under serve's
+#     `/ -> 127.0.0.1:8080` catch-all failed silently and the URL answered 200
+#     with a DIFFERENT application: longest-prefix routing makes `/` the parent
+#     of every path and an SPA history-fallback answers 200 to anything, so
+#     composed they form a total function over the URL space in which no
+#     mistake is representable. One owner per origin; a dead gallery then fails
+#     as ECONNREFUSED, which cannot be mistaken for content.
+#
+#     This is a DELIBERATE deviation from the repo's documented norm (CLAUDE.md:
+#     "services bind 127.0.0.1, accessed via Tailscale Serve HTTPS"). Traffic
+#     stays inside WireGuard either way; what changes is that a wrong URL now
+#     fails loudly instead of rendering someone else's page.
+#
+#   `bind` is delivered to the server as GALLERY_BIND, which server.mjs reads
+#   (`const BIND = process.env.GALLERY_BIND || '127.0.0.1'`). That script is
+#   mutable and outside this repo, so the binding is a CONTRACT with it, not
+#   something this module can prove — see the closing check in the PR.
 { config
 , lib
 , pkgs
@@ -107,6 +131,20 @@ in
       {
         assertion = cfg.bind != "0.0.0.0" && cfg.bind != "::";
         message = "services.sancta-gallery.bind must not be a wildcard address — the gallery is loopback- or tailnet-only by construction, never by firewall.";
+      }
+      {
+        # The alert template is declared inside sancta-soul-mirror's own mkIf.
+        # Point OnFailure at it on a host without the mirror and systemd resolves
+        # it to a non-existent unit: it records a failed transient job and the
+        # alert never runs — a crashed gallery then fails SILENTLY, which is the
+        # exact failure mode this whole module exists to close.
+        #
+        # sancta-doctrine-guard.nix carries this same assertion, added one day
+        # earlier for the same reason, and it was omitted here. Caught in review.
+        assertion =
+          !(lib.hasInfix "sancta-soul-mirror-alert" (toString (cfg.onFailureUnit or "")))
+          || (config.services.sancta-soul-mirror.enable or false);
+        message = "services.sancta-gallery.onFailureUnit points at sancta-soul-mirror-alert@, which is declared only when services.sancta-soul-mirror.enable = true. Enable the mirror, or use an alert unit that exists on this host.";
       }
     ];
 

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -129,8 +129,16 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.bind != "0.0.0.0" && cfg.bind != "::";
-        message = "services.sancta-gallery.bind must not be a wildcard address — the gallery is loopback- or tailnet-only by construction, never by firewall.";
+        # Not just "no wildcard": the bind must be an address IPAddressAllow
+        # actually permits. Anything else fails CLOSED — the unit starts, binds,
+        # and silently answers nobody, which is a quieter version of the exact
+        # failure this module exists to make loud.
+        assertion =
+          cfg.bind == "127.0.0.1"
+          || cfg.bind == "::1"
+          || lib.hasPrefix "100." cfg.bind
+          || lib.hasPrefix "fd7a:115c:a1e0:" cfg.bind;
+        message = "services.sancta-gallery.bind must be loopback (127.0.0.1 / ::1) or a Tailscale address (100.64.0.0/10 or fd7a:115c:a1e0::/48) — those are the only ranges IPAddressAllow permits, so any other value would start, bind, and silently serve nobody. A wildcard is rejected by the same rule.";
       }
       {
         # The alert template is declared inside sancta-soul-mirror's own mkIf.

--- a/modules/services/sancta-soul-mirror.nix
+++ b/modules/services/sancta-soul-mirror.nix
@@ -179,6 +179,7 @@ in
         "index"
         "projects/-home-nixos/memory"
         "skills"
+        "lenses"
         "commands"
         "hooks"
         "agents"

--- a/modules/services/sancta-soul-mirror.nix
+++ b/modules/services/sancta-soul-mirror.nix
@@ -148,11 +148,19 @@ let
   alertScript = pkgs.writeShellScript "sancta-soul-mirror-alert" ''
     set -euo pipefail
     TS=$(${cu}/date -Iseconds)
-    msg="❌ SOUL-MIRROR FAILURE: ''${1:-sancta-soul-mirror} failed at $TS on $(${cu}/hostname)"
+    # The failing unit's name arrives as $1 (systemd %N via the @%N instance).
+    # Everything user-facing is derived from it. Hardcoding "soul-mirror" here
+    # was wrong the moment a second unit reused this handler: the alert would
+    # name the right unit mid-sentence while its title and its suggested
+    # `journalctl` both pointed at the mirror. An operator following that hint
+    # finds an idle journal and concludes false alarm — which is the
+    # signal-gets-missed failure this alert path exists to prevent.
+    UNIT="''${1:-sancta-soul-mirror}"
+    msg="❌ $UNIT FAILURE: failed at $TS on $(${cu}/hostname)"
     echo "$msg" | ${pkgs.systemd}/bin/systemd-cat -t sancta-soul-mirror-alert -p err
     if [ -x ${escapeShellArg cfg.feedTool} ]; then
       ${nodejs}/bin/node ${escapeShellArg cfg.feedTool} \
-        "❌ soul-mirror FAILED" "$msg · journalctl -u sancta-soul-mirror" \
+        "❌ $UNIT FAILED" "$msg · journalctl -u $UNIT" \
         || echo "WARNING: feed alert line failed" >&2
     fi
   '';

--- a/tests/sancta-doctrine-guard.nix
+++ b/tests/sancta-doctrine-guard.nix
@@ -1,0 +1,134 @@
+# Branch coverage for modules/services/sancta-doctrine-guard.sh.
+#
+# The guard exists because on 2026-07-21 six files vanished and nothing was
+# capable of noticing. A guard that cannot itself be shown to FAIL would be the
+# same problem with better paperwork — so every case below asserts a non-zero
+# exit and the specific message, not merely "it ran".
+{ pkgs }:
+
+let
+  guard = ../modules/services/sancta-doctrine-guard.sh;
+in
+pkgs.runCommand "sancta-doctrine-guard-tests"
+{
+  nativeBuildInputs = [
+    pkgs.bash
+    pkgs.git
+    pkgs.jq
+    pkgs.diffutils
+    pkgs.util-linux
+    pkgs.gnugrep
+    pkgs.coreutils
+  ];
+}
+  ''
+    set -euo pipefail
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+    git config --global user.email "test@example.com"
+    git config --global user.name "test"
+    git config --global init.defaultBranch main
+
+    # Build a fixture soul root that the guard should find fully healthy.
+    mkfixture() {
+      root="$1"
+      rm -rf "$root"
+      mkdir -p "$root/skills/alpha" "$root/skills/beta" "$root/lenses"
+      mkdir -p "$root/skills/council/assessors"
+
+      echo "# alpha" > "$root/skills/alpha/SKILL.md"
+      echo "# beta"  > "$root/skills/beta/SKILL.md"
+      for a in compliance opportunity risk; do
+        echo "# $a" > "$root/skills/council/assessors/$a.md"
+      done
+      echo "# claude" > "$root/CLAUDE.md"
+      echo '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"date"}]}]}}' \
+        > "$root/settings.json"
+      echo "# a lens" > "$root/lenses/somelens.md"
+
+      git -C "$root/skills" init -q
+      git -C "$root/skills" add alpha/SKILL.md beta/SKILL.md
+      git -C "$root/skills" commit -q -m "fixture"
+      git -C "$root/lenses" init -q
+      git -C "$root/lenses" add somelens.md
+      git -C "$root/lenses" commit -q -m "fixture"
+    }
+
+    run() { SANCTA_DOCTRINE_ROOT="$1" bash ${guard}; }
+
+    expect_pass() {
+      if ! res=$(run "$1" 2>&1); then
+        echo "EXPECTED PASS but guard failed:"; echo "$res"; exit 1
+      fi
+      echo "  ok: $2"
+    }
+
+    expect_fail() {
+      root="$1"; want="$2"; label="$3"
+      if res=$(run "$root" 2>&1); then
+        echo "EXPECTED FAIL but guard passed: $label"; echo "$res"; exit 1
+      fi
+      if ! echo "$res" | grep -qF "$want"; then
+        echo "FAILED for the wrong reason: $label"
+        echo "  wanted substring: $want"
+        echo "$res"; exit 1
+      fi
+      echo "  ok: $label"
+    }
+
+    R="$TMPDIR/root"
+
+    echo "== positive =="
+    mkfixture "$R"
+    expect_pass "$R" "healthy fixture passes"
+
+    echo "== the 2026-07-21 failure: a tracked file vanishes =="
+    mkfixture "$R"; rm "$R/lenses/somelens.md"
+    expect_fail "$R" "missing or empty" "deleted lens file fires"
+
+    echo "== a tracked file emptied rather than deleted =="
+    mkfixture "$R"; : > "$R/skills/alpha/SKILL.md"
+    expect_fail "$R" "missing or empty" "empty SKILL.md fires"
+
+    echo "== drift: a skill on disk that was never committed (FATAL) =="
+    mkfixture "$R"; mkdir -p "$R/skills/gamma"; echo "# g" > "$R/skills/gamma/SKILL.md"
+    expect_fail "$R" "NEVER COMMITTED" "uncommitted skill is fatal, not a warning"
+
+    echo "== drift: committed but gone from disk =="
+    mkfixture "$R"; rm -rf "$R/skills/beta"
+    expect_fail "$R" "missing from disk" "deleted committed skill fires"
+
+    echo "== symlinked skills are wiring, not doctrine — must NOT drift =="
+    mkfixture "$R"; ln -s /nonexistent-store-path "$R/skills/zeta"
+    expect_pass "$R" "a dangling symlink skill does not trip drift"
+
+    echo "== the settings.json regression the obvious check misses =="
+    mkfixture "$R"
+    echo '{"hooks":{"UserPromptSubmit":[]}}' > "$R/settings.json"
+    expect_fail "$R" "lost hooks.UserPromptSubmit" "empty hook ARRAY fires (jq -e alone would pass)"
+
+    mkfixture "$R"; echo '{"hooks":{}}' > "$R/settings.json"
+    expect_fail "$R" "lost hooks.UserPromptSubmit" "absent hook key fires"
+
+    echo "== whole skills repo gone: must fail AND must not print a reassuring drift line =="
+    mkfixture "$R"; rm -rf "$R/skills/.git"
+    res=$(run "$R" 2>&1 || true)
+    echo "$res" | grep -qF "not a git repo" || { echo "expected 'not a git repo'"; echo "$res"; exit 1; }
+    if echo "$res" | grep -qF "committed set == on-disk set"; then
+      echo "REGRESSION: printed a reassuring drift line for the catastrophic case"
+      echo "$res"; exit 1
+    fi
+    echo "  ok: drift is skipped, not falsely green"
+
+    echo "== a dirty worktree is NORMAL and must never fire =="
+    mkfixture "$R"; echo "edited mid-thought" >> "$R/skills/alpha/SKILL.md"
+    expect_pass "$R" "uncommitted MODIFICATION does not fire (no cry-wolf)"
+
+    echo "== missing root env is a hard error, not a silent pass =="
+    if res=$(bash ${guard} 2>&1); then
+      echo "EXPECTED FAIL with no SANCTA_DOCTRINE_ROOT"; echo "$res"; exit 1
+    fi
+    echo "  ok: unset root fails loudly"
+
+    touch $out
+  ''

--- a/tests/sancta-doctrine-guard.nix
+++ b/tests/sancta-doctrine-guard.nix
@@ -98,6 +98,24 @@ pkgs.runCommand "sancta-doctrine-guard-tests"
     mkfixture "$R"; rm -rf "$R/skills/beta"
     expect_fail "$R" "missing from disk" "deleted committed skill fires"
 
+    echo "== lens drift: a lens on disk that was never committed (FATAL) =="
+    # Section 1 only catches a lens that was committed and then vanished. This
+    # is the other half — and it is the half that actually happened on
+    # 2026-07-21, when six assessors sat on disk for days untracked.
+    mkfixture "$R"; echo "# uncommitted" > "$R/lenses/ghost.md"
+    expect_fail "$R" "lens on disk but NEVER COMMITTED" "uncommitted lens is fatal"
+
+    echo "== lens drift: committed but gone from disk =="
+    mkfixture "$R"; rm -f "$R/lenses/somelens.md"
+    expect_fail "$R" "missing or empty" "deleted committed lens fires"
+
+    echo "== lens drift: a nested path must NOT trip it =="
+    # bin/ and any future subdirectory are covered by section 1's existence
+    # check, deliberately not by the flat *.md comparison — otherwise the two
+    # sets disagree by construction and the guard cries wolf on every run.
+    mkfixture "$R"; mkdir -p "$R/lenses/bin"; echo "#!/bin/sh" > "$R/lenses/bin/tool.sh"
+    expect_pass "$R" "an untracked NESTED file does not trip lens drift"
+
     echo "== symlinked skills are wiring, not doctrine — must NOT drift =="
     # The symlink MUST resolve. Bash's `for d in */` stats each entry, so a
     # DANGLING symlink never matches the glob at all — an earlier version of
@@ -147,7 +165,11 @@ pkgs.runCommand "sancta-doctrine-guard-tests"
     mkfixture "$R"; rm -rf "$R/skills/.git"
     res=$(run "$R" 2>&1 || true)
     echo "$res" | grep -qF "not a git repo" || { echo "expected 'not a git repo'"; echo "$res"; exit 1; }
-    if echo "$res" | grep -qF "committed set == on-disk set"; then
+    # Match the SKILLS drift line specifically. Since 2026-07-27 the lenses repo
+    # has its own drift line whose text also contains "committed set == on-disk
+    # set" — and there it is legitimate, because the lenses repo is fine. A
+    # substring match would fail on a true statement about a different repo.
+    if echo "$res" | grep -qE '^ok: +drift: committed set == on-disk set'; then
       echo "REGRESSION: printed a reassuring drift line for the catastrophic case"
       echo "$res"; exit 1
     fi

--- a/tests/sancta-doctrine-guard.nix
+++ b/tests/sancta-doctrine-guard.nix
@@ -99,8 +99,19 @@ pkgs.runCommand "sancta-doctrine-guard-tests"
     expect_fail "$R" "missing from disk" "deleted committed skill fires"
 
     echo "== symlinked skills are wiring, not doctrine — must NOT drift =="
-    mkfixture "$R"; ln -s /nonexistent-store-path "$R/skills/zeta"
-    expect_pass "$R" "a dangling symlink skill does not trip drift"
+    # The symlink MUST resolve. Bash's `for d in */` stats each entry, so a
+    # DANGLING symlink never matches the glob at all — an earlier version of
+    # this test used /nonexistent-store-path and therefore passed without ever
+    # executing the `[ -L ] && continue` line it claimed to cover. In production
+    # these point at real home-manager store directories, which do match the
+    # glob and do need the skip. A test that passes for the wrong reason is the
+    # same disease this whole module treats.
+    mkfixture "$R"
+    mkdir -p "$TMPDIR/fake-store/zeta"; echo "# zeta" > "$TMPDIR/fake-store/zeta/SKILL.md"
+    ln -s "$TMPDIR/fake-store/zeta" "$R/skills/zeta"
+    # prove the fixture is actually exercising the branch, not skipping it
+    [ -d "$R/skills/zeta" ] || { echo "fixture broken: symlink does not resolve to a dir"; exit 1; }
+    expect_pass "$R" "a RESOLVABLE symlink skill does not trip drift"
 
     echo "== the settings.json regression the obvious check misses =="
     mkfixture "$R"
@@ -109,6 +120,28 @@ pkgs.runCommand "sancta-doctrine-guard-tests"
 
     mkfixture "$R"; echo '{"hooks":{}}' > "$R/settings.json"
     expect_fail "$R" "lost hooks.UserPromptSubmit" "absent hook key fires"
+
+    echo "== malformed JSON must NOT masquerade as the hooks regression =="
+    mkfixture "$R"; echo '{"hooks": {' > "$R/settings.json"
+    expect_fail "$R" "not valid JSON" "parse error gets its own message"
+
+    echo "== git failing for a NON-empty reason must say so =="
+    # Permission bits do not constrain uid 0, so this case is only meaningful
+    # for an unprivileged builder. Skipped rather than silently passing.
+    if [ "$(id -u)" -eq 0 ]; then
+      echo "  SKIP: running as root, chmod cannot make the repo unreadable"
+    else
+      mkfixture "$R"; chmod 000 "$R/skills/.git"
+      res=$(run "$R" 2>&1 || true)
+      chmod 755 "$R/skills/.git"
+      if echo "$res" | grep -qF "no tracked files at all"; then
+        echo "REGRESSION: an unreadable repo was reported as an empty one"
+        echo "$res"; exit 1
+      fi
+      echo "$res" | grep -qF "ls-files FAILED" || {
+        echo "expected a distinct ls-files failure message"; echo "$res"; exit 1; }
+      echo "  ok: unreadable repo is not mistaken for an empty one"
+    fi
 
     echo "== whole skills repo gone: must fail AND must not print a reassuring drift line =="
     mkfixture "$R"; rm -rf "$R/skills/.git"


### PR DESCRIPTION
## The failure this closes

**2026-07-21** — the RPi5 → sancta-choir migration lost six council assessor files.
**2026-07-25** — found four days later, by accident, during an unrelated `/doctor` run.

Nothing on the host was *capable* of noticing. Every soul unit (`soul-open`, `soul-mount`, `worker`, `soul-mirror`) gates on the volume being **mounted**; not one asserts its **content**. There is no tmpfiles rule touching `.claude` at all. The weekly mirror faithfully archived the absence as zero-knowledge ciphertext — a mirror of a hole is a hole.

**The control case shows the mechanism never failed.** `compliance.md`, `opportunity.md` and `risk.md` sat in the *same directory*, went through the *same migration*, and survived — because they were committed. The three that lived were in a repo. The six that died were not.

## What this adds

- `modules/services/sancta-doctrine-guard.nix` — mount-gated oneshot + daily timer, failing into the **existing** `sancta-soul-mirror-alert@` path rather than inventing a second one.
- `"lenses"` in the soul-mirror `sourceRoots` allowlist.
- The unit enabled on `sancta-choir`.

## Three design decisions worth reviewing

**The assertion table is derived from `git ls-files`, never typed here.** A hand-maintained list of "files that must exist" goes stale the moment a skill is added — the same bug wearing a new hat. Commit a skill and it is asserted automatically. It also matters that **this repo is public**: no skill name belongs in it. The mechanism lives in Nix at deploy speed; what counts as doctrine lives in git inside the soul volume at thought speed.

**Drift is fatal, not a warning.** A skill on disk that was never committed fails the unit. This host is headless — a journal warning is precisely the class of signal that already let four days pass.

**Worktree cleanliness is never checked.** A dirty tree mid-edit is normal; a missing file never is. A guard that cries wolf during ordinary work gets muted within a fortnight, and a muted guard is worse than none.

## Verification

Standalone, as `sancta`, on choir — **before** the logic was wrapped in Nix:

| check | result |
|---|---|
| positive | exit 0, 14 + 8 tracked entries asserted |
| negative 1 — hidden lens file | exit 1, names `realist.md` |
| negative 2 — uncommitted skill | exit 1, `NEVER COMMITTED` (fatal drift) |
| negative 3 — committed file gone from disk | exit 1 |
| restored | green again |
| `tar --dereference` carries `skills/.git` | 93 entries |

The `jq` fix is the one I would most want a second pair of eyes on. The obvious check — `jq -e '.hooks.UserPromptSubmit'` — **passes** on `{"hooks":{"UserPromptSubmit":[]}}`, because `jq -e` fails only on `null`/`false`. An empty array is the most likely shape of the 2026-07-25 10:32 regression, where a settings writer preserved the key and dropped the contents. So the check written for the bug passed on the bug. `(… // []) | length > 0` is the fix, verified in both directions.

Nix eval on `sancta-choir`:

- `systemd.services.sancta-doctrine-guard.serviceConfig.ExecStart` → real derivation
- `services.sancta-soul-mirror.sourceRoots` → `[…, "skills", "lenses", …]`
- `systemd.timers.sancta-doctrine-guard.timerConfig` → `{"OnCalendar":"*-*-* 09:00:00","Persistent":true,"RandomizedDelaySec":"10m"}`
- `systemd.services.sancta-doctrine-guard.unitConfig.ConditionPathIsMountPoint` → `/var/lib/sancta/.claude`
- `nixpkgs-fmt` — 0/3 reformatted

## What it does NOT prove

Correctness. A committed file edited to garbage will not fire. This proves existence and recoverability only — named here rather than hidden.

## Design doc

`~/.claude/index/docs/plans/2026-07-25-substrate-permanence-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHTBhNXqT2ixS8akrhWWEC
