### PR TITLE
ci(security): a bot may not summon the unrestricted agent

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,19 @@ on:
 
 jobs:
   claude:
+    # A BOT MAY NOT SUMMON THIS JOB. It runs an agent with no --allowed-tools
+    # restriction, holding CLAUDE_CODE_OAUTH_TOKEN and `actions: read`, and it
+    # executes whatever the triggering comment says. Without the author gate,
+    # any workflow that posts a comment becomes a way to reach it: the review
+    # job reads an attacker-influenced PR diff, and a diff crafted to make the
+    # reviewer emit `@claude <instructions>` inside a finding would fire this
+    # job through a comment the repo itself posted. The mention is a request
+    # from a person or it is nothing.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && github.event.comment.user.type != 'Bot' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.type != 'Bot' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.type != 'Bot' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.issue.user.type != 'Bot' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

One clause per trigger in `claude.yml`: the author of the triggering comment, review or issue must not be a Bot.

## Why

That job runs an agent with **no `--allowed-tools` restriction**, holding `CLAUDE_CODE_OAUTH_TOKEN` and `actions: read`, and it executes whatever the triggering comment says. It fired on `@claude` appearing anywhere in a comment, with no check on who wrote it.

So any workflow that can post a comment was a way to reach it. The concrete path is the review job: its prompt is fed the PR diff — attacker-influenced content — and it holds `pull-requests: write`. A diff crafted to make the reviewer emit `@claude <instructions>` inside its own output reaches this job through a comment the repository itself posted. That is an escalation from *can comment* to *can run an unrestricted agent with the OAuth token*.

## Scope

Four lines, one file. Humans are unaffected — `user.type` is `User` for them, `Bot` only for apps and `github-actions[bot]`.

This is the boundary. Escaping bot mentions in comment bodies is defence in depth and stays in #550, where the poster that writes those bodies lives.

## Origin

Found by review on #550 and split out of it: a security fix with no relationship to that PR's review-threads mechanism should not wait on a branch that is still taking review rounds.

## Verification

`actionlint` clean. The condition is evaluated by GitHub before the job starts, so the closing check is behavioural and belongs to whoever merges it: after merge, a `github-actions[bot]` comment containing the mention must **not** start a `Claude Code` run, and a human comment containing it must.
