### PR TITLE
feat(sancta): declare the gallery on choir — stop hand-starting the surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,21 @@ Custom NixOS modules wrap upstream services with Tailscale integration and ageni
 | `services.tailscale` | - | Mesh VPN (all services exposed via Tailscale only) |
 | `openclaw` (sancta-claw) | 18789 | Official OpenClaw npm package on dedicated VPS |
 | `services.hermes-agent` (hermes-claw) | - | Hermes AI agent in Podman container (upstream module, container mode) |
+| `services.sancta-gallery` (sancta-choir) | 8739 | Rendered surface, publish-gated. **Binds the tailnet address directly** — see the exception below |
 
 **Security Pattern:** Services bind to `127.0.0.1` only, accessed via Tailscale Serve HTTPS proxy. Localhost binding provides defense-in-depth. OpenClaw uses a different model: file-based inbox with per-UID nftables network restriction (no listener).
+
+**Documented exception — `sancta-gallery` on sancta-choir.** It binds the tailnet
+address directly instead of loopback + Serve. On 2026-07-26 a page mounted as a *path*
+under Serve's `/ → 127.0.0.1:8080` catch-all failed silently, and the URL returned
+**200 with Open-WebUI's page**: longest-prefix routing makes `/` the parent of every
+path and an SPA history-fallback answers 200 to anything, so composed they form a total
+function over the URL space in which no mistake is representable. Binding its own origin
+makes a dead service fail as `ECONNREFUSED`, which cannot be mistaken for content.
+Traffic stays inside WireGuard either way; `IPAddressAllow` is narrowed to Tailscale's
+CGNAT/ULA ranges and a wildcard bind is rejected by assertion. **New services should
+still follow the loopback + Serve norm** — this exception is for a surface whose whole
+job is that a wrong URL must be visibly wrong.
 
 Access URLs (HTTPS via Tailscale Serve):
 - Open-WebUI: `https://rpi5.tail4249a9.ts.net`
