### PR TITLE
fix(sancta): the gallery's tailnet bind races tailscaled at boot

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -393,6 +393,12 @@
           # the 2026-07-21 silent loss with better paperwork.
           sancta-doctrine-guard = import ./tests/sancta-doctrine-guard.nix { inherit pkgs; };
 
+          # The gallery's tailnet bind probe, exercised against real sockets.
+          # module-eval proves the unit is ordered after tailscaled; this proves
+          # the probe tells "address not here yet" apart from every other
+          # bind failure, which is the only part that can be silently wrong.
+          sancta-gallery-bind-probe = import ./tests/sancta-gallery-bind-probe.nix { inherit pkgs; };
+
           # NOTE: the declarative n8n VM test (#42) deliberately lives under
           # packages.<system>.n8n-declarative-test, NOT here. `nix flake
           # check` builds every check inside the resource-constrained
@@ -417,6 +423,7 @@
           heartbeat-trusted-context = import ./tests/heartbeat-trusted-context.nix { inherit pkgs; };
           sancta-membrane = import ./tests/sancta-membrane.nix { inherit pkgs; };
           sancta-doctrine-guard = import ./tests/sancta-doctrine-guard.nix { inherit pkgs; };
+          sancta-gallery-bind-probe = import ./tests/sancta-gallery-bind-probe.nix { inherit pkgs; };
         };
 
       # Apps - makes packages runnable with `nix run`

--- a/modules/services/sancta-gallery-bind-probe.js
+++ b/modules/services/sancta-gallery-bind-probe.js
@@ -5,21 +5,32 @@
 // EADDRNOTAVAIL. This probe performs the EXACT same operation the server will,
 // so the precondition it waits on and the one that actually fails are identical.
 //
-// Exit 1 means ONLY "the address is not here yet — keep waiting". Every other
-// outcome exits 0 so the wait loop stops and ExecStart reports the real error
-// instead of this probe masking it as a timeout:
-//   EADDRINUSE — the address IS local; something else holds the port
-//   EACCES/EPERM — the systemd sandbox refused the bind (SocketBindDeny)
+// EXIT CODES — three outcomes, never two:
+//   0  proceed: the address is usable, or the bind failed for a reason the
+//      server itself should report (EADDRINUSE — the address IS local and
+//      something holds the port; EACCES/EPERM — the sandbox refused it)
+//   1  wait: EADDRNOTAVAIL, and ONLY that. The address is not here yet.
+//   2  the probe itself is broken (uncaught throw, bad require, …)
 //
-// Port 8739 is deliberate and must not become 0/ephemeral: SocketBindDeny=any
-// applies to ExecStartPre too, so an ephemeral port would fail with EACCES,
-// this probe would exit 0 immediately, and the wait would guard nothing.
+// 2 is not decoration. Node's default exit code for an uncaught exception is 1
+// — the same as "wait" — so a broken probe would silently extend the wait to the
+// full timeout and then report a missing tailnet address that was never missing.
+// The wait loop treats anything that is not 0 or 1 as immediately fatal.
+// Caught in review on #554.
+const FAIL_INTERNAL = 2;
+
+process.on("uncaughtException", (e) => {
+  console.error("sancta-gallery-bind-probe: internal failure:", e && e.stack ? e.stack : e);
+  process.exit(FAIL_INTERNAL);
+});
+
 const net = require("net");
 
 const bind = process.env.GALLERY_BIND;
 if (!bind) {
+  // A configuration error, not a wait condition — let ExecStart fail visibly.
   console.error("sancta-gallery-bind-probe: GALLERY_BIND is unset");
-  process.exit(0); // not a "wait" condition — let ExecStart fail visibly
+  process.exit(0);
 }
 
 const s = net.createServer();

--- a/modules/services/sancta-gallery-bind-probe.js
+++ b/modules/services/sancta-gallery-bind-probe.js
@@ -1,0 +1,27 @@
+// Bind probe for sancta-gallery's own-origin (tailnet) shape.
+//
+// A tailnet address is assigned by tailscaled, not owned by the host, so at boot
+// the server can call bind() before the address exists and die with
+// EADDRNOTAVAIL. This probe performs the EXACT same operation the server will,
+// so the precondition it waits on and the one that actually fails are identical.
+//
+// Exit 1 means ONLY "the address is not here yet — keep waiting". Every other
+// outcome exits 0 so the wait loop stops and ExecStart reports the real error
+// instead of this probe masking it as a timeout:
+//   EADDRINUSE — the address IS local; something else holds the port
+//   EACCES/EPERM — the systemd sandbox refused the bind (SocketBindDeny)
+//
+// Port 8739 is deliberate and must not become 0/ephemeral: SocketBindDeny=any
+// applies to ExecStartPre too, so an ephemeral port would fail with EACCES,
+// this probe would exit 0 immediately, and the wait would guard nothing.
+const net = require("net");
+
+const bind = process.env.GALLERY_BIND;
+if (!bind) {
+  console.error("sancta-gallery-bind-probe: GALLERY_BIND is unset");
+  process.exit(0); // not a "wait" condition — let ExecStart fail visibly
+}
+
+const s = net.createServer();
+s.once("error", (e) => process.exit(e.code === "EADDRNOTAVAIL" ? 1 : 0));
+s.listen(8739, bind, () => s.close(() => process.exit(0)));

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -88,6 +88,12 @@ let
   # 60s budget for the same wait.
   bindWaitSec = 60;
 
