### PR TITLE
ci: build the three x86 hosts in one nix invocation, not three steps

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -118,14 +118,33 @@ jobs:
                   save: ${{ github.ref == 'refs/heads/main' }}
                   gc-max-store-size: 5G
 
-            - name: Build sancta-choir (x86_64-linux)
-              run: nix build .#nixosConfigurations.sancta-choir.config.system.build.toplevel
-
-            - name: Build sancta-claw (x86_64-linux)
-              run: nix build .#nixosConfigurations.sancta-claw.config.system.build.toplevel
-
-            - name: Build hermes-claw (x86_64-linux)
-              run: nix build .#nixosConfigurations.hermes-claw.config.system.build.toplevel
+            # One invocation, three targets — NOT three sequential steps.
+            #
+            # These were three separate `nix build` calls, so the runner built
+            # them one after another even though they are independent. Nix
+            # already parallelises across the derivations of a single build:
+            # given all three roots at once it schedules the whole combined
+            # graph across the runner's cores, and the large shared closure
+            # (nixpkgs, hosts/common.nix, the shared modules) is realised once
+            # instead of being waited on three times in series.
+            #
+            # Kept as ONE step in ONE job on purpose. A `strategy.matrix` over
+            # the three hosts would use three runners, but it renames the job
+            # to "Build x86_64 Configs (<host>)" and splits its green/red into
+            # three — and the n8n step below is deliberately a STEP inside this
+            # job, never a separate one (council-20260706T164646Z-c3c904), so
+            # that build-x86's meaning stays single and no phantom job can hang
+            # the branch-protection contract. This gets the parallelism without
+            # reopening that decision.
+            #
+            # --print-build-logs so a failure still names which host broke; the
+            # step name no longer can.
+            - name: Build x86_64 hosts (sancta-choir, sancta-claw, hermes-claw)
+              run: |
+                  nix build --print-build-logs \
+                    .#nixosConfigurations.sancta-choir.config.system.build.toplevel \
+                    .#nixosConfigurations.sancta-claw.config.system.build.toplevel \
+                    .#nixosConfigurations.hermes-claw.config.system.build.toplevel
 
             # Heavy VM test (#42): builds n8n from source (unfree, never
             # binary-cached) + boots a KVM VM. Runs here — after the


### PR DESCRIPTION
The three host builds were three sequential `nix build` calls, so the runner built them **one after another** despite being independent.

Nix already parallelises across the derivations of a single build. Given all three roots at once it schedules the combined graph across the runner's cores, and the large shared closure — nixpkgs, `hosts/common.nix`, the shared modules — is realised **once** instead of being waited on three times in series.

```
- nix build .#…sancta-choir…
- nix build .#…sancta-claw…      three steps, serial
- nix build .#…hermes-claw…

+ nix build --print-build-logs \
+   .#…sancta-choir… .#…sancta-claw… .#…hermes-claw…
```

## Why not a matrix — the obvious move, deliberately declined

A `strategy.matrix` over the three hosts would use three runners and be faster still. It also renames the job to `Build x86_64 Configs (<host>)` and splits one green/red into three.

The n8n VM test below is deliberately a **step** inside this job and never a separate one — `council-20260706T164646Z-c3c904`, written into the comment there — precisely so `build-x86`'s meaning stays single and no phantom job can hang the branch-protection contract. Splitting the job reopens that decision for a speedup this change already gets most of.

If the matrix is wanted later it should be decided on its own, together with what the required-check name becomes.

`--print-build-logs` added because the step name can no longer say which host failed; the log has to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)