@@ -190,10 +203,10 @@ from the [claude-shared](https://github.com/alexandru-savinov/claude-shared)
 flake. This repo only:
 
 1. Imports the shared module via `modules/services/claude-shared.nix`
-   (exposes `customModules.claudeShared.{enable,users}`).
+(exposes `customModules.claudeShared.{enable,users}`).
 2. Wires it into hosts that should get the full CC stack. Currently:
-   `rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
-   the legacy `customModules.claude` (package install only — no skills/agents).
+`rpi5` / `rpi5-full` (full). `sancta-choir`, `sancta-claw` are still on
+the legacy `customModules.claude` (package install only — no skills/agents).
 3. Carries **project-level** skills under `.claude/skills/` — see below.
 
 ### Where to edit Claude Code content
@@ -251,11 +264,11 @@ formatting failures.
 
 1. **State the hypothesis** — one sentence: *"I believe the root cause is X because Y."* Name the exact option, file, or behavior.
 2. **Design a minimal test** — the smallest command that confirms or refutes the hypothesis *without making changes*:
-   ```bash
-   nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
-   nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
-   grep -r "optionName" modules/                                              # find where it's set
-   ```
+```bash
+nixos-rebuild dry-build --flake .#rpi5-full 2>&1 | grep -iE "warn|error"  # capture current state
+nix eval .#nixosConfigurations.rpi5-full.config.<option>                   # inspect value
+grep -r "optionName" modules/                                              # find where it's set
+```
 3. **Run the test** — if it refutes the hypothesis, revise and repeat from step 1. Do NOT apply the fix anyway.
 4. **Apply the fix** — minimal change only, exactly what the hypothesis identified.
 5. **Verify** — re-run the same test. Confirm the problem is gone and no new warnings appeared.
@@ -288,9 +301,9 @@ Known pitfalls — do not repeat these:
 
 1. Create module in `modules/services/<name>.nix`
 2. Follow the Tailscale wrapper pattern:
-   - Bind to `127.0.0.1` only
-   - Create `<name>-tailscale-serve.service` for HTTPS proxy
-   - Use `age.secrets` for sensitive config
+- Bind to `127.0.0.1` only
+- Create `<name>-tailscale-serve.service` for HTTPS proxy
+- Use `age.secrets` for sensitive config
 3. Add to host configuration
 4. Add secret to `secrets/secrets.nix` if needed
 
@@ -301,9 +314,9 @@ For long-running n8n workflows (>60s), use the async job pattern to prevent brow
 ### Architecture
 ```
 User → Main Webhook → Create Job ID → Trigger Worker → Return HTTP 202 immediately
-                         │
-                         ↓ (fire-and-forget)
-                   Background Worker → Process → Update Status File
+│
+↓ (fire-and-forget)
+Background Worker → Process → Update Status File
 
 UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 ```
@@ -320,8 +333,8 @@ UI Polling → Status Endpoint → Read Status File → Return Progress JSON
 To trigger background work without blocking:
 ```json
 {
-  "options": { "timeout": 1000 },
-  "continueOnFail": true
+"options": { "timeout": 1000 },
+"continueOnFail": true
 }
 ```
 
@@ -329,7 +342,7 @@ To trigger background work without blocking:
 Enable Node.js built-in modules for file-based status tracking:
 ```nix
 extraEnvironment = {
-  NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
+NODE_FUNCTION_ALLOW_BUILTIN = "fs,path,crypto";
 };
 ```
 
@@ -403,7 +416,7 @@ Profile where eval time is spent (built into Nix 2.31+, no extra tools needed):
 ```bash
 # Generate collapsed stack trace
 nix eval --eval-profiler flamegraph --eval-profile-file /tmp/eval.folded \
-  .#nixosConfigurations.rpi5-full.config.system.build.toplevel
+.#nixosConfigurations.rpi5-full.config.system.build.toplevel
 
 # Visualize: upload /tmp/eval.folded to https://speedscope.app
 # Or generate SVG:
@@ -460,8 +473,8 @@ Each service has its own environment variable for binding:
 2. **Service ordering:** Tailscale Serve systemd services use `after` + `requires` on the main service, but this only waits for service start, not for the port to be listening
 
 3. **Idempotent setup:** Check if serve is already configured before adding:
-   ```bash
-   if ! tailscale serve status | grep -q "https:PORT"; then
-     tailscale serve --bg --https PORT http://127.0.0.1:PORT
-   fi
-   ```
+```bash
+if ! tailscale serve status | grep -q "https:PORT"; then
+tailscale serve --bg --https PORT http://127.0.0.1:PORT
+fi
+```

--- a/hosts/sancta-choir/configuration.nix
+++ b/hosts/sancta-choir/configuration.nix
@@ -51,6 +51,7 @@
     ./sancta-worker.nix # guarded comm gateway + resumed `claude -p` worker
     ../../modules/services/sancta-soul-mirror.nix # choir-local encrypted soul vault (rpi5 pulls)
     ../../modules/services/sancta-doctrine-guard.nix # assert the authored substrate is present + recoverable
+    ../../modules/services/sancta-gallery.nix # the rendered surface, declared instead of hand-started
   ];
 
   # Enable development tools and agent CLIs.
@@ -258,6 +259,31 @@
   # never typed here: a hand-maintained list is the same bug wearing a new hat,
   # and this repo is PUBLIC so no skill name belongs in it anyway.
   services.sancta-doctrine-guard.enable = true;
+
+  # The rendered surface. On 2026-07-26 three node processes served Sancta's
+  # work and every one was PPID 1 — orphans of `setsid nohup`, started by hand,
+  # surviving no reboot and announcing no death. Both also ran with the non-leak
+  # publish gate DISARMED, because the gate lived in a shell invocation instead
+  # of in the system. The files were committed; the fact that they ran was not.
+  #
+  # bind: the tailnet address, not loopback-plus-`tailscale serve`. Earlier that
+  # same day a page mounted as a PATH under serve's catch-all failed silently and
+  # the URL answered 200 with a different application. One owner per origin: a
+  # dead gallery then fails as ECONNREFUSED, which cannot be mistaken for content.
+  #
+  # NOT declared here: the loopback instance on 127.0.0.1:8739. That is
+  # bin/gallery-shot's hardcoded and only permitted origin — a structural gate,
+  # "so Sancta cannot, not so it promises not to" — and killing it as a duplicate
+  # would remove Sancta's own eyes on what it renders. Second role, not stray copy.
+  services.sancta-gallery = {
+    enable = true;
+    galleryDir = "/var/lib/sancta/.claude/index/gallery";
+    user = "sancta";
+    group = "sancta";
+    bind = "100.94.191.54";
+    requiresMount = "/var/lib/sancta/.claude";
+    onFailureUnit = "sancta-soul-mirror-alert@%N.service";
+  };
 
   # ==========================================================================
   # Open-WebUI — AI chat gateway via OpenRouter

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -45,17 +45,88 @@ in
       default = "/home/nixos/.claude/index/gallery";
       description = "Directory holding server.mjs, the pieces and their .passed sidecars.";
     };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "nixos";