+  # Restart cadence. These three are bound together by the rate-limit window
+  # computed below — change one and the derived window follows, and the eval
+  # test asserts the relation still holds.
+  restartSec = 5;
+  startLimitBurst = 5;
+
   # Probe: attempt the real bind. Exit 1 means ONLY "not here yet"; anything
   # else exits 0 so the real error surfaces from ExecStart. Kept as its own
   # file — not an inline heredoc — so tests/sancta-gallery-bind-probe.nix can
@@ -97,7 +103,17 @@ let
   waitForBind = pkgs.writeShellScript "sancta-gallery-wait-bind" ''
     set -eu
     deadline=$((SECONDS + ${toString bindWaitSec}))
-    until ${pkgs.nodejs}/bin/node ${bindProbe}; do
+    while :; do
+      rc=0
+      ${pkgs.nodejs}/bin/node ${bindProbe} || rc=$?
+      [ "$rc" -eq 0 ] && break
+      if [ "$rc" -ne 1 ]; then
+        # Only exit 1 means "not here yet". Anything else is the probe itself
+        # failing, and retrying a broken probe for a minute would report a
+        # missing tailnet address that was never missing.
+        echo "ERROR: sancta-gallery: bind probe failed internally (exit $rc) — this is NOT an absent tailnet address." >&2
+        exit 1
+      fi
       if [ "$SECONDS" -ge "$deadline" ]; then
         echo "ERROR: sancta-gallery: $GALLERY_BIND:8739 is still not bindable after ${toString bindWaitSec}s (EADDRNOTAVAIL) — the tailnet address never arrived. Check tailscaled." >&2
         exit 1
@@ -226,8 +242,24 @@ in
 
       # Rate-limit restarts: a persistently crashing server ends up in a
       # loud `systemctl --failed` state instead of oscillating forever.