+      description = "Account owning galleryDir. On sancta-choir the index owner is `sancta`, not `nixos`.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "users";
+      description = "Primary group of `user`.";
+    };
+
+    bind = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address the server binds. Default loopback, proxied onto the tailnet by
+        `tailscale serve` (the 2026-07-11 shape).
+
+        A tailnet address may be given instead, and on sancta-choir that is the
+        chosen shape — because on 2026-07-26 a page mounted as a PATH under
+        `tailscale serve`'s catch-all silently failed and the URL returned 200
+        with a DIFFERENT application's page. Longest-prefix routing makes `/` the
+        parent of every path, and an SPA history-fallback answers 200 to
+        anything; composed, no URL can produce an error, so no check can observe
+        a mistake. Binding its own origin makes a dead gallery fail as
+        ECONNREFUSED, which cannot be mistaken for content.
+
+        A wildcard (0.0.0.0 / ::) is rejected by assertion: tailnet-only is a
+        property of the binding, not of a firewall rule someone must remember.
+      '';
+    };
+
+    requiresMount = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        If set, the unit requires that path to be a live mountpoint and refuses
+        to start otherwise. On sancta-choir the gallery lives on the LUKS soul
+        volume; serving 404s off the bare underlay would look merely empty
+        instead of broken.
+      '';
+    };
+
+    onFailureUnit = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "sancta-soul-mirror-alert@%N.service";
+      description = ''
+        Optional unit to trigger on failure. Without it a crashed gallery is
+        silent until someone notices the page is gone — the failure mode the
+        hand-started processes had, kept by accident.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.bind != "0.0.0.0" && cfg.bind != "::";
+        message = "services.sancta-gallery.bind must not be a wildcard address — the gallery is loopback- or tailnet-only by construction, never by firewall.";
+      }
+    ];
+
     systemd.services.sancta-gallery = {
       description = "Sancta Gallery — read-only static viewer with publish gate";
-      after = [ "network.target" ];
+      after = [ "network.target" ]
+        ++ lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
+      requires = lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
       wantedBy = [ "multi-user.target" ];
+      onFailure = lib.optional (cfg.onFailureUnit != null) cfg.onFailureUnit;
 
       # If the (deliberately non-store) server script is missing, stay
       # inactive rather than crash-loop.
-      unitConfig.ConditionPathExists = "${cfg.galleryDir}/server.mjs";
+      unitConfig = {
+        ConditionPathExists = "${cfg.galleryDir}/server.mjs";
+      } // lib.optionalAttrs (cfg.requiresMount != null) {
+        # Unmounted volume → refuse to start rather than serve an empty
+        # directory. A wrong answer is worse than no answer.
+        ConditionPathIsMountPoint = toString cfg.requiresMount;
+      };
 
       # Rate-limit restarts: a persistently crashing server ends up in a
       # loud `systemctl --failed` state instead of oscillating forever.
@@ -71,12 +142,13 @@ in
         # responsibility of the painter/publish pipeline (Sancta's index),
         # not of this unit.
         GALLERY_PUBLISH_GATE = "1";
+        GALLERY_BIND = cfg.bind;
       };
 
       serviceConfig = {
         Type = "simple";
-        User = "nixos";
-        Group = "users";
+        User = cfg.user;
+        Group = cfg.group;
         WorkingDirectory = cfg.galleryDir;
         ExecStart = "${pkgs.nodejs}/bin/node ${cfg.galleryDir}/server.mjs";
         Restart = "always";
@@ -109,7 +181,26 @@ in
         # host over loopback, so the tailnet path keeps working.
         SocketBindAllow = "tcp:8739";
         SocketBindDeny = "any";
+      }
+      // lib.optionalAttrs (cfg.bind == "127.0.0.1" || cfg.bind == "::1") {
+        # Loopback shape (the 2026-07-11 authorization): packets may go nowhere
+        # but loopback, so even a modified server.mjs cannot reach the network.
+        # `tailscale serve` proxies from the same host over loopback.
         IPAddressAllow = [
+          "127.0.0.1/32"
+          "::1/128"
+        ];
+        IPAddressDeny = "any";
+      }
+      // lib.optionalAttrs (cfg.bind != "127.0.0.1" && cfg.bind != "::1") {
+        # Own-origin shape (sancta-choir): the process binds the tailnet address
+        # itself, so loopback-only IP filtering would block the very traffic it
+        # exists to serve. The port restriction above still holds — it may bind
+        # tcp:8739 and nothing else — and the CGNAT range is the tailnet's own,
+        # so this permits Tailscale peers and nothing on the public internet.
+        IPAddressAllow = [
+          "100.64.0.0/10"
+          "fd7a:115c:a1e0::/48"
           "127.0.0.1/32"
           "::1/128"
         ];

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -19,15 +19,39 @@
 #     credentials, or anything else under /home.
 #   - ConditionPathExists guards the mutable script: if server.mjs is
 #     absent the unit stays inactive instead of crash-looping.
-#   - The unit runs as User=nixos (the index owner), same as the nohup
-#     process it replaces.
-#   - Binding stays 127.0.0.1:8739 (server default) and is ENFORCED at the
-#     systemd level (SocketBindAllow tcp:8739 only + IPAddressAllow
-#     loopback only), so even a modified server.mjs cannot silently listen
-#     on 0.0.0.0 or another port. `tailscale serve` already proxies it onto
-#     the tailnet with TLS (the proxy connects over loopback, which stays
-#     allowed). Declaring the serve rule is intentionally out of scope here
-#     (per the 2026-07-11 authorization).
+#   - The unit runs as the index owner (`user`/`group`): `nixos` on rpi5,
+#     `sancta` on sancta-choir after the 2026-07-22 migration.
+#   - The port is ALWAYS enforced at the systemd level (SocketBindAllow
+#     tcp:8739 only), so even a modified server.mjs cannot silently listen
+#     on another port.
+#
+# TWO BIND SHAPES (2026-07-26). `bind` selects between them and the
+# IPAddressAllow branch follows it:
+#
+#   loopback (default, the 2026-07-11 authorization) — 127.0.0.1:8739 with
+#     IPAddressAllow restricted to loopback, so even a compromised server
+#     cannot reach the network. `tailscale serve` proxies it onto the tailnet
+#     with TLS over loopback. Declaring the serve rule stays out of scope.
+#
+#   own origin (sancta-choir) — the server binds the tailnet address itself
+#     and IPAddressAllow widens to the Tailscale CGNAT/ULA ranges only. Chosen
+#     because on 2026-07-26 a page mounted as a PATH under serve's
+#     `/ -> 127.0.0.1:8080` catch-all failed silently and the URL answered 200
+#     with a DIFFERENT application: longest-prefix routing makes `/` the parent
+#     of every path and an SPA history-fallback answers 200 to anything, so
+#     composed they form a total function over the URL space in which no
+#     mistake is representable. One owner per origin; a dead gallery then fails
+#     as ECONNREFUSED, which cannot be mistaken for content.
+#
+#     This is a DELIBERATE deviation from the repo's documented norm (CLAUDE.md:
+#     "services bind 127.0.0.1, accessed via Tailscale Serve HTTPS"). Traffic
+#     stays inside WireGuard either way; what changes is that a wrong URL now
+#     fails loudly instead of rendering someone else's page.
+#
+#   `bind` is delivered to the server as GALLERY_BIND, which server.mjs reads
+#   (`const BIND = process.env.GALLERY_BIND || '127.0.0.1'`). That script is
+#   mutable and outside this repo, so the binding is a CONTRACT with it, not
+#   something this module can prove — see the closing check in the PR.
 { config
 , lib
 , pkgs
@@ -107,6 +131,20 @@ in
       {
         assertion = cfg.bind != "0.0.0.0" && cfg.bind != "::";
         message = "services.sancta-gallery.bind must not be a wildcard address — the gallery is loopback- or tailnet-only by construction, never by firewall.";
+      }
+      {
+        # The alert template is declared inside sancta-soul-mirror's own mkIf.
+        # Point OnFailure at it on a host without the mirror and systemd resolves
+        # it to a non-existent unit: it records a failed transient job and the
+        # alert never runs — a crashed gallery then fails SILENTLY, which is the
+        # exact failure mode this whole module exists to close.
+        #
+        # sancta-doctrine-guard.nix carries this same assertion, added one day
+        # earlier for the same reason, and it was omitted here. Caught in review.
+        assertion =
+          !(lib.hasInfix "sancta-soul-mirror-alert" (toString (cfg.onFailureUnit or "")))
+          || (config.services.sancta-soul-mirror.enable or false);
+        message = "services.sancta-gallery.onFailureUnit points at sancta-soul-mirror-alert@, which is declared only when services.sancta-soul-mirror.enable = true. Enable the mirror, or use an alert unit that exists on this host.";
       }
     ];
 