-      startLimitIntervalSec = 60;
-      startLimitBurst = 5;
+      #
+      # The window must be WIDER than the time `startLimitBurst` attempts
+      # actually take, or the limiter never trips. systemd resets the window
+      # whenever the gap since its start exceeds the interval
+      # (`ratelimit_below()`), so if one attempt costs more than the interval,
+      # every attempt lands in a fresh window, the count never reaches the
+      # burst, and the unit retries FOREVER without ever entering `failed` —
+      # which means OnFailure never fires and the alert never comes. That is
+      # this module's own silent-failure mode wearing a rate limiter.
+      #
+      # The loopback shape starts instantly, so 60s is fine. The own-origin
+      # shape spends up to `bindWaitSec` in the probe plus RestartSec between
+      # attempts, so the window is DERIVED from those numbers rather than
+      # typed — a hand-picked constant here is the same bug with a new hat.
+      # Caught in review on #554 by two independent reviewers.
+      inherit startLimitBurst;
+      startLimitIntervalSec =
+        if isLoopback then 60 else (bindWaitSec + restartSec) * startLimitBurst;
 
       environment = {
         # The publish gate: server refuses any artifact without a
@@ -248,7 +280,7 @@ in
         WorkingDirectory = cfg.galleryDir;
         ExecStart = "${pkgs.nodejs}/bin/node ${cfg.galleryDir}/server.mjs";
         Restart = "always";
-        RestartSec = 5;
+        RestartSec = restartSec;
 
         # Hardening. The server only ever READS the gallery dir; it gets a
         # read-only view of exactly that and nothing else under /home (see

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -52,6 +52,27 @@
 #   (`const BIND = process.env.GALLERY_BIND || '127.0.0.1'`). That script is
 #   mutable and outside this repo, so the binding is a CONTRACT with it, not
 #   something this module can prove — see the closing check in the PR.
+#
+# THE OWN-ORIGIN SHAPE HAS A BOOT RACE (found 2026-07-30). A tailnet address is
+# not a property of the host — it is assigned by tailscaled after it comes up.
+# `After=network.target` says nothing about that, so at boot the server calls
+# bind(100.94.191.54:8739) before the address exists and gets EADDRNOTAVAIL;
+# Restart=always then burns startLimitBurst in ~25s and the unit ends up
+# permanently failed. Every other tailnet-dependent unit in this repo already
+# orders after `tailscaled.service` (home-assistant, n8n, gatus, open-webui,
+# sancta-membrane-serve); this module, which binds the address DIRECTLY, was the
+# only one that did not.
+#
+# The cure is ordering plus a probe, not ordering alone: tailscaled can be
+# "active" before the address lands, and `FreeBind=` would make the bind succeed
+# against an address that never arrives — a server that starts and answers nobody,
+# which is the precise failure this module exists to make loud. So the probe
+# performs the EXACT operation that fails (bind tcp:8739 on `bind`), retries, and
+# then exits NON-ZERO so the unit fails and OnFailure fires.
+#
+# Note the probe must use port 8739: SocketBindDeny=any applies to ExecStartPre
+# too, so probing an ephemeral port would be refused with EACCES rather than
+# EADDRNOTAVAIL — the wait would return "ready" immediately and guard nothing.
 { config
 , lib
 , pkgs
@@ -59,6 +80,31 @@
 }:
 let
   cfg = config.services.sancta-gallery;
+
+  isLoopback = cfg.bind == "127.0.0.1" || cfg.bind == "::1";
+
+  # Seconds the probe waits for the tailnet address to be assigned before it
+  # gives up and fails the unit. tailscaled's own consumers in this repo use a
+  # 60s budget for the same wait.
+  bindWaitSec = 60;
+
+  # Probe: attempt the real bind. Exit 1 means ONLY "not here yet"; anything
+  # else exits 0 so the real error surfaces from ExecStart. Kept as its own
+  # file — not an inline heredoc — so tests/sancta-gallery-bind-probe.nix can
+  # execute the same bytes the unit runs (the sancta-doctrine-guard.sh shape).
+  bindProbe = ./sancta-gallery-bind-probe.js;
+
+  waitForBind = pkgs.writeShellScript "sancta-gallery-wait-bind" ''
+    set -eu
+    deadline=$((SECONDS + ${toString bindWaitSec}))
+    until ${pkgs.nodejs}/bin/node ${bindProbe}; do
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "ERROR: sancta-gallery: $GALLERY_BIND:8739 is still not bindable after ${toString bindWaitSec}s (EADDRNOTAVAIL) — the tailnet address never arrived. Check tailscaled." >&2
+        exit 1
+      fi
+      sleep 1
+    done
+  '';
 in
 {
   options.services.sancta-gallery = {
@@ -159,7 +205,11 @@ in
     systemd.services.sancta-gallery = {
       description = "Sancta Gallery — read-only static viewer with publish gate";
       after = [ "network.target" ]
-        ++ lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
+        ++ lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service"
+        # Own-origin shape only: the bind address is handed out by tailscaled,
+        # so without this the boot order is a coin flip (see header).
+        ++ lib.optional (!isLoopback) "tailscaled.service";
+      wants = lib.optional (!isLoopback) "tailscaled.service";
       requires = lib.optional (cfg.requiresMount != null) "sancta-soul-mount.service";
       wantedBy = [ "multi-user.target" ];
       onFailure = lib.optional (cfg.onFailureUnit != null) cfg.onFailureUnit;
@@ -228,7 +278,7 @@ in
         SocketBindAllow = "tcp:8739";
         SocketBindDeny = "any";
       }
-      // lib.optionalAttrs (cfg.bind == "127.0.0.1" || cfg.bind == "::1") {
+      // lib.optionalAttrs isLoopback {
         # Loopback shape (the 2026-07-11 authorization): packets may go nowhere
         # but loopback, so even a modified server.mjs cannot reach the network.
         # `tailscale serve` proxies from the same host over loopback.
@@ -238,7 +288,16 @@ in
         ];
         IPAddressDeny = "any";
       }
-      // lib.optionalAttrs (cfg.bind != "127.0.0.1" && cfg.bind != "::1") {
+      // lib.optionalAttrs (!isLoopback) {
+        # Wait for the address tailscaled hands out, and fail LOUD if it never
+        # arrives. Ordering after tailscaled.service is necessary but not
+        # sufficient: the unit can be active before the address is assigned.
+        ExecStartPre = toString waitForBind;
+
+        # The probe may spend up to bindWaitSec seconds; the 90s systemd default
+        # would SIGTERM it mid-wait once ExecStart is added on top.
+        TimeoutStartSec = bindWaitSec + 60;
+
         # Own-origin shape (sancta-choir): the process binds the tailnet address
         # itself, so loopback-only IP filtering would block the very traffic it
         # exists to serve. The port restriction above still holds — it may bind

--- a/modules/services/sancta-gallery.nix
+++ b/modules/services/sancta-gallery.nix
@@ -257,9 +257,20 @@ in
       # attempts, so the window is DERIVED from those numbers rather than
       # typed — a hand-picked constant here is the same bug with a new hat.
       # Caught in review on #554 by two independent reviewers.
+      #
+      # It must hold `startLimitBurst + 1` attempts, not `startLimitBurst`.
+      # systemd's ratelimit resets when `begin + interval < now` (STRICT), and
+      # the real per-attempt cost is slightly MORE than the nominal
+      # `bindWaitSec + restartSec` (the probe's `deadline` loop overshoots the
+      # last second, plus restart scheduling latency). A window sized to exactly
+      # `burst * cost` therefore lets the (burst+1)-th start land just PAST the
+      # boundary, where systemd resets the counter instead of denying it — so
+      # the limiter never trips and the unit retries forever. One extra attempt
+      # of headroom absorbs that overshoot; the burst is still reached (terminal
+      # `failed` + OnFailure) at ~`burst` cycles, only now reliably.
       inherit startLimitBurst;
       startLimitIntervalSec =
-        if isLoopback then 60 else (bindWaitSec + restartSec) * startLimitBurst;
+        if isLoopback then 60 else (bindWaitSec + restartSec) * (startLimitBurst + 1);
 
       environment = {
         # The publish gate: server refuses any artifact without a

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -604,20 +604,24 @@ let
           # The probe may spend 60s; the 90s systemd default would SIGTERM it.
           timeoutRaised = (svc.serviceConfig.TimeoutStartSec or 90) >= 120;
 
-          # The rate-limit window must be WIDER than the time startLimitBurst
-          # attempts actually take. systemd resets the window whenever the gap
-          # since its start exceeds the interval, so if one attempt (probe wait
-          # + RestartSec) costs more than the interval, the count never reaches
-          # the burst, the unit never enters `failed`, and OnFailure never
-          # fires — it just retries forever, silently. Found on #554 by two
-          # independent reviewers AFTER the fix was written; this assertion is
-          # what ties the three numbers together so the next edit to any one of
-          # them fails CI instead of re-opening the hole.
+          # The rate-limit window must hold `startLimitBurst + 1` attempts, not
+          # just `startLimitBurst`. systemd resets the window when
+          # `begin + interval < now` (STRICT), and one attempt actually costs a
+          # little MORE than the nominal `probe wait + RestartSec` (the probe's
+          # deadline loop overshoots the last second, plus restart scheduling).
+          # A window of exactly `burst * cost` therefore lets the (burst+1)-th
+          # start land just past the boundary, where systemd RESETS the counter
+          # instead of denying it — the count never reaches the burst, the unit
+          # never enters `failed`, and OnFailure never fires: it retries forever,
+          # silently. The first fix on #554 used `>= cost * burst` and was STILL
+          # on the wrong side of that boundary; two reviewers flagged it. `+ 1`
+          # attempt of headroom absorbs the overshoot. This assertion ties the
+          # numbers together so the next edit to any one fails CI, not prod.
           startLimitWindowExhaustible =
             let
               attemptCost = 60 + svc.serviceConfig.RestartSec; # probe wait + backoff
             in
-            svc.startLimitIntervalSec >= attemptCost * svc.startLimitBurst;
+            svc.startLimitIntervalSec >= attemptCost * (svc.startLimitBurst + 1);
         };
         failed = builtins.filter (name: !checks.${name}) (builtins.attrNames checks);
       in

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -583,6 +583,62 @@ let
       ];
     };
 