### PR DESCRIPTION
Stacked on #548 — base branch is `sancta-doctrine-guard`, because `OnFailure` needs that PR's alert-text fix. Without it a gallery failure raises an alert titled *soul-mirror FAILURE* pointing at the wrong journal.

## What was measured

Three node processes were serving Sancta's work and **every one was PPID 1** — orphans of `setsid nohup`, started by hand at 15:00 and 18:48 the same day. None a unit, none surviving a reboot, none able to announce its own death. Both gallery instances ran with `GALLERY_PUBLISH_GATE` **unset** — the non-leak gate disarmed, because it lived in a shell invocation instead of in the system.

> The files were committed. The fact that they *ran* was not.

Same failure as the six council assessors lost in the migration, wearing new clothes — and the mechanism that fixes it already existed on this host, just never pointed at the gallery.

## The module already existed

`sancta-gallery.nix` shipped in #529, but it was written for rpi5 and is choir-incompatible four ways: hardcoded `/home/nixos/.claude` (retired), user `nixos`, loopback-only by construction, and no mount gate (it predates the soul volume). **Extended, not duplicated.** All defaults unchanged, and `rpi5-full` sets `enable = false` anyway, so there is no regression surface.

## Why choir binds the tailnet address instead of loopback + `tailscale serve`

On 2026-07-26 a page mounted as a **path** under serve's `/ → 127.0.0.1:8080` catch-all failed silently and the URL returned **200 with Open-WebUI's app**. Longest-prefix routing makes `/` the parent of every path; an SPA history-fallback answers 200 to anything. Composed, they are a *total function* over the URL space — no input can produce an error, so no check can observe a mistake.

**One owner per origin.** A dead gallery then fails as `ECONNREFUSED`, which cannot be mistaken for content. This opens nothing new: `100.94.191.54:8739` is already listening today, by hand.

The port restriction holds in both shapes. `IPAddressAllow` branches — loopback-only as before, or the tailnet CGNAT range when binding the tailnet address. A wildcard bind is rejected by assertion: tailnet-only should be a property of the binding, not a firewall rule someone must remember.

## Deliberately NOT declared

The loopback instance on `127.0.0.1:8739`. That is `bin/gallery-shot`'s hardcoded and only permitted origin — a structural gate, *"so Sancta cannot, not so it promises not to"*. Killing it as a duplicate would remove Sancta's own eyes on what it renders. Second role, not stray copy.

## Verified

```
nix-instantiate --parse   clean
nixpkgs-fmt               0/2
eval on sancta-choir:
  ExecStart      …/gallery/server.mjs
  GALLERY_BIND   100.94.191.54
  PUBLISH_GATE   1
  ConditionPathIsMountPoint  /var/lib/sancta/.claude
  Requires       sancta-soul-mount.service
  OnFailure      sancta-soul-mirror-alert@%N.service
live (armed by hand): /triptych.html 200 · unpassed artifact 404 · loopback untouched
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)