+    # ── Sancta Gallery: the tailnet bind must not race tailscaled ──
+    #
+    # The own-origin shape binds a Tailscale address, which tailscaled assigns
+    # after it starts. `After=network.target` says nothing about that, so on
+    # 2026-07-30 the deployed unit could bind() before the address existed, get
+    # EADDRNOTAVAIL, burn Restart=always/startLimitBurst in ~25s and stay
+    # permanently failed. Assert the ordering AND the probe on the real host
+    # config, so the fix cannot be silently dropped by a later refactor.
+    sancta-gallery-choir-waits-for-tailscaled =
+      let
+        svc = self.nixosConfigurations.sancta-choir.config.systemd.services.sancta-gallery;
+        checks = {
+          bindIsTailnet = nixpkgs.lib.hasPrefix "100." svc.environment.GALLERY_BIND;
+          orderedAfterTailscaled = builtins.elem "tailscaled.service" svc.after;
+          wantsTailscaled = builtins.elem "tailscaled.service" svc.wants;
+          # Ordering alone is not enough: tailscaled can be active before the
+          # address is assigned, so the unit must also wait on the bind itself.
+          hasBindProbe = (svc.serviceConfig.ExecStartPre or null) != null;
+          # The probe may spend 60s; the 90s systemd default would SIGTERM it.
+          timeoutRaised = (svc.serviceConfig.TimeoutStartSec or 90) >= 120;
+        };
+        failed = builtins.filter (name: !checks.${name}) (builtins.attrNames checks);
+      in
+      if failed == [ ] then
+        true
+      else
+        builtins.throw "FAIL: sancta-choir sancta-gallery would race tailscaled at boot — failed checks: ${builtins.toJSON failed}";
+
+    # Negative control for the branch above: the loopback shape must NOT pull in
+    # tailscaled or the probe. Without this, making the ordering unconditional
+    # would pass the test above while adding a dangling dependency on every host
+    # that uses the loopback shape — a check that cannot fail.
+    sancta-gallery-loopback-has-no-tailscaled-dep =
+      let
+        config = evalConfig {
+          modules = [
+            ../modules/services/sancta-gallery.nix
+            {
+              services.sancta-gallery.enable = true;
+              # bind defaults to 127.0.0.1 — the loopback shape.
+              users.users.nixos = {
+                isNormalUser = true;
+                group = "users";
+              };
+            }
+          ];
+        };
+        svc = config.systemd.services.sancta-gallery;
+        leaked = builtins.elem "tailscaled.service" (svc.after ++ svc.wants);
+        probed = (svc.serviceConfig.ExecStartPre or null) != null;
+      in
+      if !leaked && !probed then
+        true
+      else
+        builtins.throw "FAIL: sancta-gallery loopback shape gained tailnet-only wiring (tailscaled dep: ${builtins.toJSON leaked}, bind probe: ${builtins.toJSON probed}) — the own-origin branch is not actually conditional.";
+
     # ── Claude module ─────────────────────────────────────────────
     claude-missing-input = shouldFail "claude: missing claude-code input" {
       modules = [

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -603,6 +603,21 @@ let
           hasBindProbe = (svc.serviceConfig.ExecStartPre or null) != null;
           # The probe may spend 60s; the 90s systemd default would SIGTERM it.
           timeoutRaised = (svc.serviceConfig.TimeoutStartSec or 90) >= 120;
+
+          # The rate-limit window must be WIDER than the time startLimitBurst
+          # attempts actually take. systemd resets the window whenever the gap
+          # since its start exceeds the interval, so if one attempt (probe wait
+          # + RestartSec) costs more than the interval, the count never reaches
+          # the burst, the unit never enters `failed`, and OnFailure never
+          # fires — it just retries forever, silently. Found on #554 by two
+          # independent reviewers AFTER the fix was written; this assertion is
+          # what ties the three numbers together so the next edit to any one of
+          # them fails CI instead of re-opening the hole.
+          startLimitWindowExhaustible =
+            let
+              attemptCost = 60 + svc.serviceConfig.RestartSec; # probe wait + backoff
+            in
+            svc.startLimitIntervalSec >= attemptCost * svc.startLimitBurst;
         };
         failed = builtins.filter (name: !checks.${name}) (builtins.attrNames checks);
       in

--- a/tests/sancta-gallery-bind-probe.nix
+++ b/tests/sancta-gallery-bind-probe.nix
@@ -18,60 +18,86 @@ pkgs.runCommand "sancta-gallery-bind-probe-tests"
 {
   nativeBuildInputs = [ pkgs.nodejs ];
 } ''
-  fails=0
+    fails=0
 
-  # Run the probe and assert its exit status. 1 means "address not here yet,
-  # keep waiting"; 0 means "stop waiting, let ExecStart speak".
-  expect() {
-    local want="$1" bind="$2" what="$3" got=0
-    GALLERY_BIND="$bind" node ${probe} || got=$?
-    if [ "$got" = "$want" ]; then
-      echo "  ok:   $what (exit $got)"
+    # Run the probe and assert its exit status. 1 means "address not here yet,
+    # keep waiting"; 0 means "stop waiting, let ExecStart speak".
+    expect() {
+      local want="$1" bind="$2" what="$3" got=0
+      GALLERY_BIND="$bind" node ${probe} || got=$?
+      if [ "$got" = "$want" ]; then
+        echo "  ok:   $what (exit $got)"
+      else
+        echo "  FAIL: $what — expected exit $want, got $got"
+        fails=$((fails + 1))
+      fi
+    }
+
+    echo "sancta-gallery bind probe:"
+
+    # 1 — the address IS local: stop waiting.
+    expect 0 127.0.0.1 "loopback is bindable -> proceed"
+
+    # 2 — the boot race itself. 100.64.0.1 is inside Tailscale's CGNAT range and
+    #     is NOT assigned in the build sandbox, so bind() gives EADDRNOTAVAIL.
+    #     This is the case that must return 1; if it ever returns 0 the wait loop
+    #     is decorative and the unit is back to racing tailscaled.
+    expect 1 100.64.0.1 "unassigned tailnet address -> wait"
+
+    # 3 — the discriminator, from the other side. Hold 127.0.0.1:8739 so the probe
+    #     gets EADDRINUSE, not EADDRNOTAVAIL. The address IS local, so the answer
+    #     must be "proceed" (exit 0) and NOT "wait" — otherwise a port conflict is
+    #     reported as an absent tailnet address.
+    node -e 'const s=require("net").createServer(); s.listen(8739,"127.0.0.1",()=>{setTimeout(()=>process.exit(0),20000)})' &
+    holder=$!
+    for _ in $(seq 1 50); do
+      node -e 'const s=require("net").createServer();s.once("error",e=>process.exit(e.code==="EADDRINUSE"?0:1));s.listen(8739,"127.0.0.1",()=>s.close(()=>process.exit(1)))' && break
+      sleep 0.1
+    done
+    expect 0 127.0.0.1 "port held (EADDRINUSE) -> proceed, not wait"
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+
+    # 4 — a BROKEN probe must not look like "still waiting". Node exits 1 on an
+    #     uncaught exception, which is the same code as EADDRNOTAVAIL, so without
+    #     the explicit handler a probe bug would silently burn the whole timeout
+    #     and then blame an absent tailnet address. Simulate by making `require`
+    #     throw before the probe reaches its own handler-installed code path.
+    cat > broken-probe.js <<'EOF'
+    process.on("uncaughtException", () => process.exit(2));
+    throw new Error("simulated probe bug");
+  EOF
+    got=0
+    node broken-probe.js || got=$?
+    if [ "$got" = 2 ]; then
+      echo "  ok:   internal probe failure -> exit 2, not 1 (distinguishable from wait)"
     else
-      echo "  FAIL: $what — expected exit $want, got $got"
+      echo "  FAIL: internal probe failure — expected exit 2, got $got"
       fails=$((fails + 1))
     fi
-  }
 
-  echo "sancta-gallery bind probe:"
+    # 4b — and the real probe must carry that handler, not just this fixture.
+    if grep -q 'uncaughtException' ${probe} && grep -q 'FAIL_INTERNAL = 2' ${probe}; then
+      echo "  ok:   the shipped probe installs the internal-failure handler"
+    else
+      echo "  FAIL: the shipped probe lost its uncaughtException -> exit 2 handler"
+      fails=$((fails + 1))
+    fi
 
-  # 1 — the address IS local: stop waiting.
-  expect 0 127.0.0.1 "loopback is bindable -> proceed"
+    # 5 — no bind configured at all is a configuration error, not a wait state.
+    got=0
+    node ${probe} || got=$?
+    if [ "$got" = 0 ]; then
+      echo "  ok:   GALLERY_BIND unset -> proceed (exit 0)"
+    else
+      echo "  FAIL: GALLERY_BIND unset — expected exit 0, got $got"
+      fails=$((fails + 1))
+    fi
 
-  # 2 — the boot race itself. 100.64.0.1 is inside Tailscale's CGNAT range and
-  #     is NOT assigned in the build sandbox, so bind() gives EADDRNOTAVAIL.
-  #     This is the case that must return 1; if it ever returns 0 the wait loop
-  #     is decorative and the unit is back to racing tailscaled.
-  expect 1 100.64.0.1 "unassigned tailnet address -> wait"
-
-  # 3 — the discriminator, from the other side. Hold 127.0.0.1:8739 so the probe
-  #     gets EADDRINUSE, not EADDRNOTAVAIL. The address IS local, so the answer
-  #     must be "proceed" (exit 0) and NOT "wait" — otherwise a port conflict is
-  #     reported as an absent tailnet address.
-  node -e 'const s=require("net").createServer(); s.listen(8739,"127.0.0.1",()=>{setTimeout(()=>process.exit(0),20000)})' &
-  holder=$!
-  for _ in $(seq 1 50); do
-    node -e 'const s=require("net").createServer();s.once("error",e=>process.exit(e.code==="EADDRINUSE"?0:1));s.listen(8739,"127.0.0.1",()=>s.close(()=>process.exit(1)))' && break
-    sleep 0.1
-  done
-  expect 0 127.0.0.1 "port held (EADDRINUSE) -> proceed, not wait"
-  kill "$holder" 2>/dev/null || true
-  wait "$holder" 2>/dev/null || true
-
-  # 4 — no bind configured at all is a configuration error, not a wait state.
-  got=0
-  node ${probe} || got=$?
-  if [ "$got" = 0 ]; then
-    echo "  ok:   GALLERY_BIND unset -> proceed (exit 0)"
-  else
-    echo "  FAIL: GALLERY_BIND unset — expected exit 0, got $got"
-    fails=$((fails + 1))
-  fi
-
-  if [ "$fails" -ne 0 ]; then
-    echo "sancta-gallery-bind-probe: $fails case(s) FAILED" >&2
-    exit 1
-  fi
-  echo "sancta-gallery-bind-probe: all 4 cases hold"
-  echo ok > $out
+    if [ "$fails" -ne 0 ]; then
+      echo "sancta-gallery-bind-probe: $fails case(s) FAILED" >&2
+      exit 1
+    fi
+    echo "sancta-gallery-bind-probe: all 6 cases hold"
+    echo ok > $out
 ''

--- a/tests/sancta-gallery-bind-probe.nix
+++ b/tests/sancta-gallery-bind-probe.nix
@@ -1,0 +1,77 @@
+# Behaviour coverage for modules/services/sancta-gallery-bind-probe.js.
+#
+# The eval test in tests/module-eval.nix proves the unit is ORDERED after
+# tailscaled and that the probe is wired in. It cannot prove the probe
+# discriminates correctly — and the discriminator is the whole point: a probe
+# that exits 0 on EADDRNOTAVAIL never waits, and a probe that exits 1 on
+# EADDRINUSE turns "the port is taken" into a 60s timeout with a misleading
+# message. So the discriminator is exercised here, for real, against real
+# sockets in the build sandbox.
+#
+# Run: nix build .#checks.<system>.sancta-gallery-bind-probe
+{ pkgs }:
+
+let
+  probe = ../modules/services/sancta-gallery-bind-probe.js;
+in
+pkgs.runCommand "sancta-gallery-bind-probe-tests"
+{
+  nativeBuildInputs = [ pkgs.nodejs ];
+} ''
+  fails=0
+
+  # Run the probe and assert its exit status. 1 means "address not here yet,
+  # keep waiting"; 0 means "stop waiting, let ExecStart speak".
+  expect() {
+    local want="$1" bind="$2" what="$3" got=0
+    GALLERY_BIND="$bind" node ${probe} || got=$?
+    if [ "$got" = "$want" ]; then
+      echo "  ok:   $what (exit $got)"
+    else
+      echo "  FAIL: $what — expected exit $want, got $got"
+      fails=$((fails + 1))
+    fi
+  }
+
+  echo "sancta-gallery bind probe:"
+
+  # 1 — the address IS local: stop waiting.
+  expect 0 127.0.0.1 "loopback is bindable -> proceed"
+
+  # 2 — the boot race itself. 100.64.0.1 is inside Tailscale's CGNAT range and
+  #     is NOT assigned in the build sandbox, so bind() gives EADDRNOTAVAIL.
+  #     This is the case that must return 1; if it ever returns 0 the wait loop
+  #     is decorative and the unit is back to racing tailscaled.
+  expect 1 100.64.0.1 "unassigned tailnet address -> wait"
+
+  # 3 — the discriminator, from the other side. Hold 127.0.0.1:8739 so the probe
+  #     gets EADDRINUSE, not EADDRNOTAVAIL. The address IS local, so the answer
+  #     must be "proceed" (exit 0) and NOT "wait" — otherwise a port conflict is
+  #     reported as an absent tailnet address.
+  node -e 'const s=require("net").createServer(); s.listen(8739,"127.0.0.1",()=>{setTimeout(()=>process.exit(0),20000)})' &
+  holder=$!
+  for _ in $(seq 1 50); do
+    node -e 'const s=require("net").createServer();s.once("error",e=>process.exit(e.code==="EADDRINUSE"?0:1));s.listen(8739,"127.0.0.1",()=>s.close(()=>process.exit(1)))' && break
+    sleep 0.1
+  done
+  expect 0 127.0.0.1 "port held (EADDRINUSE) -> proceed, not wait"
+  kill "$holder" 2>/dev/null || true
+  wait "$holder" 2>/dev/null || true
+
+  # 4 — no bind configured at all is a configuration error, not a wait state.
+  got=0
+  node ${probe} || got=$?
+  if [ "$got" = 0 ]; then
+    echo "  ok:   GALLERY_BIND unset -> proceed (exit 0)"
+  else
+    echo "  FAIL: GALLERY_BIND unset — expected exit 0, got $got"
+    fails=$((fails + 1))
+  fi
+
+  if [ "$fails" -ne 0 ]; then
+    echo "sancta-gallery-bind-probe: $fails case(s) FAILED" >&2
+    exit 1
+  fi
+  echo "sancta-gallery-bind-probe: all 4 cases hold"
+  echo ok > $out
+''


### PR DESCRIPTION
Found while investigating the open question **"why did generation 26 not boot?"**. That question is *not* answered here — but the investigation turned up a real defect: **`sancta-gallery` in the own-origin shape could never have survived a reboot.**

## The defect

A tailnet address is not a property of the host — `tailscaled` assigns it after it starts. The unit ordered only `After=network.target`, so at boot `server.mjs` calls `bind(100.94.191.54:8739)` before the address exists, gets `EADDRNOTAVAIL`, and `Restart=always` burns `startLimitBurst` (5 in 60s) in ~25 seconds. The unit then sits **permanently failed** and the surface serves nothing.

Every other tailnet-dependent unit in this repo already orders after `tailscaled.service` — `home-assistant`, `n8n`, `gatus`, `open-webui`, `sancta-membrane-serve`. This module, the only one that binds the address **directly** instead of going through `tailscale serve`, was the only one that did not.

## Why ordering alone is not the fix

`tailscaled` can be `active` before the address lands, and `FreeBind=` would make the bind *succeed* against an address that never arrives — a server that starts and answers nobody, which is precisely the failure this module exists to make loud. So: order after `tailscaled` **and** probe the real bind, failing non-zero (firing `OnFailure`) if the address never comes.

The probe must use **port 8739**. `SocketBindDeny=any` applies to `ExecStartPre` too, so probing an ephemeral port would fail with `EACCES` instead of `EADDRNOTAVAIL`, the probe would report "ready" immediately, and the wait would guard nothing — a check that cannot fail.

Both shapes stay separate: the loopback default gains neither the ordering nor the probe.

## Closing checks — run, with output

`nix build .#checks.x86_64-linux.sancta-gallery-bind-probe` — the probe against real sockets:

```
sancta-gallery bind probe:
  ok:   loopback is bindable -> proceed (exit 0)
  ok:   unassigned tailnet address -> wait (exit 1)
  ok:   port held (EADDRINUSE) -> proceed, not wait (exit 0)
  ok:   GALLERY_BIND unset -> proceed (exit 0)
sancta-gallery-bind-probe: all 4 cases hold
```

`nix build .#checks.x86_64-linux.module-eval` — all tests pass, including:

```
  ✓ sancta-gallery-choir-waits-for-tailscaled
  ✓ sancta-gallery-loopback-has-no-tailscaled-dep
```

**And the checks were shown to fail.** Three mutations, three exact messages:

| mutation | result |
|---|---|
| ordering made unconditional | `FAIL: sancta-gallery loopback shape gained tailnet-only wiring (tailscaled dep: true, bind probe: false) — the own-origin branch is not actually conditional.` |
| `lib.optional (!isLoopback)` → `lib.optional false` | `FAIL: … would race tailscaled at boot — failed checks: ["orderedAfterTailscaled","wantsTailscaled"]` |
| `ExecStartPre` removed | `FAIL: … would race tailscaled at boot — failed checks: ["hasBindProbe"]` |

`nix fmt` on the four touched files: `0 / 4 have been reformatted`. `sancta-choir` toplevel evaluates.

## On generation 26

The artifacts **exonerate the generation as a boot-blocker**, as far as artifacts can:

- `nix store diff-closures` 25→26 contains *only* the three sancta units plus the guard script and source — nothing else changed.
- kernel and initrd are byte-identical between the two generations.
- `systemd-analyze verify` is clean on all three units.
- none of them is ordered `Before` anything or required by a target in a way that could hold up boot.

**Why the boot actually failed is still unknown**, and that boot's journal is unreadable without membership in `systemd-journal` (sq038). Do not read this PR as proving the units were innocent — read it as: nothing in the generation's contents can block a boot, and one of its units was guaranteed to fail *after* boot for an unrelated reason, which this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHTBhNXqT2ixS8akrhWWEC
